### PR TITLE
docs(security): clarify trust boundary for admin-authored content

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -33,16 +33,19 @@ Reports that only include scanner output, code-search results, AI-generated
 summaries, or references to historical CVEs without a working reproduction
 against a supported LibreBooking version may be closed without investigation.
 
-## Out of Scope
+## Out of Scope / Reduced Severity
 
-The following are generally out of scope unless accompanied by a clear exploit
-path and security impact:
+Reports about the following issues may be handled as hardening requests or
+non-security bugs rather than security vulnerabilities unless accompanied by a
+clear exploit path and security impact:
 
 - Missing security headers
 - Version disclosure
 - Self-XSS
 - Logout CSRF
-- Reports requiring application administrator access
+- Issues that require administrator privileges, or administrator-authored
+  content, without crossing a lower-privilege security boundary (see
+  [Trusted Content](#trusted-content))
 - Dependency CVEs without evidence that vulnerable code is reachable in LibreBooking
 - Theoretical issues without reproduction steps
 - Social engineering or physical attacks
@@ -73,3 +76,28 @@ untrusted users. A malicious or compromised administrator account can affect the
 confidentiality, integrity, and availability of a LibreBooking installation.
 Use strong passwords, revoke unused administrator access, and assign the
 smallest administrator role needed for the user's responsibilities.
+
+## Trusted Content
+
+LibreBooking treats content authored by trusted administrators within their
+granted permissions as trusted for security triage purposes. Some administrative
+fields intentionally allow rich text, email or notification template markup, or
+custom HTML/CSS, and that content may be displayed to other users or
+unauthenticated visitors.
+
+Reports about HTML or script injection through administrator-authored content
+are welcome, but the project may handle them as defense-in-depth hardening or
+ordinary bugs rather than security vulnerabilities when exploitation requires
+administrator permissions. An administrator who can author this content is
+already a privileged operator (see
+[Administrator Trust Model](#administrator-trust-model)).
+
+LibreBooking may add or improve HTML sanitization for administrator-authored
+content, but the absence of sanitization on content that requires administrator
+permissions to create is not, by itself, treated as a security boundary.
+
+In contrast, injection issues remain security issues where the content's author
+has lower privilege than the viewer, for example content authored by an
+unauthenticated or ordinary user that executes in another user's or an
+administrator's session. This includes user-submitted custom attribute values or
+other non-administrator-authored content.


### PR DESCRIPTION
Update the security policy to distinguish trusted administrator-authored content from lower-privilege injection issues. Reports involving administrator privileges can still be submitted, but may be handled as hardening or ordinary bugs when they do not cross a lower-privilege security boundary.

Document that HTML sanitization for administrator-authored content is defense-in-depth, while content authored by lower-privilege users and executed in a higher-privilege viewer remains a security issue.

Assisted-by: Claude:claude-opus-4-8