### PR TITLE
fix: allow anonymous users to view reservation details when view.reservations=true

### DIFF
--- a/Pages/Ajax/ReservationPopupPage.php
+++ b/Pages/Ajax/ReservationPopupPage.php
@@ -441,7 +441,7 @@ class ReservationPopupPresenter
         );
 
         if (!$userSession->IsLoggedIn() && $allowGuestView && $reservation !== null) {
-            $resourceIds = array_map(fn($r) => $r->GetResourceId(), $reservation->Resources);
+            $resourceIds = array_map(fn ($r) => $r->GetResourceId(), $reservation->Resources);
             $this->_page->BindViewableResourceReservations($resourceIds);
             return;
         }

--- a/Pages/Ajax/ReservationPopupPage.php
+++ b/Pages/Ajax/ReservationPopupPage.php
@@ -209,7 +209,7 @@ class ReservationPopupPage extends Page implements IReservationPopupPage
 
         $this->Set('ReservationId', $this->GetReservationId());
 
-        $this->Display('Ajax/reservation_popup.tpl');
+        $this->Display('Ajax/respopup.tpl');
     }
 
     /**
@@ -433,8 +433,8 @@ class ReservationPopupPresenter
     {
         $userSession = ServiceLocator::GetServer()->GetUserSession();
 
-        // ÄNDERUNG: Anonymer User mit view.reservations=true bekommt die Ressourcen
-        // der aktuellen Reservierung direkt – keine DB-Berechtigungsabfrage nötig
+        // For anonymous users with view.reservations=true, use the resource IDs
+        // of the current reservation directly - no DB permission lookup needed
         $allowGuestView = Configuration::Instance()->GetKey(
             ConfigKeys::PRIVACY_VIEW_RESERVATIONS,
             new BooleanConverter()
@@ -446,7 +446,7 @@ class ReservationPopupPresenter
             return;
         }
 
-        // Eingeloggte User: bisherige Logik unverändert
+        // Logged-in users: keep existing logic unchanged
         $resourceRepo = new ResourceRepository();
         $resourceIds = [];
 

--- a/Pages/Ajax/ReservationPopupPage.php
+++ b/Pages/Ajax/ReservationPopupPage.php
@@ -403,7 +403,7 @@ class ReservationPopupPresenter
         $user = $this->_userRepository->LoadById(ServiceLocator::GetServer()->GetUserSession()->UserId);
         $owner = $this->_userRepository->LoadById($reservation->OwnerId);
 
-        $this->UserResourcePermissions(ServiceLocator::GetServer()->GetUserSession()->UserId);
+        $this->UserResourcePermissions(ServiceLocator::GetServer()->GetUserSession()->UserId, $reservation);
         $this->_page->SetCurrentUserParticipating($this->IsCurrentUserParticipating(ServiceLocator::GetServer()->GetUserSession()->UserId));
         $this->_page->SetCurrentUserInvited($this->IsCurrentUserInvited(ServiceLocator::GetServer()->GetUserSession()->UserId));
 
@@ -424,23 +424,40 @@ class ReservationPopupPresenter
     }
 
     /**
-     * Gets the resources the user has permissions (full access and view only permissions)
-     * This is used to block a user from seeing reservation details if he has no permissions to it's resources
+     * Gets the resources the user has permissions (full access and view only permissions).
+     * For anonymous users: if view.reservations=true, grant access to all resources
+     * of the requested reservation directly (no DB permission lookup needed).
+     * This is used to block a user from seeing reservation details if he has no permissions to its resources.
      */
