### PR TITLE
fix(harden-rich-text): sanitize rich text in admin views

### DIFF
--- a/tpl/Admin/Resources/manage_resources.tpl
+++ b/tpl/Admin/Resources/manage_resources.tpl
@@ -432,7 +432,7 @@
 																		data-pk="{$id}" data-value="{$description}"
 																		data-name="{FormKeys::RESOURCE_DESCRIPTION}">
 																		{if $resource->HasDescription()}
-																			{$description|unescape:'html'}
+																			{$description|sanitize_rich_text}
 																		{else}
 																			{translate key='NoDescriptionLabel'}
 																		{/if}
@@ -458,7 +458,7 @@
 																		data-pk="{$id}" data-value="{$notes}"
 																		data-name="{FormKeys::RESOURCE_NOTES}">
 																		{if $resource->HasNotes()}
-																			{$notes|unescape:'html'}
+																			{$notes|sanitize_rich_text}
 																		{else}
 																			{translate key='NoNotesLabel'}
 																		{/if}

--- a/tpl/Admin/Resources/view_resources.tpl
+++ b/tpl/Admin/Resources/view_resources.tpl
@@ -274,7 +274,7 @@
                                                                 {strip}
                                                                     <div class="descriptionValue">
                                                                         {if $resource->HasDescription()}
-                                                                            {$description|unescape:'html'}
+                                                                            {$description|sanitize_rich_text}
                                                                         {else}
                                                                             {translate key='NoDescriptionLabel'}
                                                                         {/if}
@@ -285,7 +285,7 @@
                                                                 <label class="inline fw-bold">{translate key='Notes'}</label>
                                                                 <div class="notesValue">
                                                                     {if $resource->HasNotes()}
-                                                                        {$resource->GetNotes()|unescape:'html'}
+                                                                        {$resource->GetNotes()|sanitize_rich_text}
                                                                     {else}
                                                                         {translate key='NoNotesLabel'}
                                                                     {/if}

--- a/tpl/Admin/manage_announcements.tpl
+++ b/tpl/Admin/manage_announcements.tpl
@@ -114,7 +114,7 @@
 					<tbody>
 						{foreach from=$announcements item=announcement}
 							<tr data-announcement-id="{$announcement->Id()}">
-								<td class="announcementText">{$announcement->Text()|unescape:'html'}</td>
+								<td class="announcementText">{$announcement->Text()|sanitize_rich_text}</td>
 								<td class="announcementPriority">{$announcement->Priority()}</td>
 								<td class="announcementStart" data-order="{$announcement->Start()->Format('Y-m-d H:i')}">
 									{formatdate date=$announcement->Start()->ToTimezone($timezone)}


### PR DESCRIPTION
The admin announcement list and the resource description/notes admin display rendered stored text via unescape:'html', decoding it back into live HTML. Route these through the sanitize_rich_text modifier so administrator-authored markup is reduced to a safe allowlist on output.

Defense in depth: administrator-authored content is trusted per SECURITY.md and is not a security boundary. These are admin-only display views; no security report targets them.

Refs: #1435
Assisted-by: Claude:claude-opus-4-8