### PR TITLE
fix: allow custom plugin class names in plugin configuration

### DIFF
--- a/Presenters/Admin/ManageConfigurationPresenter.php
+++ b/Presenters/Admin/ManageConfigurationPresenter.php
@@ -156,15 +156,16 @@ class ManageConfigurationPresenter extends ActionPresenter
         $displayKey = $section ? str_replace("$section.", '', $key) : $key;
 
         $setting = new ConfigSetting(
-            $displayKey,
-            $section ?: null,
-            $value,
-            $meta['type'] ?? 'string',
-            $meta['choices'] ?? '',
-            $meta['label'] ?? '',
-            $meta['description'] ?? '',
-            $isPrivate,
-            $hasEnv
+            Key: $displayKey,
+            Section: $section ?: null,
+            Value: (string)$value,
+            Type: $meta['type'] ?? 'string',
+            Choices: $meta['choices'] ?? '',
+            Label: $meta['label'] ?? '',
+            Description: $meta['description'] ?? '',
+            IsPrivate: $isPrivate,
+            hasEnv: $hasEnv,
+            AllowCustom: $meta['allow_custom'] ?? false
         );
 
         if ($section) {
@@ -413,34 +414,24 @@ class ConfigFileOption
 
 class ConfigSetting
 {
-    public $Key;
-    public $Section;
-    public $Value;
-    public $Type;
-    public $Choices;
-    public $Name;
-    public $Label;
-    public $Description;
-    public $IsPrivate;
-    public $hasEnv;
+    public string $Name;
 
-
-    public function __construct($key, $section, $value, $type = 'string', $choices = '', $label = '', $description = '', $isPrivate = false, $hasEnv = false)
-    {
-        $key = trim($key ?? '');
-        $section = trim($section ?? '');
-        $value = trim($value ?? '');
-
-        $this->Name = $this->encode($key) . '|' . $this->encode($section);
-        $this->Key = $key;
-        $this->Section = $section;
-        $this->Value = $value . '';
-        $this->Type = $type;
-        $this->Choices = $choices;
-        $this->Label = $label;
-        $this->Description = $description;
-        $this->IsPrivate = $isPrivate;
-        $this->hasEnv = $hasEnv;
+    public function __construct(
+        public string $Key,
+        public ?string $Section,
+        public string $Value,
+        public string $Type = 'string',
+        public array|string $Choices = '',
+        public string $Label = '',
+        public string $Description = '',
+        public bool $IsPrivate = false,
+        public bool $hasEnv = false,
+        public bool $AllowCustom = false,
+    ) {
+        $this->Key = trim($Key);
+        $this->Section = trim($Section ?? '');
+        $this->Value = trim($Value);
+        $this->Name = $this->encode($this->Key) . '|' . $this->encode($this->Section);
     }
 
     public static function ParseForm($key, $value)

--- a/docs/source/CUSTOM-PLUGINS.rst
+++ b/docs/source/CUSTOM-PLUGINS.rst
@@ -126,23 +126,9 @@ name.
 
 Only enable plugins that exist in the matching plugin type directory.
 
-.. warning::
-
-   Some plugin configuration keys currently have fixed choices for built-in
-   plugins. This may prevent custom plugin class names from being accepted by
-   configuration validation or the web admin configuration page. This is tracked
-   in `issue 1461 <https://github.com/LibreBooking/librebooking/issues/1461>`__
-   and should be fixed in a future change.
-
-   Until this is fixed, add the custom plugin class name to the matching
-   ``choices`` array in ``lib/Config/ConfigKeys.php`` before enabling it. For
-   example, a custom pre-reservation plugin named ``MyRule`` needs a
-   ``'MyRule' => 'MyRule'`` entry in ``ConfigKeys::PLUGIN_PRERESERVATION``.
-   This is a local workaround and may need to be repeated after upgrading
-   LibreBooking.
-
 You can also enable plugins through the web admin interface at **Application
-Configuration** (``/Web/admin/manage_configuration.php``).
+Configuration** (``/Web/admin/manage_configuration.php``). The plugin fields
+accept any plugin class name; built-in plugin names appear as suggestions.
 
 Manual Installation
 -------------------

--- a/lib/Common/PluginManager.php
+++ b/lib/Common/PluginManager.php
@@ -220,6 +220,13 @@ class PluginManager
         $configKey = $configDef['key'];
         if (!$this->Cached($configKey)) {
             $plugin = Configuration::Instance()->GetKey($configDef);
+
+            if (!empty($plugin) && !preg_match('/^[A-Za-z_][A-Za-z0-9_]*$/', $plugin)) {
+                Log::Error('Plugin name is not a valid class name. Type=%s, Plugin=%s', $configKey, $plugin);
+                $this->Cache($configKey, null);
+                return $this->GetCached($configKey);
+            }
+
             $pluginFile = ROOT_DIR . "plugins/$pluginSubDirectory/$plugin/$plugin.php";
 
             if (!empty($plugin) && file_exists($pluginFile)) {

--- a/lib/Config/AbstractConfigKeys.php
+++ b/lib/Config/AbstractConfigKeys.php
@@ -46,6 +46,14 @@ abstract class AbstractConfigKeys
         $configsWithIds = [];
         foreach ($constants as $name => $value) {
             if (is_array($value) && isset($value['key'])) {
+                if (array_key_exists('allow_custom', $value) && !is_bool($value['allow_custom'])) {
+                    throw new \InvalidArgumentException(sprintf(
+                        'Config key "%s" in %s has an invalid "allow_custom" value: must be true or false (boolean), got %s',
+                        $value['key'],
+                        static::class,
+                        gettype($value['allow_custom'])
+                    ));
+                }
                 // Preserve the constant name so collision detection can distinguish
                 // between different schema entries that may share the same key text,
                 // e.g. SERVER1_KEY and SERVER1_KEY_DUPLICATE_SECTION_CASE both using

--- a/lib/Config/ConfigKeys.php
+++ b/lib/Config/ConfigKeys.php
@@ -1677,6 +1677,7 @@ class ConfigKeys extends AbstractConfigKeys
         'key' => 'plugins.authentication',
         'type' => 'string',
         'default' => '',
+        'allow_custom' => true,
         'choices' => [
             '' => 'None',
             'ActiveDirectory' => 'ActiveDirectory',
@@ -1701,6 +1702,7 @@ class ConfigKeys extends AbstractConfigKeys
         'key' => 'plugins.authorization',
         'type' => 'string',
         'default' => '',
+        'allow_custom' => true,
         'choices' => [
             '' => 'None',
         ],
@@ -1713,6 +1715,7 @@ class ConfigKeys extends AbstractConfigKeys
         'key' => 'plugins.export',
         'type' => 'string',
         'default' => '',
+        'allow_custom' => true,
         'choices' => [
             '' => 'None',
         ],
@@ -1725,6 +1728,7 @@ class ConfigKeys extends AbstractConfigKeys
         'key' => 'plugins.permission',
         'type' => 'string',
         'default' => '',
+        'allow_custom' => true,
         'choices' => [
             '' => 'None',
         ],
@@ -1737,6 +1741,7 @@ class ConfigKeys extends AbstractConfigKeys
         'key' => 'plugins.postregistration',
         'type' => 'string',
         'default' => '',
+        'allow_custom' => true,
         'choices' => [
             '' => 'None',
         ],
@@ -1749,6 +1754,7 @@ class ConfigKeys extends AbstractConfigKeys
         'key' => 'plugins.prereservation',
         'type' => 'string',
         'default' => '',
+        'allow_custom' => true,
         'choices' => [
             '' => 'None',
             'AdminCheckOnly' => 'AdminCheckOnly',
@@ -1763,6 +1769,7 @@ class ConfigKeys extends AbstractConfigKeys
         'key' => 'plugins.postreservation',
         'type' => 'string',
         'default' => '',
+        'allow_custom' => true,
         'choices' => [
             '' => 'None',
             'PostReservationExample' => 'PostReservationExample',
@@ -1776,6 +1783,7 @@ class ConfigKeys extends AbstractConfigKeys
         'key' => 'plugins.styling',
         'type' => 'string',
         'default' => '',
+        'allow_custom' => true,
         'choices' => [
             '' => 'None',
         ],

--- a/lib/Config/Configuration.php
+++ b/lib/Config/Configuration.php
@@ -490,7 +490,9 @@ class ConfigurationFile implements IConfigurationFile
                 continue;
             }
 
-            if (isset($configDef['choices']) && !array_key_exists($value, $configDef['choices'])) {
+            if (isset($configDef['choices'])
+                && !($configDef['allow_custom'] ?? false)
+                && !array_key_exists($value, $configDef['choices'])) {
                 error_log("[CONFIG] Invalid value '$value' for '{$fullKey}'. Should be one of the following options: [" . implode(', ', array_map(fn ($key, $value) => "{$key} => {$value}", array_keys($configDef['choices']), $configDef['choices'])) . ']');
                 $validated[$key] = $configDef['default'];
                 continue;

--- a/tests/Infrastructure/Config/ConfigTest.php
+++ b/tests/Infrastructure/Config/ConfigTest.php
@@ -339,6 +339,24 @@ PHP
         TestPluginConfigKeysCollisionLegacyVsLegacy::findByKey('server1.key1');
     }
 
+    public function testConfigKeyRejectsNonBooleanAllowCustom()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('"allow_custom" value: must be true or false (boolean)');
+
+        $invalidClass = new class () extends \PluginConfigKeys {
+            public const CONFIG_ID = 'invalid-allow-custom-test';
+            public const KEY1 = [
+                'key' => 'key1',
+                'type' => 'string',
+                'default' => '',
+                'allow_custom' => 'yes',
+            ];
+        };
+
+        $invalidClass::all();
+    }
+
     public function testPluginConfigValidation()
     {
         $errorLogs = $this->captureErrorLog(function () {

--- a/tests/Presenters/Admin/ManageConfigurationPresenterTest.php
+++ b/tests/Presenters/Admin/ManageConfigurationPresenterTest.php
@@ -154,7 +154,7 @@ class ManageConfigurationPresenterTest extends TestBase
             $expectedValue = $configValues[$key];
         }
 
-        $expectedConfig = new ConfigSetting($key, $configKey['section'], $expectedValue, $type, $configKey['choices'] ?? '', $configKey['label'], $configKey['description'], $configKey['is_private']);
+        $expectedConfig = new ConfigSetting($key, $section, (string)$expectedValue, $type, $configKey['choices'] ?? '', $configKey['label'] ?? '', $configKey['description'] ?? '', $configKey['is_private'] ?? false);
 
         if ($section) {
             $this->assertTrue(

--- a/tpl/Admin/Configuration/manage_configuration.tpl
+++ b/tpl/Admin/Configuration/manage_configuration.tpl
@@ -55,8 +55,20 @@
                         {elseif $setting->IsPrivate}
                             <input id="{$name}" type="password" size="50" name="{$name}" {$disabled}
                                 value="{$setting->Value|escape}" class="form-control form-control-sm" />
+                        {elseif $setting->AllowCustom && is_array($setting->Choices)}
+                            <input type="text" id="{$name}" name="{$name}" {$disabled}
+                                   class="form-control form-control-sm"
+                                   value="{$setting->Value|escape}"
+                                   list="{$name}-list" />
+                            <datalist id="{$name}-list">
+                                {foreach $setting->Choices as $choiceKey => $choiceLabel}
+                                    {if $choiceKey !== ''}
+                                        <option value="{$choiceKey|escape}" label="{$choiceLabel|escape}"></option>
+                                    {/if}
+                                {/foreach}
+                            </datalist>
                         {elseif is_array($setting->Choices)}
-                            <select id="{$name}" name="{$name}" class="form-select form-select-sm">
+                            <select id="{$name}" name="{$name}" {$disabled} class="form-select form-select-sm">
                                 {html_options options=$setting->Choices  selected=$setting->Value}
                             </select>
                         {elseif $setting->Type == ConfigSettingType::String}


### PR DESCRIPTION
Plugin configuration keys enforced a fixed choices list, silently resetting any value not in the list to the default empty string. This prevented custom plugin class names from loading without modifying core files.

Add an allow_custom flag to config key definitions. When set to true, ValidateConfig skips choices enforcement for that key while preserving the choices list as UI suggestions. All eight plugin config keys set allow_custom = true.

Update the admin UI to render a datalist-backed text input instead of a select dropdown for allow_custom keys, so built-in plugin names appear as autocomplete suggestions while any custom name is accepted.

Add validation in AbstractConfigKeys that throws InvalidArgumentException if allow_custom is present but not a boolean, enforced at class load time and covered by a dedicated test.

Remove the #1461 workaround warning from CUSTOM-PLUGINS.rst and update the enabling-a-plugin note to reflect that custom names are now accepted.

Also refactor ConfigSetting to use constructor property promotion and named arguments at the call site.

Closes: #1461
Assisted-by: Claude:claude-sonnet-4-6