### PR TITLE
docs(security): document administrator trust model

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -60,3 +60,16 @@ Reports submitted primarily to obtain CVE assignment will be closed. Do not
 submit reports solely to request CVE assignment. We do not provide CVE
 sponsorship, CVE write-ups, embargo coordination for CVE publication, or
 repeated status updates for CVE records.
+
+## Administrator Trust Model
+
+Grant application, group, resource, and schedule administrator permissions only
+to trusted users. Administrators can change configuration, users, groups,
+resources, schedules, announcements, reservations, templates, and other content
+that may be displayed to other users or sent by email.
+
+LibreBooking treats administrator accounts as privileged operators, not as
+untrusted users. A malicious or compromised administrator account can affect the
+confidentiality, integrity, and availability of a LibreBooking installation.
+Use strong passwords, revoke unused administrator access, and assign the
+smallest administrator role needed for the user's responsibilities.

--- a/docs/source/INSTALLATION.rst
+++ b/docs/source/INSTALLATION.rst
@@ -612,6 +612,12 @@ After the database has been set up you will need to register the account
 for your application administrator. Navigate to register.php register an
 account with email address set as the ``'admin.email'`` value in your configuration.
 
+Grant administrator permissions only to trusted users. Administrator accounts
+can change configuration, users, groups, resources, schedules, announcements,
+reservations, templates, and other content that may be shown to other users or
+sent by email. Use the smallest administrator role needed for the user's
+responsibilities, and remove administrator access when it is no longer needed.
+
 Upgrading
 ---------
 


### PR DESCRIPTION
Clarify that administrator permissions should only be granted to trusted users because privileged accounts can change settings, users, resources, schedules, announcements, templates, and other content shown to users or sent by email.

Add the guidance to both SECURITY.md and the administrator registration section of the installation documentation.