### PR TITLE
fix(calendar): apply resource event colors and fix create reservation button display

### DIFF
--- a/Web/scripts/calendar.js
+++ b/Web/scripts/calendar.js
@@ -104,6 +104,10 @@ function Calendar(opts) {
         if (!_.isEmpty(info.event.id) && !$(info.el).hasClass('unreservable')) {
           $(info.el).attachReservationPopup(info.event.id);
         }
+
+        var eventBackgroundColor = info.event.backgroundColor;
+        var eventTextColor = info.event.textColor;
+
         var startStr;
         // Use currentStart to maintain a stable URL across all main views
         switch (info.view.type) {
@@ -123,6 +127,30 @@ function Calendar(opts) {
         var finalUrl = info.event.url ? info.event.url.replace('[redirect]', redirect) : null;
         if (finalUrl) {
           info.el.setAttribute('href', finalUrl);
+        }
+
+        var styleTargets = [info.el];
+        var innerAnchor = info.el.querySelector('a.fc-event, a.fc-daygrid-event, a.fc-timegrid-event, a.fc-list-event');
+        if (innerAnchor) {
+          styleTargets.push(innerAnchor);
+        }
+
+        if (eventBackgroundColor) {
+          styleTargets.forEach(function (target) {
+            target.style.setProperty('background-color', eventBackgroundColor);
+            target.style.setProperty('border-color', eventBackgroundColor);
+          });
+        }
+        if (eventTextColor) {
+          styleTargets.forEach(function (target) {
+            target.style.setProperty('color', eventTextColor);
+          });
+
+          info.el
+            .querySelectorAll('.fc-event-main, .fc-event-title, .fc-event-time, .fc-list-event-title a')
+            .forEach(function (el) {
+              el.style.setProperty('color', eventTextColor, 'important');
+            });
         }
       },
       eventClick: function (info) {
@@ -407,9 +435,9 @@ function Calendar(opts) {
       handleTimeClick();
     } else {
       dayDialog.removeClass('d-none');
-      // Hide the create button if the filter is schedule
+      // Hide the create button only when the filter is exactly the schedule root option
       var calendarFilterVal = $('#calendarFilter').val();
-      if (calendarFilterVal && calendarFilterVal.startsWith('s')) {
+      if (calendarFilterVal === 's') {
         $('#dayDialogCreate').hide();
       } else {
         $('#dayDialogCreate').show();

--- a/lib/Application/Schedule/CalendarReservation.php
+++ b/lib/Application/Schedule/CalendarReservation.php
@@ -20,8 +20,8 @@ class CalendarReservation
     public $ResourceName;
 
     /**
-    * @var int
-    */
+     * @var int
+     */
     public $ResourceId;
 
     /**
@@ -161,8 +161,8 @@ class CalendarReservation
 
         $color = $reservation->GetColor();
         if (!empty($color)) {
-            $res->Color = $reservation->GetColor() . ' !important';
-            $res->TextColor = $reservation->GetTextColor() . ' !important';
+            $res->Color = $reservation->GetColor();
+            $res->TextColor = $reservation->GetTextColor();
         }
         $res->IsEditable = $user->IsAdmin || $user->UserId == $reservation->OwnerId;
 
@@ -231,8 +231,8 @@ class CalendarReservation
             $cr->DisplayTitle = $factory->Format($reservation, Configuration::Instance()->GetKey(ConfigKeys::RESERVATION_LABELS_RESOURCE_CALENDAR));
             $color = $reservation->GetColor();
             if (!empty($color)) {
-                $cr->Color = $reservation->GetColor() . ' !important';
-                $cr->TextColor = $reservation->GetTextColor() . ' !important';
+                $cr->Color = $reservation->GetColor();
+                $cr->TextColor = $reservation->GetTextColor();
             }
 
             $cr->IsEditable = $userSession->IsAdmin || $userSession->UserId == $reservation->OwnerId;
@@ -304,7 +304,7 @@ class CalendarReservation
             'end' => $this->EndDate->Format($dateFormat),
             'url' => $this->GetUrl(),
             'allDay' => false,
-            'backgroundColor' => $this->Color,
+            'color' => $this->Color,
             'textColor' => $this->TextColor,
             'className' => $this->Class,
             'startEditable' => $this->IsEditable

--- a/tests/Application/Schedule/CalendarReservationTest.php
+++ b/tests/Application/Schedule/CalendarReservationTest.php
@@ -61,4 +61,36 @@ class CalendarReservationTest extends TestBase
 
         $this->assertStringStartsWith('view-reservation.php?rn=' . $referenceNumber, $event['url']);
     }
+
+    public function testFullCalendarColorPayloadUsesCleanColorValuesWithoutImportantSuffix(): void
+    {
+        $resourceColor = '#24ae26';
+
+        $res = new TestReservationItemView(
+            id: 1,
+            startDate: Date::Now(),
+            endDate: Date::Now()->AddHours(1),
+            resourceId: 1,
+            referenceNumber: 'color-ref-1',
+        );
+        $res->ResourceColor = $resourceColor;
+
+        $resource = new FakeBookableResource(1, 'Room A');
+
+        $calendarReservations = CalendarReservation::FromScheduleReservationList(
+            reservations: [$res],
+            blackouts: [],
+            availablePeriods: [],
+            resources: [$resource],
+            userSession: $this->fakeUser,
+        );
+
+        $event = $calendarReservations[0]->AsFullCalendarEvent();
+
+        $this->assertSame($resourceColor, $event['color']);
+        $this->assertSame($res->GetTextColor(), $event['textColor']);
+
+        $this->assertStringNotContainsString('!important', $event['color']);
+        $this->assertStringNotContainsString('!important', $event['textColor']);
+    }
 }


### PR DESCRIPTION
- Fixes event color rendering to use the configured resource color when available.
- Fixes the visibility/display of the "Create Reservation" button in the schedule UI.

Closes: #1404
Assisted-by: Copilot:GPT-4.1