### PR TITLE
docs(security): clarify vulnerability reporting policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,12 +2,61 @@
 
 ## Supported Versions
 
-Only the most current stable version will receive patches for security vulnerabilities.
+Only the most current stable version receives patches for security
+vulnerabilities.
 
 supported_version: 5.0.2
 
-Please report (suspected) security vulnerabilities to
-**[librebooking@outlook.com](mailto:librebooking@outlook.com)**. I will try to
-answer as soon as possible (please allow for 2 -5 days). If the issue is
-confirmed, a patch will be released as soon as possible depending on the
-complexity.
+## Reporting a Vulnerability
+
+Report suspected security vulnerabilities to
+**[librebooking@outlook.com](mailto:librebooking@outlook.com)**.
+
+LibreBooking is maintained by a small volunteer team. Please allow 2-5 days for
+an initial response. If the issue is confirmed, a patch will be released as
+soon as practical depending on severity, complexity, and maintainer
+availability.
+
+## Report Requirements
+
+Reports should include:
+
+- Affected LibreBooking version or commit
+- Attacker role and prerequisites
+- Clear reproduction steps
+- Request/response examples or screenshots, where applicable
+- Expected behavior and actual behavior
+- Security impact
+- Whether the issue has been publicly disclosed
+
+Reports that only include scanner output, code-search results, AI-generated
+summaries, or references to historical CVEs without a working reproduction
+against a supported LibreBooking version may be closed without investigation.
+
+## Out of Scope
+
+The following are generally out of scope unless accompanied by a clear exploit
+path and security impact:
+
+- Missing security headers
+- Version disclosure
+- Self-XSS
+- Logout CSRF
+- Reports requiring application administrator access
+- Dependency CVEs without evidence that vulnerable code is reachable in LibreBooking
+- Theoretical issues without reproduction steps
+- Social engineering or physical attacks
+- Denial-of-service reports based only on excessive traffic volume
+
+## CVE Policy
+
+LibreBooking does not request, assign, or coordinate CVE IDs.
+
+Security issues may be fixed in public commits, release notes, or GitHub
+advisories at the maintainers' discretion. Reporters who want a CVE must
+coordinate it independently and should not expect maintainer participation.
+
+Reports submitted primarily to obtain CVE assignment will be closed. Do not
+submit reports solely to request CVE assignment. We do not provide CVE
+sponsorship, CVE write-ups, embargo coordination for CVE publication, or
+repeated status updates for CVE records.


### PR DESCRIPTION
Expand the security policy with clearer reporting expectations, out-of-scope examples, and guidance for low-signal reports such as scanner output, code-search findings, AI-generated summaries, and historical CVE references without reproduction steps.

Document that LibreBooking does not request, assign, or coordinate CVE IDs, and that reports submitted primarily for CVE assignment may be closed.

Assisted-by: Codex:GPT-5