### PR TITLE
feat(security): add sanitize_rich_text Smarty modifier

### DIFF
--- a/lib/Common/SmartyPage.php
+++ b/lib/Common/SmartyPage.php
@@ -214,6 +214,7 @@ class SmartyPage extends Smarty
         $this->registerPlugin('function', 'add_querystring', $this->AddQueryString(...));
         $this->registerPlugin('function', 'resource_image', $this->GetResourceImage(...));
         $this->registerPlugin('modifier', 'escapequotes', $this->EscapeQuotes(...));
+        $this->registerPlugin('modifier', 'sanitize_rich_text', $this->SanitizeRichText(...));
         $this->registerPlugin('function', 'flush', $this->Flush(...));
         $this->registerPlugin('function', 'jsfile', $this->IncludeJavascriptFile(...));
         $this->registerPlugin('function', 'cssfile', $this->IncludeCssFile(...));
@@ -810,6 +811,11 @@ class SmartyPage extends Smarty
     {
         $str = str_replace('\'', '&#39;', $var);
         return str_replace('"', '&quot;', $str);
+    }
+
+    public function SanitizeRichText(?string $html): string
+    {
+        return RichTextHtmlSanitizer::Sanitize($html);
     }
 
     public function Flush($params, $smarty)


### PR DESCRIPTION
Register a `sanitize_rich_text` Smarty modifier that delegates to RichTextHtmlSanitizer, exposing the server-side rich-text allowlist to templates. Because LibreBooking renders both web and email templates through SmartyPage, this single registration makes the modifier available to both.

No template uses the modifier yet; wiring the announcement, resource description/note, and admin display render paths is a follow-up change.

Refs: #1435
Assisted-by: Claude:claude-opus-4-8