### PR TITLE
Fix logging to file and LDAP authentication

### DIFF
--- a/lib/Common/Logging/Log.php
+++ b/lib/Common/Logging/Log.php
@@ -31,7 +31,7 @@ class Log
         $this->logger = new Logger('app');
         $this->sqlLogger = new Logger('sql');
 
-        $log_level = Configuration::Instance()->GetKey(ConfigKeys::LOGGING_LEVEL);
+        $log_level = strtolower(Configuration::Instance()->GetKey(ConfigKeys::LOGGING_LEVEL));
 
         $log_folder = null;
         $log_sql = false;
@@ -103,7 +103,7 @@ class Log
      */
     public static function Error($message, $args = [])
     {
-        $log_level = Configuration::Instance()->GetKey(ConfigKeys::LOGGING_LEVEL);
+        $log_level = strtolower(Configuration::Instance()->GetKey(ConfigKeys::LOGGING_LEVEL));
         if ($log_level == 'none') {
             return;
         }
@@ -148,7 +148,7 @@ class Log
     }
     public static function DebugEnabled()
     {
-        $log_level = Configuration::Instance()->GetKey(ConfigKeys::LOGGING_LEVEL);
+        $log_level = strtolower(Configuration::Instance()->GetKey(ConfigKeys::LOGGING_LEVEL));
         return $log_level != 'none';
     }
 }

--- a/lib/Config/Configuration.php
+++ b/lib/Config/Configuration.php
@@ -351,8 +351,9 @@ class ConfigurationFile implements IConfigurationFile
                         if (!call_user_func([$this->_configKeysClass, 'findByKey'], $fullKey)) {
                             error_log("[CONFIG] Deprecated config key '$fullKey' used. It maps to '$finalKey'. Support for legacy keys will be removed in a future release.");
                         }
-
-                        continue;
+                    } else {
+                        // Unknown subkey - preserve in original structure for validation
+                        $rewritten[$key][$subKey] = $subValue;
                     }
                 }
 
@@ -415,7 +416,7 @@ class ConfigurationFile implements IConfigurationFile
             }
 
             if (isset($configDef['choices']) && !array_key_exists($value, $configDef['choices'])) {
-                error_log("[CONFIG] Invalid value '$value' for '{$fullKey}'. Should be one of the following options: [" . implode(', ', array_map( fn($key, $value) => "{$key} => {$value}", array_keys($configDef['choices']), $configDef['choices'])) . "]");
+                error_log("[CONFIG] Invalid value '$value' for '{$fullKey}'. Should be one of the following options: [" . implode(', ', array_map(fn($key, $value) => "{$key} => {$value}", array_keys($configDef['choices']), $configDef['choices'])) . "]");
                 $validated[$key] = $configDef['default'];
                 continue;
             }

