### PR TITLE
fix(harden-rich-text): sanitize announcement email rich text

### DIFF
--- a/lang/da_da/AnnouncementEmail.tpl
+++ b/lang/da_da/AnnouncementEmail.tpl
@@ -1,1 +1,1 @@
-{$AnnouncementText|html_entity_decode|url2link|nl2br}
+{$AnnouncementText|sanitize_rich_text|url2link|nl2br}

--- a/lang/ee_ee/AnnouncementEmail.tpl
+++ b/lang/ee_ee/AnnouncementEmail.tpl
@@ -1,1 +1,1 @@
-{$AnnouncementText|html_entity_decode|url2link|nl2br}
+{$AnnouncementText|sanitize_rich_text|url2link|nl2br}

--- a/lang/el_gr/AnnouncementEmail.tpl
+++ b/lang/el_gr/AnnouncementEmail.tpl
@@ -1,1 +1,1 @@
-{$AnnouncementText|html_entity_decode|url2link|nl2br}
+{$AnnouncementText|sanitize_rich_text|url2link|nl2br}

--- a/lang/en_us/AnnouncementEmail.tpl
+++ b/lang/en_us/AnnouncementEmail.tpl
@@ -1,1 +1,1 @@
-{$AnnouncementText|html_entity_decode|url2link|nl2br}
+{$AnnouncementText|sanitize_rich_text|url2link|nl2br}

--- a/lang/es/AnnouncementEmail.tpl
+++ b/lang/es/AnnouncementEmail.tpl
@@ -1,1 +1,1 @@
-{$AnnouncementText|html_entity_decode|url2link|nl2br}
+{$AnnouncementText|sanitize_rich_text|url2link|nl2br}

--- a/lang/fi_fi/AnnouncementEmail.tpl
+++ b/lang/fi_fi/AnnouncementEmail.tpl
@@ -1,1 +1,1 @@
-{$AnnouncementText|html_entity_decode|url2link|nl2br}
+{$AnnouncementText|sanitize_rich_text|url2link|nl2br}

--- a/lang/fr_fr/AnnouncementEmail.tpl
+++ b/lang/fr_fr/AnnouncementEmail.tpl
@@ -1,1 +1,1 @@
-{$AnnouncementText|html_entity_decode|url2link|nl2br}
+{$AnnouncementText|sanitize_rich_text|url2link|nl2br}

--- a/lang/hu_hu/AnnouncementEmail.tpl
+++ b/lang/hu_hu/AnnouncementEmail.tpl
@@ -1,1 +1,1 @@
-{$AnnouncementText|html_entity_decode|url2link|nl2br}
+{$AnnouncementText|sanitize_rich_text|url2link|nl2br}

--- a/lang/it_it/AnnouncementEmail.tpl
+++ b/lang/it_it/AnnouncementEmail.tpl
@@ -1,1 +1,1 @@
-{$AnnouncementText|html_entity_decode|url2link|nl2br}
+{$AnnouncementText|sanitize_rich_text|url2link|nl2br}

--- a/lang/pl/AnnouncementEmail.tpl
+++ b/lang/pl/AnnouncementEmail.tpl
@@ -1,1 +1,1 @@
-{$AnnouncementText|html_entity_decode|url2link|nl2br}
+{$AnnouncementText|sanitize_rich_text|url2link|nl2br}

--- a/lang/pt_br/AnnouncementEmail.tpl
+++ b/lang/pt_br/AnnouncementEmail.tpl
@@ -1,1 +1,1 @@
-{$AnnouncementText|html_entity_decode|url2link|nl2br}
+{$AnnouncementText|sanitize_rich_text|url2link|nl2br}

--- a/lang/pt_pt/AnnouncementEmail.tpl
+++ b/lang/pt_pt/AnnouncementEmail.tpl
@@ -1,1 +1,1 @@
-{$AnnouncementText|html_entity_decode|url2link|nl2br}
+{$AnnouncementText|sanitize_rich_text|url2link|nl2br}

--- a/lang/th_th/AnnouncementEmail.tpl
+++ b/lang/th_th/AnnouncementEmail.tpl
@@ -1,1 +1,1 @@
-{$AnnouncementText|html_entity_decode|url2link|nl2br}
+{$AnnouncementText|sanitize_rich_text|url2link|nl2br}

--- a/lang/vn_vn/AnnouncementEmail.tpl
+++ b/lang/vn_vn/AnnouncementEmail.tpl
@@ -1,1 +1,1 @@
-{$AnnouncementText|html_entity_decode|url2link|nl2br}
+{$AnnouncementText|sanitize_rich_text|url2link|nl2br}

--- a/lang/zh_cn/AnnouncementEmail.tpl
+++ b/lang/zh_cn/AnnouncementEmail.tpl
@@ -1,1 +1,1 @@
-{$AnnouncementText|html_entity_decode|url2link|nl2br}
+{$AnnouncementText|sanitize_rich_text|url2link|nl2br}


### PR DESCRIPTION
Render the announcement email body through the sanitize_rich_text modifier instead of html_entity_decode across all localized AnnouncementEmail.tpl templates, so administrator-authored markup is reduced to a safe allowlist on output.

Defense in depth: administrator-authored content is trusted per SECURITY.md and is not a security boundary; email risk is lower since mail clients do not execute JavaScript. No security report targets the email templates.

Closes: #1435
Assisted-by: Claude:claude-opus-4-8