### PR TITLE
Fix iCalendar property assignments mixup up summary and description to show correct subscription label

### DIFF
--- a/lib/Application/Schedule/iCalendarReservationView.php
+++ b/lib/Application/Schedule/iCalendarReservationView.php
@@ -59,13 +59,18 @@ class iCalendarReservationView
 
         $this->DateEnd = $res->EndDate;
         $this->DateStart = $res->StartDate;
-        $this->Description =  $canViewDetails ? $factory->Format($res, $summaryFormat) : $privateNotice;
+        $this->Summary = $canViewDetails ? $factory->Format($res, $summaryFormat) : $privateNotice;
+        // Escape real newlines as RFC 5545 TEXT sequences so all DESCRIPTION usages
+        // in the iCal template (including VALARM) remain RFC-compliant.
+        $this->Description = $canViewDetails ? str_replace(["
+", "
+", "
+"], '\\n', $res->Description ?? '') : $privateNotice;
         $fullName = new FullName($res->OwnerFirstName, $res->OwnerLastName);
         $this->Organizer = $canViewUser ? $fullName->__toString() : $privateNotice;
         $this->OrganizerEmail = $canViewUser ? $res->OwnerEmailAddress : $privateNotice;
         $this->RecurRule = $this->CreateRecurRule($res);
         $this->ReferenceNumber = $res->ReferenceNumber;
-        $this->Summary = $canViewDetails ? $res->Title : $privateNotice;
         $this->ReservationUrl = sprintf(
             '%s/%s?%s=%s',
             Configuration::Instance()->GetScriptUrl(),

--- a/tests/Presenters/CalendarExportPresenterTest.php
+++ b/tests/Presenters/CalendarExportPresenterTest.php
@@ -148,6 +148,54 @@ class CalendarExportPresenterTest extends TestBase
         $this->assertEquals('Private', $reservationView->Description);
     }
 
+    public function testViewShowsFormattedSummaryWhenDetailsVisible()
+    {
+        $user = new FakeUserSession();
+        $res = new ReservationItemView();
+        // IsUserOwner requires both UserId and UserLevelId so SlotLabelFactory.Format
+        // does not short-circuit and return an empty string.
+        $res->UserId = $user->UserId;
+        $res->UserLevelId = ReservationUserLevel::OWNER;
+        $res->Title = 'My Booking Title';
+        $res->StartDate = Date::Now();
+        $res->EndDate = Date::Now()->AddHours(1);
+        $res->OwnerFirstName = 'Test';
+        $res->OwnerLastName = 'User';
+        $res->OwnerEmailAddress = 'test@example.com';
+
+        $this->privacyFilter->_CanViewDetails = true;
+
+        $reservationView = new iCalendarReservationView($res, $user, $this->privacyFilter, '{title}');
+
+        $this->assertEquals('My Booking Title', $reservationView->Summary);
+    }
+
+    public function testViewShowsDescriptionFromReservationNotesWhenDetailsVisible()
+    {
+        $user = new FakeUserSession();
+        $res = new ReservationItemView();
+        $res->Description = 'Booking notes';
+
+        $this->privacyFilter->_CanViewDetails = true;
+
+        $reservationView = new iCalendarReservationView($res, $user, $this->privacyFilter);
+
+        $this->assertEquals('Booking notes', $reservationView->Description);
+    }
+
+    public function testViewEscapesNewlinesInDescriptionForICalCompliance()
+    {
+        $user = new FakeUserSession();
+        $res = new ReservationItemView();
+        $res->Description = "First line\r\nSecond line\nThird line";
+
+        $this->privacyFilter->_CanViewDetails = true;
+
+        $reservationView = new iCalendarReservationView($res, $user, $this->privacyFilter);
+
+        $this->assertEquals('First line\\nSecond line\\nThird line', $reservationView->Description);
+    }
+
     public function testCalendarExportProdIdUsesApplicationVersionInsteadOfConfigValue()
     {
         $this->fakeConfig->SetKey('version', '9.9.9-user-config');


### PR DESCRIPTION
**Reservation view logic updates:**

* Updated the `iCalendarReservationView` constructor to set the `Summary` field using the formatted summary or private notice, and the `Description` field using the reservation description or private notice, depending on user permissions. This clarifies the distinction between summary and description in reservation exports.