--- a/lib/Config/PluginConfigKeys.php
+++ b/lib/Config/PluginConfigKeys.php
@@ -28,8 +28,14 @@ abstract class PluginConfigKeys
     public static function findByKey(string $key): ?array
     {
         foreach (static::all() as $config) {
-            if (($config['key'] ?? null) === $key) {
-                return $config;
+            $configKey = $config['key'] ?? null;
+            $section = $config['section'] ?? null;
+
+            // If this config has a section, ONLY match the section-prefixed key
+            if ($section) {
+                if ("{$section}.{$configKey}" === $key) {
+                    return $config;
+                }
             }
         }
 

--- a/plugins/Authentication/ActiveDirectory/ActiveDirectory.config.dist.php
+++ b/plugins/Authentication/ActiveDirectory/ActiveDirectory.config.dist.php
@@ -2,46 +2,48 @@
 
 return [
     'settings' => [
-        // comma separated list of ldap servers such as domaincontroller1,controller2
-        'domain.controllers' => 'mydomain,local',
+        'activedirectory' => [
+            // comma separated list of ldap servers such as domaincontroller1,controller2
+            'domain.controllers' => 'mydomain,local',
 
-        // default ldap port 389 or 636 for ssl.
-        'port' => 389,
+            // default ldap port 389 or 636 for ssl.
+            'port' => 389,
 
-        // admin user - bind to ldap service with an authorized account user/password
-        'username' => '',
+            // admin user - bind to ldap service with an authorized account user/password
+            'username' => '',
 
-        // admin password - corresponding password
-        'password' => '',
+            // admin password - corresponding password
+            'password' => '',
 
-        // The base dn for your domain. This is generally the same as your account suffix, but broken up and prefixed with DC=. Your base dn can be located in the extended attributes in Active Directory Users and Computers MMC.
-        'basedn' => 'ou=uidauthent,o=domain.com',
+            // The base dn for your domain. This is generally the same as your account suffix, but broken up and prefixed with DC=. Your base dn can be located in the extended attributes in Active Directory Users and Computers MMC.
+            'basedn' => 'ou=uidauthent,o=domain.com',
 
-        // LDAP protocol version
-        'version' => 3,
+            // LDAP protocol version
+            'version' => 3,
 
-        // 'true' if 636 was used.
-        'use.ssl' => 'false',
+            // 'true' if 636 was used.
+            'use.ssl' => 'false',
 
-        // The full account suffix for your domain. Example: @uidauthent.domain.com.
-        'account.suffix' => '',
+            // The full account suffix for your domain. Example: @uidauthent.domain.com.
+            'account.suffix' => '',
 
-        // if ldap auth fails, authenticate against LibreBooking database
-        'database.auth.when.ldap.user.not.found' => false,
+            // if ldap auth fails, authenticate against LibreBooking database
+            'database.auth.when.ldap.user.not.found' => false,
 
-        // mapping of required attributes to attribute names in your directory
-        'attribute.mapping' => 'sn=sn,givenname=givenname,mail=mail,telephonenumber=telephonenumber,physicaldeliveryofficename=physicaldeliveryofficename,title=title',
+            // mapping of required attributes to attribute names in your directory
+            'attribute.mapping' => 'sn=sn,givenname=givenname,mail=mail,telephonenumber=telephonenumber,physicaldeliveryofficename=physicaldeliveryofficename,title=title',
 
-        // Required groups (empty if not necessary) User only needs to belong to at least one listed (eg. Group1,Group2)
-        'required.groups' => '',
+            // Required groups (empty if not necessary) User only needs to belong to at least one listed (eg. Group1,Group2)
+            'required.groups' => '',
 
-        // Whether or not groups should be synced into LibreBooking. When true then be sure that the attribute.mapping config value contains a correct map for groups
-        'sync.groups' => false,
+            // Whether or not groups should be synced into LibreBooking. When true then be sure that the attribute.mapping config value contains a correct map for groups
+            'sync.groups' => false,
 
-        // Whether or not to use single sign on
-        'use.sso' => false,
+            // Whether or not to use single sign on
+            'use.sso' => false,
 
-        // If the username is an email address or contains the domain, clean it
-        'prevent.clean.username' => false,
+            // If the username is an email address or contains the domain, clean it
+            'prevent.clean.username' => false,
+        ],
     ],
 ];

--- a/plugins/Authentication/ActiveDirectory/ActiveDirectoryConfigKeys.php
+++ b/plugins/Authentication/ActiveDirectory/ActiveDirectoryConfigKeys.php
@@ -28,7 +28,7 @@ class ActiveDirectoryConfigKeys extends PluginConfigKeys
         'type' => 'string',
         'default' => '',
         'label' => 'Admin Username',
-        'description' => 'Username for binding to LDAP service',
+        'description' => 'Username for binding to LDAP service. Will have account.suffix appended automatically',
         'section' => 'activedirectory'
     ];
 

--- a/plugins/Authentication/ActiveDirectory/ActiveDirectoryConfigKeys.php
+++ b/plugins/Authentication/ActiveDirectory/ActiveDirectoryConfigKeys.php
@@ -6,7 +6,7 @@ class ActiveDirectoryConfigKeys extends PluginConfigKeys
 {
     public const CONFIG_ID = 'activeDirectory';
     public const DOMAIN_CONTROLLERS = [
-        'key' => 'domain.controllers',
+        'key' => 'activedirectory.domain.controllers',
         'type' => 'string',
         'default' => '',
         'label' => 'Domain Controllers',
@@ -15,7 +15,7 @@ class ActiveDirectoryConfigKeys extends PluginConfigKeys
     ];
 
     public const PORT = [
-        'key' => 'port',
+        'key' => 'activedirectory.port',
         'type' => 'integer',
         'default' => 389,
         'label' => 'LDAP Port',
@@ -24,7 +24,7 @@ class ActiveDirectoryConfigKeys extends PluginConfigKeys
     ];
 
     public const USERNAME = [
-        'key' => 'username',
+        'key' => 'activedirectory.username',
         'type' => 'string',
         'default' => '',
         'label' => 'Admin Username',
@@ -33,7 +33,7 @@ class ActiveDirectoryConfigKeys extends PluginConfigKeys
     ];
 
     public const PASSWORD = [
-        'key' => 'password',
+        'key' => 'activedirectory.password',
         'type' => 'string',
         'default' => '',
         'label' => 'Admin Password',
@@ -43,7 +43,7 @@ class ActiveDirectoryConfigKeys extends PluginConfigKeys
     ];
 
     public const BASEDN = [
-        'key' => 'basedn',
+        'key' => 'activedirectory.basedn',
         'type' => 'string',
         'default' => '',
         'label' => 'Base DN',
@@ -52,7 +52,7 @@ class ActiveDirectoryConfigKeys extends PluginConfigKeys
     ];
 
     public const USE_SSL = [
-        'key' => 'use.ssl',
+        'key' => 'activedirectory.use.ssl',
         'type' => 'boolean',
         'default' => false,
         'label' => 'Use SSL',
@@ -61,7 +61,7 @@ class ActiveDirectoryConfigKeys extends PluginConfigKeys
     ];
 
     public const VERSION = [
-        'key' => 'version',
+        'key' => 'activedirectory.version',
         'type' => 'integer',
         'default' => 3,
         'label' => 'LDAP Protocol Version',
@@ -70,7 +70,7 @@ class ActiveDirectoryConfigKeys extends PluginConfigKeys
     ];
 
     public const ACCOUNT_SUFFIX = [
-        'key' => 'account.suffix',
+        'key' => 'activedirectory.account.suffix',
         'type' => 'string',
         'default' => '',
         'label' => 'Account Suffix',
@@ -79,7 +79,7 @@ class ActiveDirectoryConfigKeys extends PluginConfigKeys
     ];
 
     public const SECTION_AD = [
-        'key' => 'ad',
+        'key' => 'activedirectory.ad',
         'type' => 'string',
         'default' => '',
         'label' => 'Active Directory Section',
@@ -88,7 +88,7 @@ class ActiveDirectoryConfigKeys extends PluginConfigKeys
         'is_hidden' => true
     ];
     public const RETRY_AGAINST_DATABASE = [
-        'key' => 'database.auth.when.ldap.user.not.found',
+        'key' => 'activedirectory.database.auth.when.ldap.user.not.found',
         'type' => 'boolean',
         'default' => false,
         'label' => 'Retry Against Database',
@@ -97,7 +97,7 @@ class ActiveDirectoryConfigKeys extends PluginConfigKeys
     ];
 
     public const ATTRIBUTE_MAPPING = [
-        'key' => 'attribute.mapping',
+        'key' => 'activedirectory.attribute.mapping',
         'type' => 'string',
         'default' => 'sn=sn,givenname=givenname,mail=mail,telephonenumber=telephonenumber,physicaldeliveryofficename=physicaldeliveryofficename,title=title',
         'label' => 'Attribute Mapping',
@@ -106,7 +106,7 @@ class ActiveDirectoryConfigKeys extends PluginConfigKeys
     ];
 
     public const REQUIRED_GROUPS = [
-        'key' => 'required.groups',
+        'key' => 'activedirectory.required.groups',
         'type' => 'string',
         'default' => '',
         'label' => 'Required Groups',
@@ -115,7 +115,7 @@ class ActiveDirectoryConfigKeys extends PluginConfigKeys
     ];
 
     public const SYNC_GROUPS = [
-        'key' => 'sync.groups',
+        'key' => 'activedirectory.sync.groups',
         'type' => 'boolean',
         'default' => false,
         'label' => 'Sync Groups',
@@ -124,7 +124,7 @@ class ActiveDirectoryConfigKeys extends PluginConfigKeys
     ];
 
     public const USE_SSO = [
-        'key' => 'use.sso',
+        'key' => 'activedirectory.use.sso',
         'type' => 'boolean',
         'default' => false,
         'label' => 'Use SSO',
@@ -133,7 +133,7 @@ class ActiveDirectoryConfigKeys extends PluginConfigKeys
     ];
 
     public const PREVENT_CLEAN_USERNAME = [
-        'key' => 'prevent.clean.username',
+        'key' => 'activedirectory.prevent.clean.username',
         'type' => 'boolean',
         'default' => false,
         'label' => 'Prevent Clean Username',

--- a/plugins/Authentication/CAS/CAS.config.dist.php
+++ b/plugins/Authentication/CAS/CAS.config.dist.php
@@ -2,34 +2,36 @@
 
 return [
     'settings' => [
-        // '1.0' = CAS_VERSION_1_0, '2.0' = CAS_VERSION_2_0, 'S1' = SAML_VERSION_1_1
-        'cas.version' => 'S1',
+        'cas' => [
+            // '1.0' = CAS_VERSION_1_0, '2.0' = CAS_VERSION_2_0, 'S1' = SAML_VERSION_1_1
+            'version' => 'S1',
 
-        // the hostname of the CAS server
-        'cas.server.hostname' => 'localhost',
+            // the hostname of the CAS server
+            'server.hostname' => 'localhost',
 
-        // the port the CAS server is running on
-        'cas.port' => 443,
+            // the port the CAS server is running on
+            'port' => 443,
 
-        // the URI the CAS server is responding on
-        'cas.server.uri' => '',
+            // the URI the CAS server is responding on
+            'server.uri' => '',
 
-        // Allow phpCAS to change the session_id
-        'cas.change.session.id' => false,
+            // Allow phpCAS to change the session_id
+            'change.session.id' => false,
 
-        // Email suffix to use when storing CAS user account. IE, email addresses will be saved to LibreBooking as username@yourdomain.com
-        'email.suffix' => '@yourdomain.com',
+            // Email suffix to use when storing CAS user account. IE, email addresses will be saved to LibreBooking as username@yourdomain.com
+            'email.suffix' => '@yourdomain.com',
 
-        // Comma separated list of servers to use for logout. Leave blank to not use cas logout servers
-        'cas.logout.servers' => '',
+            // Comma separated list of servers to use for logout. Leave blank to not use cas logout servers
+            'logout.servers' => '',
 
-        // Path to certificate to use for CAS. Leave blank if no certificate should be used
-        'cas.certificates' => '',
+            // Path to certificate to use for CAS. Leave blank if no certificate should be used
+            'certificates' => '',
 
-        // bookedAttribute=CASAttribute
-        'cas.attribute.mapping' => 'givenName=givenName,surName=surname,email=mail,groups=Role',
+            // bookedAttribute=CASAttribute
+            'attribute.mapping' => 'givenName=givenName,surName=surname,email=mail,groups=Role',
 
-        'cas.debug.enabled' => false,
-        'cas.debug.file' => '/tmp/phpcas.log',
+            'debug.enabled' => false,
+            'debug.file' => '/tmp/phpcas.log',
+        ],
     ],
 ];

--- a/plugins/Authentication/CAS/CASConfigKeys.php
+++ b/plugins/Authentication/CAS/CASConfigKeys.php
@@ -7,7 +7,7 @@ class CASConfigKeys extends PluginConfigKeys
     public const CONFIG_ID = 'CAS';
 
     public const CAS_VERSION = [
-        'key' => 'cas.version',
+        'key' => 'version',
         'type' => 'string',
         'default' => 'S1',
         'label' => 'CAS Version',
@@ -21,7 +21,7 @@ class CASConfigKeys extends PluginConfigKeys
     ];
 
     public const CAS_SERVER_HOSTNAME = [
-        'key' => 'cas.server.hostname',
+        'key' => 'server.hostname',
         'type' => 'string',
         'default' => 'localhost',
         'label' => 'CAS Server Hostname',
@@ -30,7 +30,7 @@ class CASConfigKeys extends PluginConfigKeys
     ];
 
     public const CAS_PORT = [
-        'key' => 'cas.port',
+        'key' => 'port',
         'type' => 'integer',
         'default' => 443,
         'label' => 'CAS Server Port',
@@ -39,7 +39,7 @@ class CASConfigKeys extends PluginConfigKeys
     ];
 
     public const CAS_SERVER_URI = [
-        'key' => 'cas.server.uri',
+        'key' => 'server.uri',
         'type' => 'string',
         'default' => '',
         'label' => 'CAS Server URI',
@@ -48,7 +48,7 @@ class CASConfigKeys extends PluginConfigKeys
     ];
 
     public const CAS_CHANGESESSIONID = [
-        'key' => 'cas.change.session.id',
+        'key' => 'change.session.id',
         'type' => 'boolean',
         'default' => false,
         'label' => 'Change Session ID',
@@ -57,7 +57,7 @@ class CASConfigKeys extends PluginConfigKeys
     ];
 
     public const CAS_LOGOUT_SERVERS = [
-        'key' => 'cas.logout.servers',
+        'key' => 'logout.servers',
         'type' => 'string',
         'default' => '',
         'label' => 'CAS Logout Servers',
@@ -66,7 +66,7 @@ class CASConfigKeys extends PluginConfigKeys
     ];
 
     public const CAS_CERTIFICATES = [
-        'key' => 'cas.certificates',
+        'key' => 'certificates',
         'type' => 'string',
         'default' => '',
         'label' => 'CAS Certificate',
@@ -75,7 +75,7 @@ class CASConfigKeys extends PluginConfigKeys
     ];
 
     public const CAS_DEBUG_ENABLED = [
-        'key' => 'cas.debug.enabled',
+        'key' => 'debug.enabled',
         'type' => 'boolean',
         'default' => false,
         'label' => 'Enable CAS Debug',
@@ -84,7 +84,7 @@ class CASConfigKeys extends PluginConfigKeys
     ];
 
     public const DEBUG_FILE = [
-        'key' => 'cas.debug.file',
+        'key' => 'debug.file',
         'type' => 'string',
         'default' => '/tmp/cas.log',
         'label' => 'Debug File',
@@ -102,7 +102,7 @@ class CASConfigKeys extends PluginConfigKeys
     ];
 
     public const ATTRIBUTE_MAPPING = [
-        'key' => 'cas.attribute.mapping',
+        'key' => 'attribute.mapping',
         'type' => 'string',
         'default' => 'givenName=givenName,surName=surname,email=mail,groups=Role',
         'label' => 'Attribute Mapping',

--- a/plugins/Authentication/Drupal/Drupal.config.dist.php
+++ b/plugins/Authentication/Drupal/Drupal.config.dist.php
@@ -2,11 +2,13 @@
 
 return [
     'settings' => [
-        // Path to the Drupal root directory.
-        'drupal.root.dir' => '/full/drupal/path',
+        'drupal' => [
+            // Path to the Drupal root directory.
+            'root.dir' => '/full/drupal/path',
 
-        // Leaving this parameter empty will allow all authenticated users.
-        'drupal.allowed_roles' => 'comma,separated,roles',
+            // Leaving this parameter empty will allow all authenticated users.
+            'allowed_roles' => 'comma,separated,roles',
+        ],
     ],
 ];
 

--- a/plugins/Authentication/Drupal/DrupalConfigKeys.php
+++ b/plugins/Authentication/Drupal/DrupalConfigKeys.php
@@ -7,7 +7,7 @@ class DrupalConfigKeys extends PluginConfigKeys
     public const CONFIG_ID = 'Drupal';
 
     public const DRUPAL_ROOT_DIR = [
-        'key' => 'drupal.root.dir',
+        'key' => 'root.dir',
         'type' => 'string',
         'default' => 'S1',
         'label' => 'Drupal Root Directory',
@@ -16,7 +16,7 @@ class DrupalConfigKeys extends PluginConfigKeys
     ];
 
     public const DRUPAL_ALLOWED_ROLES = [
-        'key' => 'drupal.allowed_roles',
+        'key' => 'allowed_roles',
         'type' => 'string',
         'default' => 'comma,separated,roles',
         'label' => 'Drupal Allowed Roles',

--- a/plugins/Authentication/Ldap/Ldap.config.dist.php
+++ b/plugins/Authentication/Ldap/Ldap.config.dist.php
@@ -5,52 +5,54 @@
 
 return [
     'settings' => [
-        // comma separated list of ldap servers such as ldap://mydomain1,ldap://localhost
-        'host' => 'ldap://localhost',
+        'ldap' => [
+            // comma separated list of ldap servers such as ldap://mydomain1,ldap://localhost
+            'host' => 'ldap://localhost',
 
-        // default ldap port 389 or 636 for ssl.
-        'port' => 389,
+            // default ldap port 389 or 636 for ssl.
+            'port' => 389,
 
-        // LDAP protocol version
-        'version' => 3,
+            // LDAP protocol version
+            'version' => 3,
 
-        // TLS is started after connecting
-        'starttls' => false,
+            // TLS is started after connecting
+            'starttls' => false,
 
-        // The distinguished name to bind as (username). If you don't supply this, an anonymous bind will be established.
-        'binddn' => '',
+            // The distinguished name to bind as (username). If you don't supply this, an anonymous bind will be established.
+            'binddn' => '',
 
-        // Password for the binddn. If the credentials are wrong, the bind will fail server-side and an anonymous bind will be established instead. An empty bindpw string requests an unauthenticated bind.
-        'bindpw' => '',
+            // Password for the binddn. If the credentials are wrong, the bind will fail server-side and an anonymous bind will be established instead. An empty bindpw string requests an unauthenticated bind.
+            'bindpw' => '',
 
-        // LDAP base name (eg. dc=example,dc=com)
-        'basedn' => '',
+            // LDAP base name (eg. dc=example,dc=com)
+            'basedn' => '',
 
-        // Default search filter
-        'filter' => '',
+            // Default search filter
+            'filter' => '',
 
-        // Search scope (eg. uid)
-        'scope' => '',
+            // Search scope (eg. uid)
+            'scope' => '',
 
-        // Required group (empty if not necessary) (eg. cn=MyGroup,cn=Groups,dc=example,dc=com)
-        'required.group' => '',
+            // Required group (empty if not necessary) (eg. cn=MyGroup,cn=Groups,dc=example,dc=com)
+            'required.group' => '',
 
-        // if ldap auth fails, authenticate against LibreBooking database
-        'database.auth.when.ldap.user.not.found' => false,
+            // if ldap auth fails, authenticate against LibreBooking database
+            'database.auth.when.ldap.user.not.found' => false,
 
-        // if LDAP2 should use debug logging
-        'debug.enabled' => false,
+            // if LDAP2 should use debug logging
+            'debug.enabled' => false,
 
-        // mapping of required attributes to attribute names in your directory
-        'attribute.mapping' => 'sn=sn,givenname=givenname,mail=mail,telephonenumber=telephonenumber,physicaldeliveryofficename=physicaldeliveryofficename,title=title',
+            // mapping of required attributes to attribute names in your directory
+            'attribute.mapping' => 'sn=sn,givenname=givenname,mail=mail,telephonenumber=telephonenumber,physicaldeliveryofficename=physicaldeliveryofficename,title=title',
 
-        // the attribute name for user identification
-        'user.id.attribute' => 'uid',
+            // the attribute name for user identification
+            'user.id.attribute' => 'uid',
 
-        // Whether or not groups should be synced into LibreBooking
-        'sync.groups' => false,
+            // Whether or not groups should be synced into LibreBooking
+            'sync.groups' => false,
 
-        // If the username is an email address or contains the domain, clean it
-        'prevent.clean.username' => false,
+            // If the username is an email address or contains the domain, clean it
+            'prevent.clean.username' => false,
+        ],
     ],
 ];

--- a/plugins/Authentication/Ldap/Ldap.config.dist.php
+++ b/plugins/Authentication/Ldap/Ldap.config.dist.php
@@ -5,52 +5,54 @@
 
 return [
     'settings' => [
-        // comma separated list of ldap servers such as ldap://mydomain1,ldap://localhost
-        'host' => 'ldap://localhost',
+        'ldap' => [
+            // comma separated list of ldap servers such as ldap://mydomain1,ldap://localhost
+            'host' => 'ldap://localhost',
 
-        // default ldap port 389 or 636 for ssl.
-        'port' => 389,
+            // default ldap port 389 or 636 for ssl.
+            'port' => 389,
 
-        // LDAP protocol version
-        'version' => 3,
+            // LDAP protocol version
+            'version' => 3,
 
-        // TLS is started after connecting
-        'starttls' => false,
+            // TLS is started after connecting
+            'starttls' => false,
 
-        // The distinguished name to bind as (username). If you don't supply this, an anonymous bind will be established.
-        'binddn' => '',
+            // The distinguished name to bind as (username). If you don't supply this, an anonymous bind will be established.
+            'binddn' => '',
 
-        // Password for the binddn. If the credentials are wrong, the bind will fail server-side and an anonymous bind will be established instead. An empty bindpw string requests an unauthenticated bind.
-        'bindpw' => '',
+            // Password for the binddn. If the credentials are wrong, the bind will fail server-side and an anonymous bind will be established instead. An empty bindpw string requests an unauthenticated bind.
+            'bindpw' => '',
 
-        // LDAP base name (eg. dc=example,dc=com)
-        'basedn' => '',
+            // LDAP base name (eg. dc=example,dc=com)
+            'basedn' => '',
 
-        // Default search filter
-        'filter' => '',
+            // Default search filter
+            'filter' => '',
 
-        // Search scope (eg. uid)
-        'scope' => '',
+            // Search scope (eg. uid)
+            'scope' => '',
 
-        // Required group (empty if not necessary) (eg. cn=MyGroup,cn=Groups,dc=example,dc=com)
-        'required.group' => '',
+            // Required group (empty if not necessary) (eg. cn=MyGroup,cn=Groups,dc=example,dc=com)
+            'required.group' => '',
 
-        // if ldap auth fails, authenticate against LibreBooking database
-        'database.auth.when.ldap.user.not.found' => false,
+            // if ldap auth fails, authenticate against LibreBooking database
+            'database.auth.when.ldap.user.not.found' => false,
 
-        // if LDAP2 should use debug logging
-        'ldap.debug.enabled' => false,
+            // if LDAP2 should use debug logging
+            'debug.enabled' => false,
 
-        // mapping of required attributes to attribute names in your directory
-        'attribute.mapping' => 'sn=sn,givenname=givenname,mail=mail,telephonenumber=telephonenumber,physicaldeliveryofficename=physicaldeliveryofficename,title=title',
+            // mapping of required attributes to attribute names in your directory
+            'attribute.mapping' => 'sn=sn,givenname=givenname,mail=mail,telephonenumber=telephonenumber,physicaldeliveryofficename=physicaldeliveryofficename,title=title',
 
-        // the attribute name for user identification
-        'user.id.attribute' => 'uid',
+            // the attribute name for user identification
+            'user.id.attribute' => 'uid',
 
-        // Whether or not groups should be synced into LibreBooking
-        'sync.groups' => false,
+            // Whether or not groups should be synced into LibreBooking
+            'sync.groups' => false,
 
-        // If the username is an email address or contains the domain, clean it
-        'prevent.clean.username' => false,
+            // If the username is an email address or contains the domain, clean it
+            'prevent.clean.username' => false,
+        ],
     ],
 ];

--- a/plugins/Authentication/Ldap/Ldap.config.dist.php
+++ b/plugins/Authentication/Ldap/Ldap.config.dist.php
@@ -39,7 +39,7 @@ return [
         'database.auth.when.ldap.user.not.found' => false,
 
         // if LDAP2 should use debug logging
-        'ldap.debug.enabled' => false,
+        'debug.enabled' => false,
 
         // mapping of required attributes to attribute names in your directory
         'attribute.mapping' => 'sn=sn,givenname=givenname,mail=mail,telephonenumber=telephonenumber,physicaldeliveryofficename=physicaldeliveryofficename,title=title',

--- a/plugins/Authentication/Ldap/Ldap2Wrapper.php
+++ b/plugins/Authentication/Ldap/Ldap2Wrapper.php
@@ -91,7 +91,7 @@ class Ldap2Wrapper
     {
         $uidAttribute = $this->options->GetUserIdAttribute();
         $requiredGroup = $this->options->GetRequiredGroup();
-        Log::Error('LDAP - uid attribute: %s', $uidAttribute);
+        Log::Debug('LDAP - uid attribute: %s', $uidAttribute);
 
         $filter = Net_LDAP2_Filter::create($uidAttribute, 'equals', $username);
 

--- a/plugins/Authentication/Ldap/LdapConfigKeys.php
+++ b/plugins/Authentication/Ldap/LdapConfigKeys.php
@@ -11,7 +11,7 @@ class LdapConfigKeys extends PluginConfigKeys
         'type' => 'string',
         'default' => '',
         'label' => 'LDAP Host',
-        'description' => 'Hostname or IP address of LDAP server',
+        'description' => 'Hostname or IP address of LDAP server. Should start with ldap:// or ldaps://',
         'section' => 'ldap'
     ];
 

--- a/plugins/Authentication/Ldap/LdapConfigKeys.php
+++ b/plugins/Authentication/Ldap/LdapConfigKeys.php
@@ -85,12 +85,7 @@ class LdapConfigKeys extends PluginConfigKeys
         'default' => 'sub',
         'label' => 'Search Scope',
         'description' => 'LDAP search scope (base, one, or sub)',
-        'section' => 'ldap',
-        'choices' => [
-            'base' => 'Base',
-            'one' => 'One Level',
-            'sub' => 'Subtree'
-        ]
+        'section' => 'ldap'
     ];
 
     public const RETRY_AGAINST_DATABASE = [

--- a/plugins/Authentication/Ldap/LdapConfigKeys.php
+++ b/plugins/Authentication/Ldap/LdapConfigKeys.php
@@ -149,7 +149,7 @@ class LdapConfigKeys extends PluginConfigKeys
 
     // Adding the debug setting that's referenced in LdapOptions::IsLdapDebugOn()
     public const DEBUG_ENABLED = [
-        'key' => 'ldap.debug.enabled',
+        'key' => 'debug.enabled',
         'type' => 'boolean',
         'default' => false,
         'label' => 'Enable LDAP Debug',

--- a/plugins/Authentication/Ldap/LdapConfigKeys.php
+++ b/plugins/Authentication/Ldap/LdapConfigKeys.php
@@ -73,9 +73,9 @@ class LdapConfigKeys extends PluginConfigKeys
     public const FILTER = [
         'key' => 'filter',
         'type' => 'string',
-        'default' => '(uid=%s)',
+        'default' => '',
         'label' => 'Search Filter',
-        'description' => 'LDAP search filter (use %s for username)',
+        'description' => 'Optional LDAP search filter for additional constraints (leave empty for default)',
         'section' => 'ldap'
     ];
 

--- a/plugins/Authentication/Ldap/LdapConfigKeys.php
+++ b/plugins/Authentication/Ldap/LdapConfigKeys.php
@@ -7,7 +7,7 @@ class LdapConfigKeys extends PluginConfigKeys
     public const CONFIG_ID = 'ldap';
 
     public const HOST = [
-        'key' => 'host',
+        'key' => 'ldap.host',
         'type' => 'string',
         'default' => '',
         'label' => 'LDAP Host',
@@ -16,7 +16,7 @@ class LdapConfigKeys extends PluginConfigKeys
     ];
 
     public const PORT = [
-        'key' => 'port',
+        'key' => 'ldap.port',
         'type' => 'integer',
         'default' => 389,
         'label' => 'LDAP Port',
@@ -25,7 +25,7 @@ class LdapConfigKeys extends PluginConfigKeys
     ];
 
     public const VERSION = [
-        'key' => 'version',
+        'key' => 'ldap.version',
         'type' => 'integer',
         'default' => 3,
         'label' => 'LDAP Version',
@@ -34,7 +34,7 @@ class LdapConfigKeys extends PluginConfigKeys
     ];
 
     public const STARTTLS = [
-        'key' => 'starttls',
+        'key' => 'ldap.starttls',
         'type' => 'boolean',
         'default' => false,
         'label' => 'Use StartTLS',
@@ -43,7 +43,7 @@ class LdapConfigKeys extends PluginConfigKeys
     ];
 
     public const BINDDN = [
-        'key' => 'binddn',
+        'key' => 'ldap.binddn',
         'type' => 'string',
         'default' => '',
         'label' => 'Bind DN',
@@ -52,7 +52,7 @@ class LdapConfigKeys extends PluginConfigKeys
     ];
 
     public const BINDPW = [
-        'key' => 'bindpw',
+        'key' => 'ldap.bindpw',
         'type' => 'string',
         'default' => '',
         'label' => 'Bind Password',
@@ -62,7 +62,7 @@ class LdapConfigKeys extends PluginConfigKeys
     ];
 
     public const BASEDN = [
-        'key' => 'basedn',
+        'key' => 'ldap.basedn',
         'type' => 'string',
         'default' => '',
         'label' => 'Base DN',
@@ -71,7 +71,7 @@ class LdapConfigKeys extends PluginConfigKeys
     ];
 
     public const FILTER = [
-        'key' => 'filter',
+        'key' => 'ldap.filter',
         'type' => 'string',
         'default' => '(uid=%s)',
         'label' => 'Search Filter',
@@ -80,7 +80,7 @@ class LdapConfigKeys extends PluginConfigKeys
     ];
 
     public const SCOPE = [
-        'key' => 'scope',
+        'key' => 'ldap.scope',
         'type' => 'string',
         'default' => 'sub',
         'label' => 'Search Scope',
@@ -94,7 +94,7 @@ class LdapConfigKeys extends PluginConfigKeys
     ];
 
     public const RETRY_AGAINST_DATABASE = [
-        'key' => 'database.auth.when.ldap.user.not.found',
+        'key' => 'ldap.database.auth.when.ldap.user.not.found',
         'type' => 'boolean',
         'default' => false,
         'label' => 'Retry Against Database',
@@ -103,7 +103,7 @@ class LdapConfigKeys extends PluginConfigKeys
     ];
 
     public const ATTRIBUTE_MAPPING = [
-        'key' => 'attribute.mapping',
+        'key' => 'ldap.attribute.mapping',
         'type' => 'string',
         'default' => 'sn=sn,givenname=givenname,mail=mail,telephonenumber=telephonenumber,physicaldeliveryofficename=physicaldeliveryofficename,title=title',
         'label' => 'Attribute Mapping',
@@ -112,7 +112,7 @@ class LdapConfigKeys extends PluginConfigKeys
     ];
 
     public const USER_ID_ATTRIBUTE = [
-        'key' => 'user.id.attribute',
+        'key' => 'ldap.user.id.attribute',
         'type' => 'string',
         'default' => 'uid',
         'label' => 'User ID Attribute',
@@ -121,7 +121,7 @@ class LdapConfigKeys extends PluginConfigKeys
     ];
 
     public const REQUIRED_GROUP = [
-        'key' => 'required.group',
+        'key' => 'ldap.required.group',
         'type' => 'string',
         'default' => '',
         'label' => 'Required Group',
@@ -130,7 +130,7 @@ class LdapConfigKeys extends PluginConfigKeys
     ];
 
     public const SYNC_GROUPS = [
-        'key' => 'sync.groups',
+        'key' => 'ldap.sync.groups',
         'type' => 'boolean',
         'default' => false,
         'label' => 'Sync Groups',
@@ -139,7 +139,7 @@ class LdapConfigKeys extends PluginConfigKeys
     ];
 
     public const PREVENT_CLEAN_USERNAME = [
-        'key' => 'prevent.clean.username',
+        'key' => 'ldap.prevent.clean.username',
         'type' => 'boolean',
         'default' => false,
         'label' => 'Prevent Clean Username',

--- a/plugins/Authentication/Ldap/LdapOptions.php
+++ b/plugins/Authentication/Ldap/LdapOptions.php
@@ -78,7 +78,7 @@ class LdapOptions
 
     public function IsLdapDebugOn()
     {
-        return $this->GetConfig('ldap.debug.enabled', new BooleanConverter());
+        return $this->GetConfig(LdapConfigKeys::DEBUG_ENABLED, new BooleanConverter());
     }
 
     public function Attributes()

--- a/plugins/Authentication/Ldap/LdapOptions.php
+++ b/plugins/Authentication/Ldap/LdapOptions.php
@@ -31,7 +31,7 @@ class LdapOptions
         $this->SetOption('basedn', $this->GetConfig(LdapConfigKeys::BASEDN));
         $this->SetOption('filter', $this->GetConfig(LdapConfigKeys::FILTER));
         $this->SetOption('scope', $this->GetConfig(LdapConfigKeys::SCOPE));
-
+        
         return $this->_options;
     }
 

--- a/plugins/Authentication/Mellon/Mellon.config.dist.php
+++ b/plugins/Authentication/Mellon/Mellon.config.dist.php
@@ -2,15 +2,17 @@
 
 return [
     'settings' => [
-        // The email domain to append after the REMOTE_USER variable.
-        'email.domain' => 'yourdomain.com',
-        'key.given.name' => 'MELLON_givenname',
-        'key.surname' => 'MELLON_surname',
+        'mellon' => [
+            // The email domain to append after the REMOTE_USER variable.
+            'email.domain' => 'yourdomain.com',
+            'key.given.name' => 'MELLON_givenname',
+            'key.surname' => 'MELLON_surname',
 
-        // The Group field that has been provided by Mellon.  Must be one line.  (Remember to set MellonMergeEnvVars to On)
-        'key.groups' => 'ADFS_GROUP',
+            // The Group field that has been provided by Mellon.  Must be one line.  (Remember to set MellonMergeEnvVars to On)
+            'key.groups' => 'ADFS_GROUP',
 
-        // Group mappings, bookedAttribute=mellonAttribute.  Separate different mappings by semicolon (;).
-        'group.mappings' => 'Application Administrators=SomeMellonGroup',
+            // Group mappings, bookedAttribute=mellonAttribute.  Separate different mappings by semicolon (;).
+            'group.mappings' => 'Application Administrators=SomeMellonGroup',
+        ],
     ],
 ];

--- a/plugins/Authentication/Moodle/Moodle.config.dist.php
+++ b/plugins/Authentication/Moodle/Moodle.config.dist.php
@@ -2,10 +2,12 @@
 
 return [
     'settings' => [
-        // full path to your moodle root directory
-        'moodle.root.directory' => '/home/user/public_html/moodle',
-        // if plugin auth fails, authenticate against phpScheduleIt database
-        'database.auth.when.user.not.found' => false,
-        'moodle.cookie.id' => 'MoodleSession',
+        'moodle' => [
+            // full path to your moodle root directory
+            'root.directory' => '/home/user/public_html/moodle',
+            // if plugin auth fails, authenticate against phpScheduleIt database
+            'database.auth.when.user.not.found' => false,
+            'cookie.id' => 'MoodleSession',
+        ],
     ],
 ];

--- a/plugins/Authentication/Moodle/MoodleConfigKeys.php
+++ b/plugins/Authentication/Moodle/MoodleConfigKeys.php
@@ -7,7 +7,7 @@ class MoodleConfigKeys extends PluginConfigKeys
     public const CONFIG_ID = 'moodle';
 
     public const ROOT_DIRECTORY = [
-        'key' => 'moodle.root.directory',
+        'key' => 'root.directory',
         'type' => 'string',
         'default' => '/home/user/public_html/moodle',
         'label' => 'Moodle Root Directory',
@@ -25,7 +25,7 @@ class MoodleConfigKeys extends PluginConfigKeys
     ];
 
     public const COOKIE_ID = [
-        'key' => 'moodle.cookie.id',
+        'key' => 'cookie.id',
         'type' => 'string',
         'default' => 'MoodleSession',
         'label' => 'Moodle Cookie ID',

--- a/plugins/Authentication/MoodleAdv/MoodleAdv.config.dist.php
+++ b/plugins/Authentication/MoodleAdv/MoodleAdv.config.dist.php
@@ -2,13 +2,15 @@
 
 return [
     'settings' => [
-        'moodleadv.dbhost' => 'localhost',
-        'moodleadv.dbname' => 'moodle',
-        'moodleadv.dbuser' => '',
-        'moodleadv.dbpass' => '',
-        'moodleadv.prefix' => 'mdl_',
-        'moodleadv.authmethod' => 'all',
-        'moodleadv.roles' => '',
-        'moodleadv.field' => '',
-    ]
+        'moodleadv' => [
+            'dbhost' => 'localhost',
+            'dbname' => 'moodle',
+            'dbuser' => '',
+            'dbpass' => '',
+            'prefix' => 'mdl_',
+            'authmethod' => 'all',
+            'roles' => '',
+            'field' => '',
+        ],
+    ],
 ];

--- a/plugins/Authentication/MoodleAdv/MoodleAdvConfigKeys.php
+++ b/plugins/Authentication/MoodleAdv/MoodleAdvConfigKeys.php
@@ -7,7 +7,7 @@ class MoodleAdvConfigKeys extends PluginConfigKeys
     public const CONFIG_ID = 'MOODLEADV';
 
     public const DB_HOST = [
-        'key' => 'moodleadv.dbhost',
+        'key' => 'dbhost',
         'type' => 'string',
         'default' => 'localhost',
         'label' => 'Moodle Database Host',
@@ -16,7 +16,7 @@ class MoodleAdvConfigKeys extends PluginConfigKeys
     ];
 
     public const DB_NAME = [
-        'key' => 'moodleadv.dbname',
+        'key' => 'dbname',
         'type' => 'string',
         'default' => 'moodle',
         'label' => 'Moodle Database Name',
@@ -25,7 +25,7 @@ class MoodleAdvConfigKeys extends PluginConfigKeys
     ];
 
     public const DB_USER = [
-        'key' => 'moodleadv.dbuser',
+        'key' => 'dbuser',
         'type' => 'string',
         'default' => '',
         'label' => 'Moodle Database User',
@@ -34,7 +34,7 @@ class MoodleAdvConfigKeys extends PluginConfigKeys
     ];
 
     public const DB_PASS = [
-        'key' => 'moodleadv.dbpass',
+        'key' => 'dbpass',
         'type' => 'string',
         'default' => '',
         'label' => 'Moodle Database Password',
@@ -44,7 +44,7 @@ class MoodleAdvConfigKeys extends PluginConfigKeys
     ];
 
     public const DB_PREFIX = [
-        'key' => 'moodleadv.prefix',
+        'key' => 'prefix',
         'type' => 'string',
         'default' => 'mdl_',
         'label' => 'Moodle Table Prefix',
@@ -53,7 +53,7 @@ class MoodleAdvConfigKeys extends PluginConfigKeys
     ];
 
     public const AUTH_METHOD = [
-        'key' => 'moodleadv.authmethod',
+        'key' => 'authmethod',
         'type' => 'string',
         'default' => 'all',
         'label' => 'Authentication Method',
@@ -67,7 +67,7 @@ class MoodleAdvConfigKeys extends PluginConfigKeys
     ];
 
     public const ROLES = [
-        'key' => 'moodleadv.roles',
+        'key' => 'roles',
         'type' => 'string',
         'default' => '',
         'label' => 'Required Roles',
@@ -76,7 +76,7 @@ class MoodleAdvConfigKeys extends PluginConfigKeys
     ];
 
     public const FIELD = [
-        'key' => 'moodleadv.field',
+        'key' => 'field',
         'type' => 'string',
         'default' => '',
         'label' => 'Custom Field ID',

--- a/plugins/Authentication/Saml/Saml.config.dist.php
+++ b/plugins/Authentication/Saml/Saml.config.dist.php
@@ -12,46 +12,48 @@
 
 return [
     'settings' => [
-        // path to SimpleSAMLphp Service Provider(SP) base directory
-        // the SP should be installed on the same server as LibreBooking
-        'simplesamlphp.lib' => '/var/simplesamlphp',
+        'saml' => [
+            // path to SimpleSAMLphp Service Provider(SP) base directory
+            // the SP should be installed on the same server as LibreBooking
+            'simplesamlphp.lib' => '/var/simplesamlphp',
 
-        // path to SimpleSAML SP configuration directory
-        'simplesamlphp.config' => '/var/simplesamlphp/config',
+            // path to SimpleSAML SP configuration directory
+            'simplesamlphp.config' => '/var/simplesamlphp/config',
 
-        // name of the SimpleSAML authentication source configured
-        // in SimpleSAML SP /var/simplesamlphp/config/authsources.php
-        'simplesamlphp.sp' => 'default-sp',
+            // name of the SimpleSAML authentication source configured
+            // in SimpleSAML SP /var/simplesamlphp/config/authsources.php
+            'simplesamlphp.sp' => 'default-sp',
 
-        // SAML attribute names found in SimpleSAMLphp Identify Provider (Idp)
-        // configuration /var/simplesamlphp/config/authsources.php
-        // The Idp will most likely be installed on another server
+            // SAML attribute names found in SimpleSAMLphp Identify Provider (Idp)
+            // configuration /var/simplesamlphp/config/authsources.php
+            // The Idp will most likely be installed on another server
 
-        // SAML attribute that is mapped to LibreBooking username
-        'simplesamlphp.username' => 'sAMAccountName',
+            // SAML attribute that is mapped to LibreBooking username
+            'simplesamlphp.username' => 'sAMAccountName',
 
-        // SAML attribute that is mapped to LibreBooking firstname
-        'simplesamlphp.firstname' => 'givenName',
+            // SAML attribute that is mapped to LibreBooking firstname
+            'simplesamlphp.firstname' => 'givenName',
 
-        // SAML attribute that is mapped to LibreBooking lastname
-        'simplesamlphp.lastname' => 'sn',
+            // SAML attribute that is mapped to LibreBooking lastname
+            'simplesamlphp.lastname' => 'sn',
 
-        // SAML attribute that is mapped to LibreBooking email
-        'simplesamlphp.email' => 'mail',
+            // SAML attribute that is mapped to LibreBooking email
+            'simplesamlphp.email' => 'mail',
 
-        // SAML attribute that is mapped to LibreBooking phone
-        'simplesamlphp.phone' => 'telephoneNumber',
+            // SAML attribute that is mapped to LibreBooking phone
+            'simplesamlphp.phone' => 'telephoneNumber',
 
-        // SAML attribute that is mapped to LibreBooking organization
-        'simplesamlphp.organization' => 'department',
+            // SAML attribute that is mapped to LibreBooking organization
+            'simplesamlphp.organization' => 'department',
 
-        // SAML attribute that is mapped to LibreBooking position
-        'simplesamlphp.position' => 'title',
+            // SAML attribute that is mapped to LibreBooking position
+            'simplesamlphp.position' => 'title',
 
-        // SAML attribute that is mapped to LibreBooking groups
-        'simplesamlphp.groups' => 'groups',
+            // SAML attribute that is mapped to LibreBooking groups
+            'simplesamlphp.groups' => 'groups',
 
-        // Whether or not groups should be synced into LibreBooking
-        'simplesamlphp.sync.groups' => false,
+            // Whether or not groups should be synced into LibreBooking
+            'simplesamlphp.sync.groups' => false,
+        ],
     ],
 ];

--- a/plugins/Authentication/Shibboleth/Shibboleth.config.dist.php
+++ b/plugins/Authentication/Shibboleth/Shibboleth.config.dist.php
@@ -10,22 +10,24 @@
 
 return [
     'settings' => [
-        // the key of the external user's identity. mandatory.
-        'shibboleth.username' => 'REMOTE_USER',
+        'shibboleth' => [
+            // the key of the external user's identity. mandatory.
+            'username' => 'REMOTE_USER',
 
-        // the key of the external user's email address. mandatory.
-        'shibboleth.email' => 'mail',
+            // the key of the external user's email address. mandatory.
+            'email' => 'mail',
 
-        // the key of the external user's first name. optional.
-        'shibboleth.firstname' => 'givenName',
+            // the key of the external user's first name. optional.
+            'firstname' => 'givenName',
 
-        // the key of the external user's last name. optional.
-        'shibboleth.lastname' => 'sn',
+            // the key of the external user's last name. optional.
+            'lastname' => 'sn',
 
-        // the key of the external user's phone number. optional.
-        'shibboleth.phone' => 'telephone',
+            // the key of the external user's phone number. optional.
+            'phone' => 'telephone',
 
-        // the key of the external user's organization. optional.
-        'shibboleth.organization' => 'ou',
+            // the key of the external user's organization. optional.
+            'organization' => 'ou',
+        ],
     ],
 ];

--- a/plugins/Authentication/Shibboleth/ShibbolethConfigKeys.php
+++ b/plugins/Authentication/Shibboleth/ShibbolethConfigKeys.php
@@ -10,7 +10,7 @@ class ShibbolethConfigKeys extends PluginConfigKeys
     public const CONFIG_ID = 'shibboleth';
 
     public const USERNAME = [
-        'key' => 'shibboleth.username',
+        'key' => 'username',
         'type' => 'string',
         'default' => 'REMOTE_USER',
         'label' => 'Username Attribute',
@@ -19,7 +19,7 @@ class ShibbolethConfigKeys extends PluginConfigKeys
     ];
 
     public const FIRSTNAME = [
-        'key' => 'shibboleth.firstname',
+        'key' => 'firstname',
         'type' => 'string',
         'default' => 'givenName',
         'label' => 'First Name Attribute',
@@ -28,7 +28,7 @@ class ShibbolethConfigKeys extends PluginConfigKeys
     ];
 
     public const LASTNAME = [
-        'key' => 'shibboleth.lastname',
+        'key' => 'lastname',
         'type' => 'string',
         'default' => 'sn',
         'label' => 'Last Name Attribute',
@@ -37,7 +37,7 @@ class ShibbolethConfigKeys extends PluginConfigKeys
     ];
 
     public const EMAIL = [
-        'key' => 'shibboleth.email',
+        'key' => 'email',
         'type' => 'string',
         'default' => 'mail',
         'label' => 'Email Attribute',
@@ -46,7 +46,7 @@ class ShibbolethConfigKeys extends PluginConfigKeys
     ];
 
     public const PHONE = [
-        'key' => 'shibboleth.phone',
+        'key' => 'phone',
         'type' => 'string',
         'default' => 'telephone',
         'label' => 'Phone Attribute',
@@ -55,7 +55,7 @@ class ShibbolethConfigKeys extends PluginConfigKeys
     ];
 
     public const ORGANIZATION = [
-        'key' => 'shibboleth.organization',
+        'key' => 'organization',
         'type' => 'string',
         'default' => 'ou',
         'label' => 'Organization Attribute',
@@ -65,7 +65,7 @@ class ShibbolethConfigKeys extends PluginConfigKeys
 
     // Additional attributes can be added here
     public const GROUPS = [
-        'key' => 'shibboleth.groups',
+        'key' => 'groups',
         'type' => 'string',
         'default' => 'groups',
         'label' => 'Groups Attribute',
@@ -74,7 +74,7 @@ class ShibbolethConfigKeys extends PluginConfigKeys
     ];
 
     public const SYNC_GROUPS = [
-        'key' => 'shibboleth.sync.groups',
+        'key' => 'sync.groups',
         'type' => 'boolean',
         'default' => false,
         'label' => 'Sync Groups',

--- a/plugins/Authentication/WordPress/WordPress.config.dist.php
+++ b/plugins/Authentication/WordPress/WordPress.config.dist.php
@@ -2,10 +2,12 @@
 
 return [
     'settings' => [
-        // full path to your wp-includes directory or path relative to LibreBooking root
-        'wp_includes.directory' => '/home/user/public_html/wordpress/wp-includes',
+        'wordpress' => [
+            // full path to your wp-includes directory or path relative to LibreBooking root
+            'wp_includes.directory' => '/home/user/public_html/wordpress/wp-includes',
 
-        // if wordpress auth fails, authenticate against LibreBooking database
-        'database.auth.when.wp.user.not.found' => false,
+            // if wordpress auth fails, authenticate against LibreBooking database
+            'database.auth.when.wp.user.not.found' => false,
+        ],
     ],
 ];

--- a/tests/Plugins/Authentication/PluginConfigLoadingTest.php
+++ b/tests/Plugins/Authentication/PluginConfigLoadingTest.php
@@ -1,0 +1,490 @@
+<?php
+
+require_once(ROOT_DIR . 'lib/Config/namespace.php');
+
+/**
+ * Tests that all authentication plugin configurations load correctly
+ * and that plugin configs are properly namespaced under their section keys.
+ */
+class PluginConfigLoadingTest extends TestBase
+{
+    private $pluginsDir;
+
+    public function setUp(): void
+    {
+        parent::setup();
+        $this->pluginsDir = ROOT_DIR . 'plugins/Authentication/';
+        Configuration::SetInstance(null);
+    }
+
+    public function tearDown(): void
+    {
+        parent::tearDown();
+        Configuration::SetInstance(null);
+    }
+
+    /**
+     * Get all authentication plugins that have config files
+     */
+    private function getAuthenticationPlugins(): array
+    {
+        $plugins = [];
+
+        if (!is_dir($this->pluginsDir)) {
+            $this->fail("Plugins directory not found: {$this->pluginsDir}");
+        }
+
+        $dirs = scandir($this->pluginsDir);
+        foreach ($dirs as $dir) {
+            if ($dir === '.' || $dir === '..') {
+                continue;
+            }
+
+            $pluginPath = $this->pluginsDir . $dir;
+            if (!is_dir($pluginPath)) {
+                continue;
+            }
+
+            // Check for config.dist.php file
+            $configDistFile = $pluginPath . '/' . $dir . '.config.dist.php';
+            $configKeysFile = $pluginPath . '/' . $dir . 'ConfigKeys.php';
+
+            if (file_exists($configDistFile) && file_exists($configKeysFile)) {
+                $plugins[] = [
+                    'name' => $dir,
+                    'path' => $pluginPath,
+                    'configDistFile' => $configDistFile,
+                    'configKeysFile' => $configKeysFile,
+                ];
+            }
+        }
+
+        return $plugins;
+    }
+
+    /**
+     * Test that all plugin config.dist.php files have proper structure
+     */
+    public function testAllPluginConfigsHaveProperStructure()
+    {
+        $plugins = $this->getAuthenticationPlugins();
+        $this->assertNotEmpty($plugins, "No authentication plugins found with config files");
+
+        foreach ($plugins as $plugin) {
+            $config = require($plugin['configDistFile']);
+
+            // Check basic structure
+            $this->assertIsArray($config, "Config for {$plugin['name']} must be an array");
+            $this->assertArrayHasKey('settings', $config, "Config for {$plugin['name']} must have 'settings' key");
+
+            $settings = $config['settings'];
+            $this->assertIsArray($settings, "Settings for {$plugin['name']} must be an array");
+
+            // Check that settings are wrapped in a plugin-specific section
+            $sectionKey = strtolower($plugin['name']);
+            $this->assertArrayHasKey(
+                $sectionKey,
+                $settings,
+                "Config for {$plugin['name']} must have settings wrapped in '{$sectionKey}' section array"
+            );
+
+            $pluginSettings = $settings[$sectionKey];
+            $this->assertIsArray($pluginSettings, "Plugin settings for {$plugin['name']} must be an array");
+            $this->assertNotEmpty($pluginSettings, "Plugin settings for {$plugin['name']} should not be empty");
+        }
+    }
+
+    /**
+     * Test that all plugin ConfigKeys classes extend PluginConfigKeys
+     */
+    public function testAllPluginConfigKeysExtendBaseClass()
+    {
+        $plugins = $this->getAuthenticationPlugins();
+
+        foreach ($plugins as $plugin) {
+            require_once($plugin['configKeysFile']);
+
+            $configKeysClass = $plugin['name'] . 'ConfigKeys';
+            $this->assertTrue(class_exists($configKeysClass), "ConfigKeys class {$configKeysClass} not found");
+
+            $reflection = new ReflectionClass($configKeysClass);
+            $this->assertTrue(
+                $reflection->isSubclassOf('PluginConfigKeys'),
+                "{$configKeysClass} must extend PluginConfigKeys"
+            );
+        }
+    }
+
+    /**
+     * Test that all ConfigKeys have a section defined and match the plugin name
+     */
+    public function testAllConfigKeysHaveProperSections()
+    {
+        $plugins = $this->getAuthenticationPlugins();
+
+        foreach ($plugins as $plugin) {
+            require_once($plugin['configKeysFile']);
+
+            $configKeysClass = $plugin['name'] . 'ConfigKeys';
+            $expectedSection = strtolower($plugin['name']);
+
+            $allKeys = $configKeysClass::all();
+            $this->assertNotEmpty($allKeys, "{$configKeysClass} should have config key definitions");
+
+            foreach ($allKeys as $keyDef) {
+                $this->assertArrayHasKey('section', $keyDef, "Config key in {$configKeysClass} must have 'section'");
+                $this->assertEquals(
+                    $expectedSection,
+                    $keyDef['section'],
+                    "Config key in {$configKeysClass} must have section '{$expectedSection}', got '{$keyDef['section']}'"
+                );
+            }
+        }
+    }
+
+    /**
+     * Test that plugin configs can be registered and loaded correctly
+     */
+    public function testPluginConfigsCanBeRegisteredAndLoaded()
+    {
+        $plugins = $this->getAuthenticationPlugins();
+
+        foreach ($plugins as $plugin) {
+            // Reset configuration for each plugin test
+            Configuration::SetInstance(null);
+
+            require_once($plugin['configKeysFile']);
+
+            $configKeysClass = $plugin['name'] . 'ConfigKeys';
+            $configId = defined("{$configKeysClass}::CONFIG_ID")
+                ? constant("{$configKeysClass}::CONFIG_ID")
+                : strtolower($plugin['name']);
+
+            // Register the config with correct parameter order
+            Configuration::Instance()->Register(
+                $plugin['configDistFile'],
+                '', // envFile
+                $configId,
+                false, // overwrite
+                $configKeysClass // configKeysClass
+            );
+
+            $config = Configuration::Instance()->File($configId);
+            $this->assertNotNull($config, "Config for {$plugin['name']} should be loaded");
+
+            // Test that we can retrieve at least one config value
+            $allKeys = $configKeysClass::all();
+            if (!empty($allKeys)) {
+                $firstKey = $allKeys[0];
+                $value = $config->GetKey($firstKey);
+                // Value can be anything, just check it doesn't throw an exception
+                $this->assertTrue(true, "Successfully retrieved config value for {$plugin['name']}");
+            }
+        }
+    }
+
+    /**
+     * Test that plugin configs are only accessible via section-prefixed keys
+     */
+    public function testPluginConfigsRequireSectionPrefix()
+    {
+        $plugins = $this->getAuthenticationPlugins();
+
+        foreach ($plugins as $plugin) {
+            require_once($plugin['configKeysFile']);
+
+            $configKeysClass = $plugin['name'] . 'ConfigKeys';
+            $expectedSection = strtolower($plugin['name']);
+
+            $allKeys = $configKeysClass::all();
+
+            foreach ($allKeys as $keyDef) {
+                $bareKey = $keyDef['key'];
+                $fullKey = $expectedSection . '.' . $bareKey;
+
+                // Test that findByKey with bare key returns null (because it has a section)
+                $foundWithBareKey = $configKeysClass::findByKey($bareKey);
+                $this->assertNull(
+                    $foundWithBareKey,
+                    "Plugin config key '{$bareKey}' in {$configKeysClass} should NOT be accessible without section prefix"
+                );
+
+                // Test that findByKey with section-prefixed key returns the config
+                $foundWithFullKey = $configKeysClass::findByKey($fullKey);
+                $this->assertNotNull(
+                    $foundWithFullKey,
+                    "Plugin config key '{$fullKey}' in {$configKeysClass} should be accessible with section prefix"
+                );
+
+                // Verify it's the same config definition
+                $this->assertEquals(
+                    $bareKey,
+                    $foundWithFullKey['key'],
+                    "Found config should have bare key '{$bareKey}'"
+                );
+                $this->assertEquals(
+                    $expectedSection,
+                    $foundWithFullKey['section'],
+                    "Found config should have section '{$expectedSection}'"
+                );
+            }
+        }
+    }
+
+    /**
+     * Test that config validation works for plugin configs
+     */
+    public function testPluginConfigValidation()
+    {
+        $plugins = $this->getAuthenticationPlugins();
+
+        foreach ($plugins as $plugin) {
+            Configuration::SetInstance(null);
+
+            require_once($plugin['configKeysFile']);
+
+            $configKeysClass = $plugin['name'] . 'ConfigKeys';
+            $configId = defined("{$configKeysClass}::CONFIG_ID")
+                ? constant("{$configKeysClass}::CONFIG_ID")
+                : strtolower($plugin['name']);
+
+            // Register the config (this should trigger validation)
+            $errorLogs = $this->captureErrorLog(function () use ($plugin, $configKeysClass, $configId) {
+                Configuration::Instance()->Register(
+                    $plugin['configDistFile'],
+                    '', // envFile
+                    $configId,
+                    false, // overwrite
+                    $configKeysClass // configKeysClass
+                );
+            });
+
+            // Config should load without validation errors for known keys
+            // (Unknown keys would trigger warnings, but dist configs should be clean)
+            $hasUnknownKeyWarnings = false;
+            foreach ($errorLogs as $log) {
+                if (strpos($log, 'Unknown configuration key') !== false) {
+                    $hasUnknownKeyWarnings = true;
+                    break;
+                }
+            }
+
+            $this->assertFalse(
+                $hasUnknownKeyWarnings,
+                "Plugin {$plugin['name']} config.dist.php should not have unknown keys"
+            );
+        }
+    }
+
+    /**
+     * Test that actual plugin config files load correctly and all config keys are accessible
+     * This tests the real *.config.php files used by the application (not .dist files)
+     */
+    public function testActualPluginConfigsLoadAllValues()
+    {
+        $plugins = $this->getAuthenticationPlugins();
+        $testedPlugins = 0;
+        $skippedPlugins = [];
+
+        foreach ($plugins as $plugin) {
+            Configuration::SetInstance(null);
+
+            require_once($plugin['configKeysFile']);
+
+            $configKeysClass = $plugin['name'] . 'ConfigKeys';
+            $configId = defined("{$configKeysClass}::CONFIG_ID")
+                ? constant("{$configKeysClass}::CONFIG_ID")
+                : strtolower($plugin['name']);
+
+            // Try to use actual config file first (what the application uses)
+            $actualConfigFile = $plugin['path'] . '/' . $plugin['name'] . '.config.php';
+
+            if (!file_exists($actualConfigFile)) {
+                $skippedPlugins[] = $plugin['name'];
+                continue; // Skip plugins without actual config files
+            }
+
+            // Register the actual config file
+            Configuration::Instance()->Register(
+                $actualConfigFile,
+                '', // envFile
+                $configId,
+                false, // overwrite
+                $configKeysClass // configKeysClass
+            );
+
+            $config = Configuration::Instance()->File($configId);
+            $this->assertNotNull($config, "Config for {$plugin['name']} should be loaded");
+
+            // Test ALL config keys are accessible via Configuration->GetKey()
+            $allKeys = $configKeysClass::all();
+            $expectedSection = strtolower($plugin['name']);
+
+            foreach ($allKeys as $keyDef) {
+                $keyName = $keyDef['key'];
+                $section = $keyDef['section'] ?? null;
+
+                // Test that the value can be retrieved
+                try {
+                    $value = $config->GetKey($keyDef);
+                    // Value retrieved successfully (can be empty string, null, or actual value)
+                    $this->assertTrue(true, "Successfully retrieved {$plugin['name']}.{$keyName}");
+                } catch (Exception $e) {
+                    $this->fail("Failed to retrieve {$plugin['name']}.{$keyName}: " . $e->getMessage());
+                }
+
+                // Test that section-prefixed key lookup works
+                $fullKey = $section ? "{$section}.{$keyName}" : $keyName;
+                $foundKey = $configKeysClass::findByKey($fullKey);
+                $this->assertNotNull(
+                    $foundKey,
+                    "Should find '{$fullKey}' in {$configKeysClass}"
+                );
+
+                // If key has a section, verify bare key is NOT accessible
+                if ($section) {
+                    $bareKey = $configKeysClass::findByKey($keyName);
+                    $this->assertNull(
+                        $bareKey,
+                        "Should NOT find bare key '{$keyName}' in {$configKeysClass} (requires section prefix)"
+                    );
+                }
+            }
+
+            // Output per-plugin summary
+            fwrite(STDERR, sprintf(
+                "\n  ✓ %s: %d config keys tested",
+                $plugin['name'],
+                count($allKeys)
+            ));
+
+            $testedPlugins++;
+        }
+
+        // Report which plugins were tested
+        fwrite(STDERR, sprintf(
+            "\n\n[SUMMARY] Tested %d plugins (%d config keys total)\n",
+            $testedPlugins,
+            array_sum(array_map(function ($p) use (&$plugins) {
+                $keysClass = $p['name'] . 'ConfigKeys';
+                return count($keysClass::all());
+            }, array_filter($plugins, function ($p) {
+                return file_exists($p['path'] . '/' . $p['name'] . '.config.php');
+            })))
+        ));
+
+        if (!empty($skippedPlugins)) {
+            fwrite(STDERR, sprintf(
+                "[SUMMARY] Skipped %d plugins: %s\n\n",
+                count($skippedPlugins),
+                implode(', ', $skippedPlugins)
+            ));
+        }
+
+        if ($testedPlugins > 0) {
+            $this->addToAssertionCount(1); // Count this as a successful test
+        } else {
+            $this->markTestIncomplete(
+                "No actual plugin config files found to test. Skipped: " . implode(', ', $skippedPlugins)
+            );
+        }
+    }
+
+    /**
+     * Test that config files match their ConfigKeys definitions
+     * Validates: 1) No extra keys in config, 2) All expected keys present, 3) Structure matches
+     */
+    public function testConfigFilesMatchConfigKeyDefinitions()
+    {
+        $plugins = $this->getAuthenticationPlugins();
+        $errors = [];
+
+        foreach ($plugins as $plugin) {
+            require_once($plugin['configKeysFile']);
+
+            $configKeysClass = $plugin['name'] . 'ConfigKeys';
+            $expectedSection = strtolower($plugin['name']);
+
+            // Load actual config file
+            $actualConfigFile = $plugin['path'] . '/' . $plugin['name'] . '.config.php';
+            if (!file_exists($actualConfigFile)) {
+                continue; // Skip plugins without actual config files
+            }
+
+            $loadedConfig = require($actualConfigFile);
+
+            // Verify structure: settings -> section -> keys
+            if (!isset($loadedConfig['settings'])) {
+                $errors[] = "{$plugin['name']}: Missing 'settings' top-level key";
+                continue;
+            }
+
+            if (!isset($loadedConfig['settings'][$expectedSection])) {
+                $errors[] = "{$plugin['name']}: Missing section '{$expectedSection}' under settings";
+                continue;
+            }
+
+            $configKeys = $loadedConfig['settings'][$expectedSection];
+            $definedKeys = $configKeysClass::all();
+
+            // Build list of expected keys from ConfigKeys
+            $expectedKeys = [];
+            foreach ($definedKeys as $keyDef) {
+                $expectedKeys[] = $keyDef['key'];
+            }
+
+            // Check for extra keys in config file that aren't in ConfigKeys
+            $actualKeys = array_keys($configKeys);
+            $extraKeys = array_diff($actualKeys, $expectedKeys);
+            if (!empty($extraKeys)) {
+                $errors[] = sprintf(
+                    "%s: Extra keys in config file not defined in %s: %s",
+                    $plugin['name'],
+                    $configKeysClass,
+                    implode(', ', $extraKeys)
+                );
+            }
+
+            // Check for missing keys that are defined in ConfigKeys but not in config
+            $missingKeys = array_diff($expectedKeys, $actualKeys);
+            if (!empty($missingKeys)) {
+                // Filter out keys that have defaults - those are optional
+                $criticalMissing = [];
+                foreach ($missingKeys as $missingKey) {
+                    $keyDef = array_filter($definedKeys, function ($k) use ($missingKey) {
+                        return $k['key'] === $missingKey;
+                    });
+                    $keyDef = reset($keyDef);
+                    // If no default is set, it's critical
+                    if (!isset($keyDef['default']) || $keyDef['default'] === null) {
+                        $criticalMissing[] = $missingKey;
+                    }
+                }
+
+                if (!empty($criticalMissing)) {
+                    $errors[] = sprintf(
+                        "%s: Missing required keys in config file (no default value): %s",
+                        $plugin['name'],
+                        implode(', ', $criticalMissing)
+                    );
+                }
+            }
+        }
+
+        // Report all errors
+        if (!empty($errors)) {
+            fwrite(STDERR, "\n\n[CONFIG VALIDATION ERRORS]\n");
+            foreach ($errors as $error) {
+                fwrite(STDERR, "  ✗ " . $error . "\n");
+            }
+            fwrite(STDERR, "\n");
+
+            $this->fail(
+                "Config file validation failed:\n  - " . implode("\n  - ", $errors)
+            );
+        } else {
+            fwrite(STDERR, "\n[CONFIG VALIDATION] All plugin configs match their ConfigKeys definitions ✓\n");
+            $this->assertTrue(true, "All config files match their ConfigKeys");
+        }
+    }
+}


### PR DESCRIPTION
Hi!

This pull request fixes:

- logging to file app.log not working due to comparison of upper- and lower-case strings
- LDAP authentication not working due to problems with new config file format  
  - ConfigKeys and config file missing prefix
  - hard-coded string instead of ConfigKey used
- ActiveDirectory authentication also fixed, but could not be tested ( #856 )
- LDAP log message not an error thus changed to debug

#