-    private function UserResourcePermissions($userId)
+    private function UserResourcePermissions($userId, $reservation = null)
     {
+        $userSession = ServiceLocator::GetServer()->GetUserSession();
+
+        // ÄNDERUNG: Anonymer User mit view.reservations=true bekommt die Ressourcen
+        // der aktuellen Reservierung direkt – keine DB-Berechtigungsabfrage nötig
+        $allowGuestView = Configuration::Instance()->GetKey(
+            ConfigKeys::PRIVACY_VIEW_RESERVATIONS,
+            new BooleanConverter()
+        );
+
+        if (!$userSession->IsLoggedIn() && $allowGuestView && $reservation !== null) {
+            $resourceIds = array_map(fn($r) => $r->GetResourceId(), $reservation->Resources);
+            $this->_page->BindViewableResourceReservations($resourceIds);
+            return;
+        }
+
+        // Eingeloggte User: bisherige Logik unverändert
         $resourceRepo = new ResourceRepository();
         $resourceIds = [];
 
         $resourceIds = $resourceRepo->GetUserResourcePermissions($userId);
-
         $resourceIds = $resourceRepo->GetUserGroupResourcePermissions($userId, $resourceIds);
 
-        if (ServiceLocator::GetServer()->GetUserSession()->IsResourceAdmin) {
+        if ($userSession->IsResourceAdmin) {
             $resourceIds = $resourceRepo->GetResourceAdminResourceIds($userId, $resourceIds);
         }
 
-        if (ServiceLocator::GetServer()->GetUserSession()->IsScheduleAdmin) {
+        if ($userSession->IsScheduleAdmin) {
             $resourceIds = $resourceRepo->GetScheduleAdminResourceIds($userId, $resourceIds);
         }
 

--- a/lib/Application/Reservation/ReservationComponentBinder.php
+++ b/lib/Application/Reservation/ReservationComponentBinder.php
@@ -389,8 +389,8 @@ class ReservationDetailsBinder implements IReservationComponentBinder
     {
         $userSession = ServiceLocator::GetServer()->GetUserSession();
 
-        // ÄNDERUNG: Anonymer User mit view.reservations=true bekommt die Ressourcen
-        // der aktuellen Reservierung direkt – keine DB-Berechtigungsabfrage nötig
+        // For anonymous users with view.reservations=true, use the resource IDs
+        // of the current reservation directly - no DB permission lookup needed
         $allowGuestView = Configuration::Instance()->GetKey(
             ConfigKeys::PRIVACY_VIEW_RESERVATIONS,
             new BooleanConverter()
@@ -405,7 +405,7 @@ class ReservationDetailsBinder implements IReservationComponentBinder
             return;
         }
 
-        // Eingeloggte User: bisherige Logik unverändert
+        // Logged-in users: keep existing logic unchanged
         $resourceRepo = new ResourceRepository();
         $resourceIds = [];
 

--- a/lib/Application/Reservation/ReservationComponentBinder.php
+++ b/lib/Application/Reservation/ReservationComponentBinder.php
@@ -381,10 +381,31 @@ class ReservationDetailsBinder implements IReservationComponentBinder
 
     /**
      * Gets the resources the user has permissions (full access and view only permissions)
-     * This is used to block a user from seeing reservation details if he has no permissions to it's resources
+     * This is used to block a user from seeing reservation details if he has no permissions to it's resources.
+     * For anonymous users: if view.reservations=true, grant access to all resources
+     * of the current reservation directly (no DB permission lookup needed).
      */
     private function UserResourcePermissions($userId)
     {
+        $userSession = ServiceLocator::GetServer()->GetUserSession();
+
+        // ÄNDERUNG: Anonymer User mit view.reservations=true bekommt die Ressourcen
+        // der aktuellen Reservierung direkt – keine DB-Berechtigungsabfrage nötig
+        $allowGuestView = Configuration::Instance()->GetKey(
+            ConfigKeys::PRIVACY_VIEW_RESERVATIONS,
+            new BooleanConverter()
+        );
+
+        if (!$userSession->IsLoggedIn() && $allowGuestView) {
+            $resourceIds = array_merge(
+                [$this->reservationView->ResourceId],
+                $this->reservationView->AdditionalResourceIds
+            );
+            $this->page->BindViewableResourceReservations($resourceIds);
+            return;
+        }
+
+        // Eingeloggte User: bisherige Logik unverändert
         $resourceRepo = new ResourceRepository();
         $resourceIds = [];
 
@@ -392,11 +413,11 @@ class ReservationDetailsBinder implements IReservationComponentBinder
 
         $resourceIds = $resourceRepo->GetUserGroupResourcePermissions($userId, $resourceIds);
 
-        if (ServiceLocator::GetServer()->GetUserSession()->IsResourceAdmin) {
+        if ($userSession->IsResourceAdmin) {
             $resourceIds = $resourceRepo->GetResourceAdminResourceIds($userId, $resourceIds);
         }
 
-        if (ServiceLocator::GetServer()->GetUserSession()->IsScheduleAdmin) {
+        if ($userSession->IsScheduleAdmin) {
             $resourceIds = $resourceRepo->GetScheduleAdminResourceIds($userId, $resourceIds);
         }
 

--- a/lib/Application/Schedule/SlotLabelFactory.php
+++ b/lib/Application/Schedule/SlotLabelFactory.php
@@ -68,12 +68,29 @@ class SlotLabelFactory
             return '';
         }
 
-        if (!$shouldHideReservations && !$this->user->IsLoggedIn()) {
-            return '';
-        }
+        // ÄNDERUNG 1: Anonyme User dürfen Details sehen wenn view.reservations=true
+        $isAnonymousUser = !$this->user->IsLoggedIn();
 
-        if (!in_array($reservation->ResourceId, $this->UserResourcePermissions($this->user->UserId)) && !$reservation->IsUserOwner($this->user->UserId) && !$reservation->IsUserInvited($this->user->UserId) && !$reservation->IsUserParticipating($this->user->UserId)) {
-            return '';
+        if ($isAnonymousUser) {
+            // Anonymer User und view.reservations=false → nichts anzeigen
+            if (!$shouldHideReservations) {
+                return '';
+            }
+            // Anonymer User und view.reservations=true → Ressourcen-Berechtigungsprüfung
+            // überspringen (UserId=0 hat keine DB-Einträge), direkt zum Label aufbauen
+        } else {
+            // Eingeloggte User: bisherige Logik unverändert
+            if (!$shouldHideReservations && !$this->user->IsLoggedIn()) {
+                return '';
+            }
+
+            // ÄNDERUNG 2: Ressourcen-Berechtigungsprüfung nur für eingeloggte User
+            if (!in_array($reservation->ResourceId, $this->UserResourcePermissions($this->user->UserId))
+                && !$reservation->IsUserOwner($this->user->UserId)
+                && !$reservation->IsUserInvited($this->user->UserId)
+                && !$reservation->IsUserParticipating($this->user->UserId)) {
+                return '';
+            }
         }
 
         if (empty($format)) {
@@ -145,9 +162,9 @@ class SlotLabelFactory
     }
 
     /**
-    * Gets the resources the user has permissions (full access and view only permissions)
-    * This is used to block a user from seeing reservation details if he has no permissions to it's resources
-    */
+     * Gets the resources the user has permissions (full access and view only permissions)
+     * This is used to block a user from seeing reservation details if he has no permissions to its resources
+     */
     private function UserResourcePermissions($userId)
     {
         $resourceRepo = new ResourceRepository();

--- a/lib/Application/Schedule/SlotLabelFactory.php
+++ b/lib/Application/Schedule/SlotLabelFactory.php
@@ -68,23 +68,23 @@ class SlotLabelFactory
             return '';
         }
 
-        // ÄNDERUNG 1: Anonyme User dürfen Details sehen wenn view.reservations=true
+        // Anonymous users may see details if view.reservations=true
         $isAnonymousUser = !$this->user->IsLoggedIn();
 
         if ($isAnonymousUser) {
-            // Anonymer User und view.reservations=false → nichts anzeigen
+            // Anonymous user and view.reservations=false: show nothing
             if (!$shouldHideReservations) {
                 return '';
             }
-            // Anonymer User und view.reservations=true → Ressourcen-Berechtigungsprüfung
-            // überspringen (UserId=0 hat keine DB-Einträge), direkt zum Label aufbauen
+            // Anonymous user and view.reservations=true: skip the DB resource
+            // permission check (UserId=0 has no DB entries) and proceed to build the label
         } else {
-            // Eingeloggte User: bisherige Logik unverändert
+            // Logged-in users: keep existing logic unchanged
             if (!$shouldHideReservations && !$this->user->IsLoggedIn()) {
                 return '';
             }
 
-            // ÄNDERUNG 2: Ressourcen-Berechtigungsprüfung nur für eingeloggte User
+            // Resource permission check only for logged-in users
             if (!in_array($reservation->ResourceId, $this->UserResourcePermissions($this->user->UserId))
                 && !$reservation->IsUserOwner($this->user->UserId)
                 && !$reservation->IsUserInvited($this->user->UserId)


### PR DESCRIPTION
## Problem

When `privacy.view.reservations` is set to `true` in config.php,
anonymous (unauthenticated) users were still unable to see reservation
details. They could see that a slot was booked, but no title, name or
description. Clicking on a reservation showed the error:

> "Can't see reservation details because you don't have permissions
> to any of the resources in this reservation"

Related issue: https://github.com/LibreBooking/app/issues/444

## Root Cause

In three places, the code calls `UserResourcePermissions()` which
queries the database for resource permissions by UserId. Anonymous
users have `UserId=0`, so this query always returns an empty array,
causing all details to be hidden regardless of the privacy settings.

## Fix

For anonymous users when `view.reservations=true`:
- Skip the DB permission lookup
- Grant access directly to the resource IDs of the requested reservation
- Logged-in users are completely unaffected

## Files Changed

- `lib/Application/Schedule/SlotLabelFactory.php` – slot labels in schedule view
- `Pages/Ajax/ReservationPopupPage.php` – reservation popup
- `lib/Application/Reservation/ReservationComponentBinder.php` – reservation detail page

## Testing

1. Set in config.php:
   - `privacy.view.schedules = true`
   - `privacy.view.reservations = true`
2. Open schedule as anonymous user (not logged in)
3. Reservation details (title, name etc.) are now visible in:
   - Schedule slot labels ✅
   - Reservation popup ✅
   - Reservation detail page ✅