### PR TITLE
fix(harden-rich-text): sanitize announcement and resource output

### DIFF
--- a/tpl/Ajax/resource_popup.tpl
+++ b/tpl/Ajax/resource_popup.tpl
@@ -155,7 +155,7 @@
                 <span class="fw-bold mt-2">{translate key=Description}</span>
                 <div class="descriptionContent px-2">
                 {if $description neq ''}
-                    {$description|html_entity_decode|url2link|nl2br}
+                    {$description|sanitize_rich_text|url2link|nl2br}
                 {else}
                     {translate key=NoDescriptionLabel}
                 {/if}
@@ -163,7 +163,7 @@
                 <span class="fw-bold mt-2">{translate key=Notes}</span>                
                 <div class="noteContent px-2">
                 {if $notes neq ''}
-                    {$notes|html_entity_decode|url2link|nl2br}
+                    {$notes|sanitize_rich_text|url2link|nl2br}
                 {else}
                     {translate key=NoNotesLabel}
                 {/if}

--- a/tpl/Dashboard/announcements.tpl
+++ b/tpl/Dashboard/announcements.tpl
@@ -10,7 +10,7 @@
 		<div class="accordion-body">
 			<div class="announcementContent">
 				{foreach from=$Announcements item=each}
-					<div class="border-bottom py-2">{$each->Text()|html_entity_decode|url2link|nl2br}</div>
+					<div class="border-bottom py-2">{$each->Text()|sanitize_rich_text|url2link|nl2br}</div>
 				{foreachelse}
 					<p class="noresults text-center fst-italic fs-5">{translate key="NoAnnouncements"}</p>
 				{/foreach}

--- a/tpl/login.tpl
+++ b/tpl/login.tpl
@@ -13,7 +13,7 @@
             <div class="card-body">
                 <ul class="list-group list-group-flush">
                     {foreach from=$Announcements item=each}
-                        <li class="announcement list-group-item">{$each->Text()|html_entity_decode}</li>
+                        <li class="announcement list-group-item">{$each->Text()|sanitize_rich_text}</li>
                     {/foreach}
                 </ul>
             </div>


### PR DESCRIPTION
Render the resource description/notes popup and the dashboard and login announcement text through the sanitize_rich_text modifier instead of html_entity_decode, reducing administrator-authored markup to a safe allowlist on output.

These are the public-facing render paths: the resource popup (/ajax/resource_details.php) and the login page are reachable without authentication, so administrator-authored rich text reaches unauthenticated visitors here.

Defense in depth. Administrator-authored content is trusted per SECURITY.md and is not treated as a security boundary; this hardening neutralizes such markup on output regardless.

Refs: #1435
Reported-by: Yash Shendge <yashshendge6@gmail.com>
Reported-by: Dylan GUERVILLE <dylan.guerville@protonmail.com>
Assisted-by: Claude:claude-opus-4-8