### PR TITLE
feat(config): add ConfigKey readonly class for typed config definitions

### DIFF
--- a/lib/Config/ConfigKey.php
+++ b/lib/Config/ConfigKey.php
@@ -1,0 +1,57 @@
+<?php
+
+/**
+ * Typed definition of a single application configuration entry.
+ *
+ * ConfigKey instances are declared as class constants on ConfigKeys and
+ * plugin *ConfigKeys classes. Once the migration from associative arrays
+ * is complete they will be passed directly to Configuration::GetKey() to
+ * retrieve the live value from config.php or the matching environment variable.
+ */
+readonly class ConfigKey
+{
+    private const VALID_TYPES = ['string', 'boolean', 'integer'];
+
+    public function __construct(
+        /** Dot-separated config file key, e.g. 'app.title' or 'database.name'. */
+        public string $key,
+        /** Value type: 'string', 'boolean', or 'integer'. Controls validation and conversion. */
+        public string $type,
+        /** Value used when the key is absent from config.php and no env var is set. */
+        public mixed $default,
+        /** Config file section, e.g. 'database'. When set, the value is read from $conf['settings'][$section] using the key with the section prefix removed (e.g. section='database', key='database.name' reads $conf['settings']['database']['name']). */
+        public ?string $section = null,
+        /** Short human-readable label shown in the admin configuration UI. */
+        public ?string $label = null,
+        /** Longer explanatory text shown as a tooltip in the admin configuration UI. */
+        public ?string $description = null,
+        /**
+         * Allowed values for select/datalist inputs, keyed by stored value with display label as value.
+         * When allowCustom is false, ValidateConfig() enforces this list strictly.
+         *
+         * @var array<int|string, string>|null
+         */
+        public ?array $choices = null,
+        /** Comment written above the key in generated config.dist.php. Falls back to description if null. */
+        public ?string $configFileComment = null,
+        /** Former key name. When set, old configs using this name are transparently migrated on load. */
+        public ?string $legacy = null,
+        /** When true, the admin UI treats the value as sensitive and preserves the existing value when the submitted value is empty. */
+        public bool $isPrivate = false,
+        /** When true, the key is not shown in the admin configuration UI at all. */
+        public bool $isHidden = false,
+        /** When true, choices acts as suggestions only; any valid PHP class name is accepted. Used for plugin selectors. */
+        public bool $allowCustom = false,
+        /** When true (plugin use only), the value is not overwritten when the admin UI saves other fields. */
+        public bool $isProtected = false,
+    ) {
+        if (trim($this->key) === '') {
+            throw new \InvalidArgumentException('Config key cannot be empty or whitespace');
+        }
+        if (!in_array($this->type, self::VALID_TYPES, strict: true)) {
+            throw new \InvalidArgumentException(
+                "Invalid config type '{$this->type}' for key '{$this->key}'"
+            );
+        }
+    }
+}

--- a/lib/Config/namespace.php
+++ b/lib/Config/namespace.php
@@ -1,5 +1,6 @@
 <?php
 
+require_once(ROOT_DIR . 'lib/Config/ConfigKey.php');
 require_once(ROOT_DIR . 'lib/Config/AbstractConfigKeys.php');
 require_once(ROOT_DIR . 'lib/Config/ConfigKeysMeta.php');
 require_once(ROOT_DIR . 'lib/Config/ConfigKeys.php');

--- a/tests/Infrastructure/Config/ConfigKeyTest.php
+++ b/tests/Infrastructure/Config/ConfigKeyTest.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+require_once(ROOT_DIR . 'lib/Config/ConfigKey.php');
+
+class ConfigKeyTest extends TestBase
+{
+    public function testValidConstruction(): void
+    {
+        $key = new ConfigKey(
+            key: 'app.title',
+            type: 'string',
+            default: 'LibreBooking',
+        );
+
+        $this->assertEquals('app.title', $key->key);
+        $this->assertEquals('string', $key->type);
+        $this->assertEquals('LibreBooking', $key->default);
+    }
+
+    public function testOptionalFieldsDefaultCorrectly(): void
+    {
+        $key = new ConfigKey(key: 'some.key', type: 'string', default: '');
+
+        $this->assertNull($key->section);
+        $this->assertNull($key->label);
+        $this->assertNull($key->description);
+        $this->assertNull($key->choices);
+        $this->assertNull($key->configFileComment);
+        $this->assertNull($key->legacy);
+        $this->assertFalse($key->isPrivate);
+        $this->assertFalse($key->isHidden);
+        $this->assertFalse($key->allowCustom);
+        $this->assertFalse($key->isProtected);
+    }
+
+    #[\PHPUnit\Framework\Attributes\DataProvider('validTypeProvider')]
+    public function testAllValidTypesAreAccepted(string $type): void
+    {
+        $key = new ConfigKey(key: 'some.key', type: $type, default: '');
+
+        $this->assertEquals($type, $key->type);
+    }
+
+    public static function validTypeProvider(): array
+    {
+        return [
+            ['string'],
+            ['boolean'],
+            ['integer'],
+        ];
+    }
+
+    public function testEmptyKeyThrows(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Config key cannot be empty or whitespace');
+
+        new ConfigKey(key: '', type: 'string', default: '');
+    }
+
+    public function testWhitespaceOnlyKeyThrows(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Config key cannot be empty or whitespace');
+
+        new ConfigKey(key: '   ', type: 'string', default: '');
+    }
+
+    public function testInvalidTypeThrows(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage("Invalid config type 'bool' for key 'some.key'");
+
+        new ConfigKey(key: 'some.key', type: 'bool', default: '');
+    }
+
+    public function testInvalidTypeIntThrows(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage("Invalid config type 'int' for key 'some.key'");
+
+        new ConfigKey(key: 'some.key', type: 'int', default: 0);
+    }
+}


### PR DESCRIPTION
Introduce ConfigKey as a typed readonly value object to replace the plain associative arrays currently used for config key definitions. The class validates at construction time that key is non-empty and type is one of the three accepted values ('string', 'boolean', 'integer'), catching typos that previously went silently wrong.

This commit adds the class and its tests only. No existing definitions are converted yet — that follows in subsequent commits.

Assisted-by: Claude:claude-sonnet-4-6