### PR TITLE
fix(auth): block unsafe external redirect targets

### DIFF
--- a/Pages/Page.php
+++ b/Pages/Page.php
@@ -160,23 +160,26 @@ abstract class Page implements IPage
 
     public function Redirect($url)
     {
-        if (!BookedStringHelper::StartsWith($url, $this->path)) {
-            $url = $this->path . $url;
-        }
-
-        $url = str_replace('&amp;', '&', $url);
+        $url = $this->SanitizeRedirectUrl($url);
         header("Location: $url");
         die();
     }
 
     public function RedirectResume($url)
     {
-        if (!BookedStringHelper::StartsWith($url, $this->path)) {
-            $url = $this->path . $url;
-        }
-
+        $url = $this->SanitizeRedirectUrl($url);
         header("Location: $url");
         die();
+    }
+
+    private function SanitizeRedirectUrl(string $url): string
+    {
+        return RedirectUrlSanitizer::Sanitize(
+            url: $url,
+            path: $this->path,
+            scriptUrl: Configuration::Instance()->GetScriptUrl(),
+            fallback: Pages::UrlFromId(Pages::DEFAULT_HOMEPAGE_ID)
+        );
     }
 
     public function RedirectToError($errorMessageId = ErrorMessages::UNKNOWN_ERROR, $lastPage = '')

--- a/Presenters/Authentication/LoginRedirector.php
+++ b/Presenters/Authentication/LoginRedirector.php
@@ -1,19 +1,29 @@
 <?php
 
 require_once(ROOT_DIR . 'Pages/Authentication/ILoginBasePage.php');
+require_once(ROOT_DIR . 'lib/Common/namespace.php');
+require_once(ROOT_DIR . 'lib/Config/namespace.php');
 
 class LoginRedirector
 {
     public static function Redirect(ILoginBasePage $page)
     {
         $redirect = $page->GetResumeUrl();
+        $defaultId = ServiceLocator::GetServer()->GetUserSession()->HomepageId;
+        $fallback = Pages::UrlFromId($defaultId);
+        if (empty($fallback)) {
+            $fallback = Pages::UrlFromId(Pages::DEFAULT_HOMEPAGE_ID);
+        }
 
         if (!empty($redirect)) {
-            $page->Redirect(html_entity_decode($redirect));
+            $page->Redirect(RedirectUrlSanitizer::Sanitize(
+                url: $redirect,
+                path: '',
+                scriptUrl: Configuration::Instance()->GetScriptUrl(),
+                fallback: $fallback
+            ));
         } else {
-            $defaultId = ServiceLocator::GetServer()->GetUserSession()->HomepageId;
-            $url = Pages::UrlFromId($defaultId);
-            $page->Redirect(empty($url) ? Pages::UrlFromId(Pages::DEFAULT_HOMEPAGE_ID) : $url);
+            $page->Redirect($fallback);
         }
     }
 }

