### PR TITLE
fix(reservations): validate reservation owner on create

### DIFF
--- a/lib/Application/Reservation/Validation/CurrentUserCanReserveForUserRule.php
+++ b/lib/Application/Reservation/Validation/CurrentUserCanReserveForUserRule.php
@@ -1,0 +1,31 @@
+<?php
+
+require_once(ROOT_DIR . 'lib/Application/Authorization/namespace.php');
+
+class CurrentUserCanReserveForUserRule implements IReservationValidationRule
+{
+    /**
+     * @var UserSession
+     */
+    private $userSession;
+
+    /**
+     * @var IAuthorizationService
+     */
+    private $authorizationService;
+
+    public function __construct(UserSession $userSession, IAuthorizationService $authorizationService)
+    {
+        $this->userSession = $userSession;
+        $this->authorizationService = $authorizationService;
+    }
+
+    public function Validate($reservationSeries, $retryParameters)
+    {
+        $reservationUserId = $reservationSeries->UserId();
+        $isAllowed = $this->userSession->UserId == $reservationUserId
+            || $this->authorizationService->CanReserveFor($this->userSession, $reservationUserId);
+
+        return new ReservationRuleResult($isAllowed, Resources::GetInstance()->GetString('InvalidReservationData'));
+    }
+}

--- a/lib/Application/Reservation/Validation/PreReservationFactory.php
+++ b/lib/Application/Reservation/Validation/PreReservationFactory.php
@@ -139,6 +139,7 @@ class PreReservationFactory implements IPreReservationFactory
 
     private function CreateAddService(ReservationValidationRuleProcessor $ruleProcessor, UserSession $userSession)
     {
+        $ruleProcessor->PushRule(new CurrentUserCanReserveForUserRule($userSession, PluginManager::Instance()->LoadAuthorization()));
         $ruleProcessor->AddRule(new TermsOfServiceRule(new TermsOfServiceRepository()));
         $ruleProcessor->AddRule(new AdminExcludedRule(new ResourceMinimumNoticeRuleAdd($userSession), $userSession, $this->userRepository));
         $ruleProcessor->AddRule(new AdminExcludedRule(new RequiresApprovalRule(PluginManager::Instance()->LoadAuthorization()), $userSession, $this->userRepository));

--- a/lib/Application/Reservation/Validation/namespace.php
+++ b/lib/Application/Reservation/Validation/namespace.php
@@ -45,6 +45,7 @@ require_once(ROOT_DIR . 'lib/Application/Reservation/Validation/IBlackoutValidat
 require_once(ROOT_DIR . 'lib/Application/Reservation/Validation/BlackoutValidationResult.php');
 require_once(ROOT_DIR . 'lib/Application/Reservation/Validation/BlackoutDateTimeValidationResult.php');
 require_once(ROOT_DIR . 'lib/Application/Reservation/Validation/CurrentUserIsReservationUserRule.php');
+require_once(ROOT_DIR . 'lib/Application/Reservation/Validation/CurrentUserCanReserveForUserRule.php');
 require_once(ROOT_DIR . 'lib/Application/Reservation/Validation/AccessoryResourceRule.php');
 require_once(ROOT_DIR . 'lib/Application/Reservation/Validation/ReservationCanBeCheckedInRule.php');
 require_once(ROOT_DIR . 'lib/Application/Reservation/Validation/ReservationCanBeCheckedOutRule.php');

--- a/tests/Application/Reservation/CurrentUserCanReserveForUserRuleTest.php
+++ b/tests/Application/Reservation/CurrentUserCanReserveForUserRuleTest.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+require_once(ROOT_DIR . 'lib/Application/Reservation/Validation/namespace.php');
+
+class CurrentUserCanReserveForUserRuleTest extends TestBase
+{
+    private TestReservationSeries $reservationSeries;
+
+    public function setUp(): void
+    {
+        parent::setup();
+
+        $this->fakeUser->IsAdmin = false;
+        $this->fakeUser->IsGroupAdmin = false;
+        $this->fakeUser->IsResourceAdmin = false;
+        $this->fakeUser->IsScheduleAdmin = false;
+        $this->reservationSeries = new TestReservationSeries();
+    }
+
+    public function testAllowsCurrentUserToReserveForSelf()
+    {
+        $this->reservationSeries->WithOwnerId($this->fakeUser->UserId);
+
+        $authorizationService = $this->createMock('IAuthorizationService');
+        $authorizationService->expects($this->never())
+                             ->method('CanReserveFor');
+
+        $rule = new CurrentUserCanReserveForUserRule($this->fakeUser, $authorizationService);
+
+        $result = $rule->Validate($this->reservationSeries, null);
+
+        $this->assertTrue($result->IsValid());
+    }
+
+    public function testRejectsReservationForAnotherUserWithoutAuthorization()
+    {
+        $reserveForId = 1234;
+        $this->reservationSeries->WithOwnerId($reserveForId);
+
+        $authorizationService = $this->createMock('IAuthorizationService');
+        $authorizationService->expects($this->once())
+                             ->method('CanReserveFor')
+                             ->with($this->fakeUser, $reserveForId)
+                             ->willReturn(false);
+
+        $rule = new CurrentUserCanReserveForUserRule($this->fakeUser, $authorizationService);
+
+        $result = $rule->Validate($this->reservationSeries, null);
+
+        $this->assertFalse($result->IsValid());
+        $this->assertEquals(Resources::GetInstance()->GetString('InvalidReservationData'), $result->ErrorMessage());
+    }
+
+    public function testAllowsReservationForAnotherUserWithAuthorization()
+    {
+        $reserveForId = 1234;
+        $this->reservationSeries->WithOwnerId($reserveForId);
+
+        $authorizationService = $this->createMock('IAuthorizationService');
+        $authorizationService->expects($this->once())
+                             ->method('CanReserveFor')
+                             ->with($this->fakeUser, $reserveForId)
+                             ->willReturn(true);
+
+        $rule = new CurrentUserCanReserveForUserRule($this->fakeUser, $authorizationService);
+
+        $result = $rule->Validate($this->reservationSeries, null);
+
+        $this->assertTrue($result->IsValid());
+    }
+
+    public function testAllowsApplicationAdminToReserveForAnotherUser()
+    {
+        $reserveForId = 1234;
+        $adminUser = new FakeUserSession(true, null, 999);
+        $adminUser->IsResourceAdmin = false;
+        $this->reservationSeries->WithOwnerId($reserveForId);
+
+        $userRepository = $this->createMock('IUserRepository');
+        $userRepository->expects($this->never())
+                       ->method('LoadById');
+
+        $rule = new CurrentUserCanReserveForUserRule($adminUser, new AuthorizationService($userRepository));
+
+        $result = $rule->Validate($this->reservationSeries, null);
+
+        $this->assertTrue($result->IsValid());
+    }
+
+    public function testRejectsResourceAdminWithoutReserveForAuthorization()
+    {
+        $reserveForId = 1234;
+        $this->fakeUser->IsResourceAdmin = true;
+        $this->reservationSeries->WithOwnerId($reserveForId);
+
+        $authorizationService = $this->createMock('IAuthorizationService');
+        $authorizationService->expects($this->once())
+                             ->method('CanReserveFor')
+                             ->with($this->fakeUser, $reserveForId)
+                             ->willReturn(false);
+
+        $rule = new CurrentUserCanReserveForUserRule($this->fakeUser, $authorizationService);
+
+        $result = $rule->Validate($this->reservationSeries, null);
+
+        $this->assertFalse($result->IsValid());
+    }
+}


### PR DESCRIPTION
Reject reservation create requests when the submitted owner userId does not match the authenticated user and the user is not authorized to reserve on behalf of that owner.

The reservation create flow accepted userId from form input before running reservation validation. Resource permission checks only verified whether the current user could book the resource, not whether they could create a reservation owned by the submitted user.

Add a create-time validation rule that delegates reserve-for-user authorization to the existing authorization service. This preserves legitimate admin/group-admin reserve-for workflows while blocking ordinary users from tampering with userId.

https://nvd.nist.gov/vuln/detail/CVE-2023-24058

Reported-by: Santhoshini Ganta <santhoshinive75@gmail.com>
Security: CVE-2023-24058
Assisted-by: Codex:GPT-5