### PR TITLE
fix(harden-email-templates): reject path traversal in template name

### DIFF
--- a/Presenters/Admin/ManageEmailTemplatesPresenter.php
+++ b/Presenters/Admin/ManageEmailTemplatesPresenter.php
@@ -74,13 +74,25 @@ class ManageEmailTemplatesPresenter extends ActionPresenter
         return preg_replace('/\{\*.+\*\}/', '', $contents);
     }
 
+    private function IsValidTemplateName($templateName)
+    {
+        if (!is_string($templateName)) {
+            return false;
+        }
+        // Require an exact lowercase .tpl extension so validation matches the
+        // case-sensitive replacement used to build the saved filename.
+        return BookedStringHelper::EndsWith($templateName, '.tpl')
+            && !BookedStringHelper::Contains($templateName, '..')
+            && !BookedStringHelper::Contains($templateName, '\\')
+            && !BookedStringHelper::Contains($templateName, '/')
+            // Reject control characters (e.g. newlines) so a crafted name cannot
+            // forge log entries or produce a control-character filename on save.
+            && !preg_match('/[\x00-\x1f\x7f]/', $templateName);
+    }
+
     public function LoadTemplate()
     {
-        $templateName = strtolower($this->page->GetTemplateName());
-        if (!BookedStringHelper::EndsWith($templateName, '.tpl')
-            || BookedStringHelper::Contains($templateName, '..')
-            || BookedStringHelper::Contains($templateName, '\\')
-            || BookedStringHelper::Contains($templateName, '/')) {
+        if (!$this->IsValidTemplateName($this->page->GetTemplateName())) {
             return '';
         }
         $templatePath = Paths::EmailTemplates($this->GetSelectedLanguage()) . $this->page->GetTemplateName();
@@ -98,11 +110,7 @@ class ManageEmailTemplatesPresenter extends ActionPresenter
 
     public function LoadOriginalTemplate()
     {
-        $templateName = strtolower($this->page->GetTemplateName());
-        if (!BookedStringHelper::EndsWith($templateName, '.tpl')
-            || BookedStringHelper::Contains($templateName, '..')
-            || BookedStringHelper::Contains($templateName, '\\')
-            || BookedStringHelper::Contains($templateName, '/')) {
+        if (!$this->IsValidTemplateName($this->page->GetTemplateName())) {
             return '';
         }
         $templatePath = Paths::EmailTemplates($this->GetSelectedLanguage()) . $this->page->GetTemplateName();
@@ -113,6 +121,12 @@ class ManageEmailTemplatesPresenter extends ActionPresenter
     public function UpdateEmailTemplate()
     {
         $templateName = $this->page->GetUpdatedTemplateName();
+
+        if (!$this->IsValidTemplateName($templateName)) {
+            Log::Error('Rejected email template update with invalid template name. Template=%s', json_encode($templateName));
+            $this->page->SetSaveResult(false);
+            return;
+        }
 
         try {
             Log::Debug('Updating email template. Template=%s', $templateName);

--- a/tests/Presenters/Admin/ManageEmailTemplatesPresenterTest.php
+++ b/tests/Presenters/Admin/ManageEmailTemplatesPresenterTest.php
@@ -84,6 +84,97 @@ class ManageEmailTemplatesPresenterTest extends TestBase
         $this->assertEquals(Paths::EmailTemplates('cz'), $this->fileSystem->_AddedFilePath);
         $this->assertEquals('template-custom.tpl', $this->fileSystem->_AddedFileName);
     }
+
+    public function testRejectsUpdateWithPathTraversalTemplateName()
+    {
+        // PoC vector: the file name traverses out of the lang directory.
+        $this->page->_UpdatedTemplateName = '../../Web/lb_shell.php';
+        $this->page->_TemplateContents = 'contents';
+        $this->page->_UpdatedLanguage = 'en_us';
+
+        $this->presenter->UpdateEmailTemplate();
+
+        $this->assertNull($this->fileSystem->_AddedFileName, 'no file should be written');
+        $this->assertNull($this->fileSystem->_AddedFileContents);
+        $this->assertFalse($this->page->_SaveResult);
+    }
+
+    public function testRejectsUpdateWithTraversalEndingInTpl()
+    {
+        // Ends in .tpl, so this is blocked specifically by the traversal checks.
+        $this->page->_UpdatedTemplateName = '../../Web/shell.tpl';
+        $this->page->_TemplateContents = 'contents';
+        $this->page->_UpdatedLanguage = 'en_us';
+
+        $this->presenter->UpdateEmailTemplate();
+
+        $this->assertNull($this->fileSystem->_AddedFileName, 'no file should be written');
+        $this->assertFalse($this->page->_SaveResult);
+    }
+
+    public function testRejectsUpdateWithControlCharactersInTemplateName()
+    {
+        // Ends in .tpl with no traversal, but the embedded newline must be rejected
+        // (log forging / control-character filename).
+        $this->page->_UpdatedTemplateName = "welcome\ninjected.tpl";
+        $this->page->_TemplateContents = 'contents';
+        $this->page->_UpdatedLanguage = 'en_us';
+
+        $this->presenter->UpdateEmailTemplate();
+
+        $this->assertNull($this->fileSystem->_AddedFileName, 'no file should be written');
+        $this->assertFalse($this->page->_SaveResult);
+    }
+
+    public function testRejectsUpdateWithUppercaseTplExtension()
+    {
+        // Uppercase extension would not be rewritten to -custom.tpl by the
+        // case-sensitive save path, so it must be rejected outright.
+        $this->page->_UpdatedTemplateName = 'WELCOME.TPL';
+        $this->page->_TemplateContents = 'contents';
+        $this->page->_UpdatedLanguage = 'en_us';
+
+        $this->presenter->UpdateEmailTemplate();
+
+        $this->assertNull($this->fileSystem->_AddedFileName, 'no file should be written');
+        $this->assertFalse($this->page->_SaveResult);
+    }
+
+    public function testRejectsUpdateWithoutTplExtension()
+    {
+        $this->page->_UpdatedTemplateName = 'shell.php';
+        $this->page->_TemplateContents = '<?php ?>';
+        $this->page->_UpdatedLanguage = 'en_us';
+
+        $this->presenter->UpdateEmailTemplate();
+
+        $this->assertNull($this->fileSystem->_AddedFileName, 'no file should be written');
+        $this->assertFalse($this->page->_SaveResult);
+    }
+
+    public function testRejectsUpdateWithSlashInTemplateName()
+    {
+        $this->page->_UpdatedTemplateName = 'subdir/template.tpl';
+        $this->page->_TemplateContents = 'contents';
+        $this->page->_UpdatedLanguage = 'en_us';
+
+        $this->presenter->UpdateEmailTemplate();
+
+        $this->assertNull($this->fileSystem->_AddedFileName, 'no file should be written');
+        $this->assertFalse($this->page->_SaveResult);
+    }
+
+    public function testRejectsUpdateWithBackslashInTemplateName()
+    {
+        $this->page->_UpdatedTemplateName = '..\\..\\Web\\shell.php.tpl';
+        $this->page->_TemplateContents = 'contents';
+        $this->page->_UpdatedLanguage = 'en_us';
+
+        $this->presenter->UpdateEmailTemplate();
+
+        $this->assertNull($this->fileSystem->_AddedFileName, 'no file should be written');
+        $this->assertFalse($this->page->_SaveResult);
+    }
 }
 
 class FakeManageEmailTemplatesPage extends ManageEmailTemplatesPage


### PR DESCRIPTION
The email template editor's save action passed the submitted template name straight into the destination file path, while the load actions already rejected names that do not end in .tpl or that contain "..", "/", or "\". An administrator could therefore write an arbitrary file outside the template directory — e.g. a PHP file under /Web — and achieve remote code execution.

Extract the load-path validation into a shared IsValidTemplateName helper and apply it to the save path as well, rejecting invalid names before writing. The template directory was already constrained to a known language via AvailableLanguages, so the file name was the only unvalidated component.

Requires application administrator access; hardened as defense in depth per the SECURITY.md administrator trust model. Add regression tests covering the reported traversal payload and other invalid names.

Reported-by: Noah Magill <noahamagill@gmail.com>
Assisted-by: Claude:claude-opus-4-8