--- a/lib/Common/RedirectUrlSanitizer.php
+++ b/lib/Common/RedirectUrlSanitizer.php
@@ -1,0 +1,101 @@
+<?php
+
+class RedirectUrlSanitizer
+{
+    /**
+     * Normalizes a redirect target and falls back to an internal URL when the
+     * target is external, malformed, or uses an unsafe scheme.
+     */
+    public static function Sanitize(string $url, string $path, string $scriptUrl, string $fallback): string
+    {
+        $url = trim(html_entity_decode($url, ENT_QUOTES));
+        if ($url === '') {
+            return $fallback;
+        }
+
+        $parts = parse_url($url);
+        if ($parts === false) {
+            return $fallback;
+        }
+
+        $scheme = isset($parts['scheme']) ? strtolower((string)$parts['scheme']) : null;
+        $host = isset($parts['host']) ? strtolower((string)$parts['host']) : null;
+
+        if ($host !== null) {
+            if ($scheme === null) {
+                return $fallback;
+            }
+
+            if (!in_array($scheme, ['http', 'https'], true)) {
+                return $fallback;
+            }
+
+            if (!self::MatchesConfiguredOrigin($parts, $scriptUrl)) {
+                return $fallback;
+            }
+
+            return $url;
+        }
+
+        if ($scheme !== null) {
+            return $fallback;
+        }
+
+        if (self::IsAlreadyAbsolutePath($url)) {
+            return $url;
+        }
+
+        if (!empty($path) && !BookedStringHelper::StartsWith($url, $path)) {
+            return $path . $url;
+        }
+
+        return $url;
+    }
+
+    /**
+     * @param array<string, mixed> $redirectParts
+     */
+    private static function MatchesConfiguredOrigin(array $redirectParts, string $scriptUrl): bool
+    {
+        $scriptParts = parse_url($scriptUrl);
+        if ($scriptParts === false) {
+            return false;
+        }
+
+        $redirectScheme = strtolower((string)($redirectParts['scheme'] ?? ''));
+        $redirectHost = strtolower((string)($redirectParts['host'] ?? ''));
+        $scriptScheme = strtolower((string)($scriptParts['scheme'] ?? ''));
+        $scriptHost = strtolower((string)($scriptParts['host'] ?? ''));
+
+        if (empty($redirectScheme) || empty($redirectHost) || empty($scriptScheme) || empty($scriptHost)) {
+            return false;
+        }
+
+        if ($redirectScheme !== $scriptScheme || $redirectHost !== $scriptHost) {
+            return false;
+        }
+
+        return self::EffectivePort($redirectScheme, $redirectParts['port'] ?? null)
+            === self::EffectivePort($scriptScheme, $scriptParts['port'] ?? null);
+    }
+
+    private static function EffectivePort(string $scheme, mixed $port): ?int
+    {
+        if ($port !== null) {
+            return (int)$port;
+        }
+
+        return match ($scheme) {
+            'http' => 80,
+            'https' => 443,
+            default => null,
+        };
+    }
+
+    private static function IsAlreadyAbsolutePath(string $url): bool
+    {
+        return BookedStringHelper::StartsWith($url, '/')
+            || BookedStringHelper::StartsWith($url, '?')
+            || BookedStringHelper::StartsWith($url, '#');
+    }
+}

--- a/lib/Common/namespace.php
+++ b/lib/Common/namespace.php
@@ -15,4 +15,5 @@ require_once(ROOT_DIR . 'lib/Common/ErrorMessages.php');
 require_once(ROOT_DIR . 'lib/Common/Logging/Log.php');
 require_once(ROOT_DIR . 'lib/Common/Logging/ExceptionHandler.php');
 require_once(ROOT_DIR . 'lib/Common/ContrastingColor.php');
+require_once(ROOT_DIR . 'lib/Common/RedirectUrlSanitizer.php');
 require_once(ROOT_DIR . 'lib/Common/VersionDisplayResolver.php');

--- a/tests/Infrastructure/Common/RedirectUrlSanitizerTest.php
+++ b/tests/Infrastructure/Common/RedirectUrlSanitizerTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+require_once(ROOT_DIR . 'lib/Common/namespace.php');
+
+class RedirectUrlSanitizerTest extends TestBase
+{
+    private const SCRIPT_URL = 'https://booked.example/Web';
+    private const FALLBACK = 'dashboard.php';
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->fakeConfig->_ScriptUrl = self::SCRIPT_URL;
+    }
+
+    /**
+     * @dataProvider safeRedirectProvider
+     */
+    public function testAllowsSafeRedirects(string $url, string $path, string $expected): void
+    {
+        $actual = RedirectUrlSanitizer::Sanitize($url, $path, self::SCRIPT_URL, self::FALLBACK);
+
+        $this->assertSame($expected, $actual);
+    }
+
+    /**
+     * @dataProvider blockedRedirectProvider
+     */
+    public function testFallsBackForUnsafeRedirects(string $url): void
+    {
+        $actual = RedirectUrlSanitizer::Sanitize($url, '../', self::SCRIPT_URL, self::FALLBACK);
+
+        $this->assertSame(self::FALLBACK, $actual);
+    }
+
+    /**
+     * @return array<string, array{string, string, string}>
+     */
+    public static function safeRedirectProvider(): array
+    {
+        return [
+            'plain relative path is prefixed for nested pages' => ['schedule.php', '../', '../schedule.php'],
+            'current-directory relative path is prefixed for nested pages' => ['./schedule.php', '../', '.././schedule.php'],
+            'parent relative path already includes prefix' => ['../dashboard.php', '../', '../dashboard.php'],
+            'application-root path remains unchanged' => ['/Web/schedule.php', '../', '/Web/schedule.php'],
+            'query-only redirect remains unchanged' => ['?foo=bar', '../', '?foo=bar'],
+            'same-origin absolute https remains unchanged' => ['https://booked.example/Web/schedule.php', '../', 'https://booked.example/Web/schedule.php'],
+        ];
+    }
+
+    /**
+     * @return array<string, array{string}>
+     */
+    public static function blockedRedirectProvider(): array
+    {
+        return [
+            'absolute external url' => ['https://evil.com/steal'],
+            'protocol relative external url' => ['//evil.com/steal'],
+            'javascript scheme' => ['javascript:alert(1)'],
+            'data scheme' => ['data:text/html,alert(1)'],
+            'mailto scheme' => ['mailto:test@example.com'],
+            'same host different scheme' => ['http://booked.example/Web/schedule.php'],
+            'same host different port' => ['https://booked.example:8443/Web/schedule.php'],
+            'malformed absolute url' => ['https://[broken'],
+        ];
+    }
+}

