### PR TITLE
fix(harden-url2link): only linkify safe http(s) URLs and valid emails

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,8 @@
         "vlucas/phpdotenv": "^5.6",
         "pear/net_ldap2": "^2.3",
         "ext-ldap": "*",
-        "symfony/html-sanitizer": "^7.4"
+        "symfony/html-sanitizer": "^7.4",
+        "league/uri": "^7.8"
     },
     "scripts": {
         "install-tools": "phive install --trust-gpg-keys",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f7f400a9cf6b9cc05bd9ae4fa2c97e48",
+    "content-hash": "1d8ecad17d2863aa697363a3a6a175ed",
     "packages": [
         {
             "name": "bacon/bacon-qr-code",

--- a/lib/Common/SmartyPage.php
+++ b/lib/Common/SmartyPage.php
@@ -540,12 +540,19 @@ class SmartyPage extends Smarty
                 $url = substr((string) $url, 0, strlen((string) $url) - 1);
             }
 
+            // Only linkify safe http(s) URLs. Without this, url2link would wrap
+            // text such as javascript://%0Aalert%281%29 in a live <a href>, which
+            // bypasses any later sanitizer allowlist.
+            if (!self::IsSafeLinkifyUrl((string) $url)) {
+                return $matches[0];
+            }
+
             $text = $url;
             if (strlen($text) > 30) {
                 $text = substr($text, 0, 30) . '...';
             }
 
-            return $matches[1] . "<a href=\"$url\" target=\"_blank\" rel=\"nofollow\">$text</a>" . $ret;
+            return $matches[1] . "<a href=\"$url\" target=\"_blank\" rel=\"noopener noreferrer nofollow\">$text</a>" . $ret;
         };
 
         $make_web_ftp_clickable_cb = function ($matches) {
@@ -564,11 +571,14 @@ class SmartyPage extends Smarty
                 $text = substr($text, 0, 30) . '...';
             }
 
-            return $matches[1] . "<a href=\"$dest\" rel=\"nofollow\">$text</a>" . $ret;
+            return $matches[1] . "<a href=\"$dest\" rel=\"noopener noreferrer nofollow\">$text</a>" . $ret;
         };
 
         $make_email_clickable_cb = function ($matches) {
             $email = $matches[2] . '@' . $matches[3];
+            if (!self::IsValidEmailAddress($email)) {
+                return $matches[0];
+            }
             return $matches[1] . "<a href=\"mailto:$email\">$email</a>";
         };
 
@@ -591,6 +601,27 @@ class SmartyPage extends Smarty
         $url = preg_replace('#(<a( [^>]+?>|>))<a [^>]+?>([^>]+?)</a></a>#i', '$1$3</a>', (string) $url);
         $url = trim((string) $url);
         return $url;
+    }
+
+    private static function IsSafeLinkifyUrl(string $url): bool
+    {
+        try {
+            $scheme = \League\Uri\Uri::new($url)->getScheme();
+        } catch (\Throwable $e) {
+            return false;
+        }
+
+        return in_array(strtolower((string) $scheme), ['http', 'https'], true);
+    }
+
+    private static function IsValidEmailAddress(string $email): bool
+    {
+        static $validator = null;
+        static $rule = null;
+        $validator ??= new \Egulias\EmailValidator\EmailValidator();
+        $rule ??= new \Egulias\EmailValidator\Validation\RFCValidation();
+
+        return $validator->isValid($email, $rule);
     }
 
     private function GetDefaultDataTablePageSize()

--- a/tests/Infrastructure/Common/SmartyPageTest.php
+++ b/tests/Infrastructure/Common/SmartyPageTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+require_once(ROOT_DIR . 'lib/Common/namespace.php');
+
+class SmartyPageTest extends TestBase
+{
+    public function testCreateUrlLinkifiesHttpAndHttpsUrls(): void
+    {
+        $page = new SmartyPage();
+
+        $this->assertStringContainsString(
+            '<a href="http://example.com"',
+            $page->CreateUrl('visit http://example.com today')
+        );
+        $this->assertStringContainsString(
+            '<a href="https://example.com/path"',
+            $page->CreateUrl('visit https://example.com/path today')
+        );
+    }
+
+    public function testCreateUrlForcesNoopenerNoreferrerOnGeneratedLinks(): void
+    {
+        $page = new SmartyPage();
+
+        $this->assertStringContainsString(
+            'rel="noopener noreferrer nofollow"',
+            $page->CreateUrl('visit https://example.com today')
+        );
+    }
+
+    public function testCreateUrlDoesNotLinkifyJavascriptScheme(): void
+    {
+        $page = new SmartyPage();
+
+        $actual = $page->CreateUrl('click javascript://%0Aalert%281%29 now');
+
+        $this->assertStringNotContainsString('<a', $actual);
+        $this->assertStringNotContainsString('href=', $actual);
+    }
+
+    public function testCreateUrlDoesNotLinkifyNonHttpSchemes(): void
+    {
+        $page = new SmartyPage();
+
+        $this->assertStringNotContainsString('<a', $page->CreateUrl('x ftp://host/file y'));
+        $this->assertStringNotContainsString('<a', $page->CreateUrl('x data://text/html,x y'));
+    }
+
+    public function testCreateUrlLinkifiesValidEmail(): void
+    {
+        $page = new SmartyPage();
+
+        $this->assertStringContainsString(
+            'mailto:user@example.com',
+            $page->CreateUrl('mail user@example.com please')
+        );
+    }
+}


### PR DESCRIPTION
CreateUrl (the url2link modifier) wrapped any "scheme://" match in an anchor with no scheme validation, so administrator-authored text such as javascript://%0Aalert%281%29 (URL-encoded parens) was turned into a live <a href="javascript:..."> that executes on click and bypasses the RichTextHtmlSanitizer scheme allowlist.

Validate the scheme with league/uri and only linkify http/https; leave anything else as plain text. Validate addresses with egulias/email-validator before creating mailto links.

Promote league/uri to a direct dependency: it is now used directly rather than only transitively via symfony/html-sanitizer.

url2link is only applied to administrator-authored content (announcements and resource description/notes), so this is defense in depth per SECURITY.md, not a vulnerability fix. Non-http(s) schemes (e.g. ftp://) are no longer auto-linked, matching the sanitizer's http/https/mailto policy.

Refs: #1435
Assisted-by: Claude:claude-opus-4-8