### PR TITLE
fix(reservations): prevent attachment filename stored XSS

### DIFF
--- a/Domain/ReservationAttachment.php
+++ b/Domain/ReservationAttachment.php
@@ -110,7 +110,7 @@ class ReservationAttachment
     public static function Create($fileName, $fileType, $fileSize, $fileContent, $fileExtension, $seriesId)
     {
         $file = new ReservationAttachment();
-        $file->fileName = $fileName;
+        $file->fileName = self::NormalizeFileName($fileName);
         $file->fileType = $fileType;
         $file->fileSize = $fileSize;
         $file->fileContent = $fileContent;
@@ -118,6 +118,19 @@ class ReservationAttachment
         $file->seriesId = $seriesId;
 
         return $file;
+    }
+
+    public static function NormalizeFileName(string $fileName): string
+    {
+        $normalized = trim((string)$fileName);
+        $normalized = str_replace(['/', '\\'], '_', $normalized);
+        $normalized = preg_replace('/[[:cntrl:]<>:"|?*]+/', '_', $normalized) ?? '';
+
+        if ($normalized === '' || trim($normalized, '._ ') === '') {
+            return 'attachment';
+        }
+
+        return $normalized;
     }
 
     /**

--- a/Domain/ReservationAttachmentView.php
+++ b/Domain/ReservationAttachmentView.php
@@ -1,5 +1,7 @@
 <?php
 
+require_once(ROOT_DIR . 'Domain/ReservationAttachment.php');
+
 class ReservationAttachmentView
 {
     private int $fileId;
@@ -15,7 +17,7 @@ class ReservationAttachmentView
     {
         $this->fileId = $fileId;
         $this->seriesId = $seriesId;
-        $this->fileName = $fileName;
+        $this->fileName = ReservationAttachment::NormalizeFileName($fileName);
     }
 
     /**

--- a/Pages/Reservation/ReservationAttachmentPage.php
+++ b/Pages/Reservation/ReservationAttachmentPage.php
@@ -1,6 +1,7 @@
 <?php
 
 require_once(ROOT_DIR . 'Pages/SecurePage.php');
+require_once(ROOT_DIR . 'Domain/ReservationAttachment.php');
 require_once(ROOT_DIR . 'Presenters/Reservation/ReservationAttachmentPresenter.php');
 
 interface IReservationAttachmentPage
@@ -81,12 +82,25 @@ class ReservationAttachmentPage extends SecurePage implements IReservationAttach
     {
         ob_start();
         $contents = $attachment->FileContents();
+        $fileName = $this->GetHeaderFileName($attachment->FileName());
         header('Content-Type: ' . $attachment->FileType());
-        header('Content-Disposition: attachment; filename="' . $attachment->FileName() . '"');
+        header(
+            "Content-Disposition: attachment; filename=\"{$fileName}\"; filename*=UTF-8''"
+            . rawurlencode($attachment->FileName())
+        );
         header('Content-Length: ' . strlen($contents));
         while (ob_get_level()) {
             ob_end_clean();
         }
         echo $contents;
+    }
+
+    private function GetHeaderFileName(string $fileName): string
+    {
+        $headerFileName = ReservationAttachment::NormalizeFileName($fileName);
+        $headerFileName = preg_replace('/[^\x20-\x7E]/', '_', $headerFileName) ?? 'attachment';
+        $headerFileName = str_replace(['"', '\\'], '_', $headerFileName);
+
+        return $headerFileName;
     }
 }

--- a/tests/Domain/Reservation/ReservationAttachmentTest.php
+++ b/tests/Domain/Reservation/ReservationAttachmentTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+require_once(ROOT_DIR . 'Domain/ReservationAttachment.php');
+require_once(ROOT_DIR . 'Domain/ReservationAttachmentView.php');
+
+class ReservationAttachmentTest extends TestBase
+{
+    public function testCreateNormalizesStoredFileName()
+    {
+        $attachment = ReservationAttachment::Create(
+            '<img src=x onerror=alert(\'XSS\')>.pdf',
+            'application/pdf',
+            100,
+            'contents',
+            'pdf',
+            1
+        );
+
+        $this->assertEquals('_img src=x onerror=alert(\'XSS\')_.pdf', $attachment->FileName());
+    }
+
+    public function testAttachmentViewNormalizesFileNameFromStorage()
+    {
+        $attachment = new ReservationAttachmentView(
+            1,
+            2,
+            "../bad\r\nname?.pdf"
+        );
+
+        $this->assertEquals('.._bad_name_.pdf', $attachment->FileName());
+    }
+
+    public function testNormalizeFileNameFallsBackForEmptyNames()
+    {
+        $this->assertEquals('attachment', ReservationAttachment::NormalizeFileName("\r\n<>"));
+    }
+
+    public function testNormalizeFileNamePreservesHarmlessRepeatedUnderscores()
+    {
+        $this->assertEquals('my__file.pdf', ReservationAttachment::NormalizeFileName('my__file.pdf'));
+    }
+}

--- a/tpl/Reservation/edit.tpl
+++ b/tpl/Reservation/edit.tpl
@@ -171,8 +171,8 @@
                 <br />
                 {foreach from=$Attachments item=attachment}
                     {assign var=attachmentUrl value="attachments/{Pages::RESERVATION_FILE}?{QueryStringKeys::ATTACHMENT_FILE_ID}={$attachment->FileId()}&{QueryStringKeys::REFERENCE_NUMBER}={$ReferenceNumber}"}
-                    <a href="{$attachmentUrl}" download="{$attachmentUrl}" target="_blank"
-                        class="link-primary">{$attachment->FileName()}</a>
+                    <a href="{$attachmentUrl|escape:'html'}" download="{$attachmentUrl|escape:'html'}" target="_blank"
+                        class="link-primary">{$attachment->FileName()|escape:'html'}</a>
                     <input style='display: none;' type="checkbox" name="{FormKeys::REMOVED_FILE_IDS}[{$attachment->FileId()}]" />
                 {/foreach}
             </div>

--- a/tpl/Reservation/view.tpl
+++ b/tpl/Reservation/view.tpl
@@ -306,8 +306,8 @@
                             <br />
                             {foreach from=$Attachments item=attachment}
                                 {assign var=attachmentUrl value="attachments/{Pages::RESERVATION_FILE}?{QueryStringKeys::ATTACHMENT_FILE_ID}={$attachment->FileId()}&{QueryStringKeys::REFERENCE_NUMBER}={$ReferenceNumber}"}
-                                <a href="{$attachmentUrl}" download="{$attachmentUrl}" target="_blank"
-                                    class="link-primary">{$attachment->FileName()}</a>
+                                <a href="{$attachmentUrl|escape:'html'}" download="{$attachmentUrl|escape:'html'}" target="_blank"
+                                    class="link-primary">{$attachment->FileName()|escape:'html'}</a>
                             {/foreach}
                         </div>
                     </div>


### PR DESCRIPTION
Escape reservation attachment filenames when rendering reservation view and edit pages, and normalize reservation attachment filenames when creating or loading attachment view models. Also harden attachment download Content-Disposition headers so stored filenames cannot break out of header parameters.

Reported-by: Dylan GUERVILLE <dylan.guerville@protonmail.com>
Assisted-by: Codex:GPT-5