--- a/tests/Presenters/LoginPresenterTest.php
+++ b/tests/Presenters/LoginPresenterTest.php
@@ -42,6 +42,7 @@ class LoginPresenterTest extends TestBase
         $this->page = new FakeLoginPage();
         $this->captchaService = $this->createMock('ICaptchaService');
         $this->announcementRepository = new FakeAnnouncementRepository();
+        $this->fakeConfig->_ScriptUrl = 'https://booked.example/Web';
 
         $this->page->_EmailAddress = 'nobody@localhost';
         $this->page->_Password = 'somepassword';
@@ -97,6 +98,47 @@ class LoginPresenterTest extends TestBase
         $this->presenter->Login();
 
         $this->assertEquals($redirect, $this->page->_LastRedirect);
+    }
+
+    public function testRedirectsToSameOriginAbsoluteRequestedPage()
+    {
+        $redirect = 'https://booked.example/Web/someurl/something.php';
+        $this->page->_ResumeUrl = $redirect;
+
+        $this->auth->_ValidateResult = true;
+        $this->presenter->Login();
+
+        $this->assertEquals($redirect, $this->page->_LastRedirect);
+    }
+
+    public function testBlocksAbsoluteExternalUrlRedirect()
+    {
+        $this->page->_ResumeUrl = 'https://evil.com/steal';
+
+        $this->auth->_ValidateResult = true;
+        $this->presenter->Login();
+
+        $this->assertEquals(Pages::UrlFromId(Pages::DEFAULT_HOMEPAGE_ID), $this->page->_LastRedirect);
+    }
+
+    public function testBlocksProtocolRelativeExternalUrlRedirect()
+    {
+        $this->page->_ResumeUrl = '//evil.com/steal';
+
+        $this->auth->_ValidateResult = true;
+        $this->presenter->Login();
+
+        $this->assertEquals(Pages::UrlFromId(Pages::DEFAULT_HOMEPAGE_ID), $this->page->_LastRedirect);
+    }
+
+    public function testBlocksJavascriptRedirect()
+    {
+        $this->page->_ResumeUrl = 'javascript:alert(1)';
+
+        $this->auth->_ValidateResult = true;
+        $this->presenter->Login();
+
+        $this->assertEquals(Pages::UrlFromId(Pages::DEFAULT_HOMEPAGE_ID), $this->page->_LastRedirect);
     }
 
     public function testPageLoadSetsVariablesCorrectly()


### PR DESCRIPTION
Sanitize redirect destinations before issuing Location headers so login, SSO callback, logout, and resume flows cannot forward users to attacker- controlled URLs.

Allow only internal relative redirects and same-origin absolute HTTP(S) URLs. Reject protocol-relative, malformed, and non-HTTP scheme targets by falling back to a safe internal page.

Add shared redirect sanitizer coverage and login presenter regression tests for external redirect payloads.

Reported-by: Lorenzo Russo <lorenzorusso2911@gmail.com>
Assisted-by: Codex:GPT-5