### PR TITLE
refactor(config): add ConfigKey::fromArray() factory

### DIFF
--- a/lib/Config/ConfigKey.php
+++ b/lib/Config/ConfigKey.php
@@ -3,14 +3,51 @@
 /**
  * Typed definition of a single application configuration entry.
  *
- * ConfigKey instances are declared as class constants on ConfigKeys and
- * plugin *ConfigKeys classes. Once the migration from associative arrays
- * is complete they will be passed directly to Configuration::GetKey() to
- * retrieve the live value from config.php or the matching environment variable.
+ * Config keys are defined as associative-array class constants on ConfigKeys and
+ * the plugin *ConfigKeys classes. Those arrays are converted to ConfigKey
+ * instances at runtime via ConfigKey::fromArray() at the read boundary
+ * (AbstractConfigKeys::all()/findByKey() and Configuration::GetKey()) rather than
+ * being declared as `new ConfigKey(...)` constants directly, because `new` in a
+ * class constant is only supported from PHP 8.5 and the project floor is PHP 8.2.
+ * Consumers receive a typed ConfigKey; the constructor and fromArray() validate the
+ * definition.
  */
 readonly class ConfigKey
 {
     private const VALID_TYPES = ['string', 'boolean', 'integer'];
+
+    /** Array keys that every config definition must provide. */
+    private const REQUIRED_KEYS = ['key', 'type', 'default'];
+
+    /** Array keys a config definition may provide but is not required to. */
+    private const OPTIONAL_KEYS = [
+        'section',
+        'label',
+        'description',
+        'choices',
+        'config_file_comment',
+        'legacy',
+        'is_private',
+        'is_hidden',
+        'allow_custom',
+        'is_protected',
+    ];
+
+    /**
+     * Top-level field names allowed in an array config definition (required plus
+     * optional). Anything outside this set passed to fromArray() is a typo and is
+     * rejected.
+     */
+    private const KNOWN_KEYS = [...self::REQUIRED_KEYS, ...self::OPTIONAL_KEYS];
+
+    /** Array keys whose values must be booleans when present. */
+    private const BOOLEAN_KEYS = ['is_private', 'is_hidden', 'allow_custom', 'is_protected'];
+
+    /** Array keys whose values must be strings when present. */
+    private const STRING_KEYS = ['key', 'type'];
+
+    /** Array keys whose values must be a string or null when present. */
+    private const NULLABLE_STRING_KEYS = ['section', 'label', 'description', 'config_file_comment', 'legacy'];
 
     public function __construct(
         /** Dot-separated config file key, e.g. 'app.title' or 'database.name'. */
@@ -53,5 +90,115 @@ readonly class ConfigKey
                 "Invalid config type '{$this->type}' for key '{$this->key}'"
             );
         }
+    }
+
+    /**
+     * Build a ConfigKey from a legacy associative-array definition.
+     *
+     * Maps the snake_case array keys to the camelCase constructor parameters and
+     * validates the definition at this single conversion point: unknown keys and
+     * non-boolean flag values are rejected, so definition typos surface the first
+     * time the config registry is built (the constructor additionally validates
+     * key/type).
+     *
+     * @param array<string, mixed> $def
+     */
+    public static function fromArray(array $def): self
+    {
+        // Build a descriptor used only for error messages. The section is included
+        // when present because plugin definitions can share the same bare 'key' in
+        // different sections (e.g. SERVER1_KEY and SERVER2_KEY both 'key' => 'key'),
+        // so the key alone would not identify which definition is invalid.
+        $configKey = is_string($def['key'] ?? null) ? $def['key'] : '';
+        $section = (isset($def['section']) && is_string($def['section']) && $def['section'] !== '')
+            ? $def['section']
+            : null;
+        $keyDescriptor = $section !== null
+            ? sprintf('"%s" (section "%s")', $configKey, $section)
+            : sprintf('"%s"', $configKey);
+
+        $unknownKeys = array_diff(array_keys($def), self::KNOWN_KEYS);
+        if ($unknownKeys !== []) {
+            throw new \InvalidArgumentException(sprintf(
+                'Unknown config definition key(s) [%s] for config key %s',
+                implode(', ', $unknownKeys),
+                $keyDescriptor
+            ));
+        }
+
+        // Every definition must provide the required keys. 'default' in particular
+        // is indexed without guarding by consumers such as
+        // ConfigurationFile::ValidateConfig() and ConfigDistGenerator, so an omitted
+        // value (an explicit null is allowed) must not pass this gate.
+        foreach (self::REQUIRED_KEYS as $requiredKey) {
+            if (!array_key_exists($requiredKey, $def)) {
+                throw new \InvalidArgumentException(sprintf(
+                    'Config key %s is missing a required "%s" value',
+                    $keyDescriptor,
+                    $requiredKey
+                ));
+            }
+        }
+
+        foreach (self::BOOLEAN_KEYS as $booleanKey) {
+            if (array_key_exists($booleanKey, $def) && !is_bool($def[$booleanKey])) {
+                throw new \InvalidArgumentException(sprintf(
+                    'Config key %s has an invalid "%s" value: must be true or false (boolean), got %s',
+                    $keyDescriptor,
+                    $booleanKey,
+                    gettype($def[$booleanKey])
+                ));
+            }
+        }
+
+        // Validate scalar field types explicitly: ConfigKey.php is not strict_types,
+        // so without these checks PHP would silently coerce e.g. 'key' => 123 to "123".
+        foreach (self::STRING_KEYS as $stringKey) {
+            if (array_key_exists($stringKey, $def) && !is_string($def[$stringKey])) {
+                throw new \InvalidArgumentException(sprintf(
+                    'Config key %s has an invalid "%s" value: must be a string, got %s',
+                    $keyDescriptor,
+                    $stringKey,
+                    gettype($def[$stringKey])
+                ));
+            }
+        }
+
+        foreach (self::NULLABLE_STRING_KEYS as $nullableStringKey) {
+            if (array_key_exists($nullableStringKey, $def)
+                && $def[$nullableStringKey] !== null
+                && !is_string($def[$nullableStringKey])) {
+                throw new \InvalidArgumentException(sprintf(
+                    'Config key %s has an invalid "%s" value: must be a string or null, got %s',
+                    $keyDescriptor,
+                    $nullableStringKey,
+                    gettype($def[$nullableStringKey])
+                ));
+            }
+        }
+
+        if (array_key_exists('choices', $def) && $def['choices'] !== null && !is_array($def['choices'])) {
+            throw new \InvalidArgumentException(sprintf(
+                'Config key %s has an invalid "choices" value: must be an array or null, got %s',
+                $keyDescriptor,
+                gettype($def['choices'])
+            ));
+        }
+
+        return new self(
+            key: $def['key'],
+            type: $def['type'],
+            default: $def['default'],
+            section: $def['section'] ?? null,
+            label: $def['label'] ?? null,
+            description: $def['description'] ?? null,
+            choices: $def['choices'] ?? null,
+            configFileComment: $def['config_file_comment'] ?? null,
+            legacy: $def['legacy'] ?? null,
+            isPrivate: $def['is_private'] ?? false,
+            isHidden: $def['is_hidden'] ?? false,
+            allowCustom: $def['allow_custom'] ?? false,
+            isProtected: $def['is_protected'] ?? false,
+        );
     }
 }

--- a/tests/Infrastructure/Config/ConfigKeyDefinitionsTest.php
+++ b/tests/Infrastructure/Config/ConfigKeyDefinitionsTest.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+require_once(ROOT_DIR . 'lib/Config/namespace.php');
+
+/**
+ * Guards that every real config definition — core and plugin — is a valid
+ * ConfigKey definition by running ConfigKey::fromArray() over all of them.
+ *
+ * This catches a malformed constant (unknown field, non-boolean flag, invalid
+ * type) in CI at its source, rather than letting it surface later when the read
+ * boundary (AbstractConfigKeys::all()/findByKey(), Configuration::GetKey())
+ * builds the registry.
+ *
+ * Reflects the raw array constants rather than calling all() so it remains valid
+ * regardless of what all() returns as the migration progresses.
+ */
+class ConfigKeyDefinitionsTest extends TestBase
+{
+    public function testAllCoreConfigKeysConvertToConfigKey(): void
+    {
+        $converted = $this->assertAllConstantsConvert(ConfigKeys::class);
+
+        $this->assertGreaterThan(0, $converted, 'Expected ConfigKeys to define config entries');
+    }
+
+    public function testAllPluginConfigKeysConvertToConfigKey(): void
+    {
+        $files = glob(ROOT_DIR . 'plugins/*/*/*ConfigKeys.php');
+        $this->assertNotEmpty($files, 'Expected to discover plugin *ConfigKeys.php files');
+
+        $classesChecked = 0;
+        foreach ($files as $file) {
+            require_once($file);
+            $class = basename($file, '.php');
+            $this->assertTrue(class_exists($class), "Plugin ConfigKeys class {$class} not found after loading {$file}");
+
+            $this->assertAllConstantsConvert($class);
+            $classesChecked++;
+        }
+
+        $this->assertGreaterThan(0, $classesChecked, 'Expected to check at least one plugin ConfigKeys class');
+    }
+
+    /**
+     * Convert every array-shaped config constant on the class via fromArray(),
+     * failing if any definition is invalid. Returns the number converted.
+     *
+     * @param class-string $configKeysClass
+     */
+    private function assertAllConstantsConvert(string $configKeysClass): int
+    {
+        $constants = (new \ReflectionClass($configKeysClass))->getConstants();
+
+        $converted = 0;
+        foreach ($constants as $name => $value) {
+            // array_key_exists (not isset) so a malformed 'key' => null definition is
+            // still handed to fromArray() and rejected, rather than silently skipped.
+            if (!is_array($value) || !array_key_exists('key', $value)) {
+                continue;
+            }
+
+            try {
+                $configKey = ConfigKey::fromArray($value);
+            } catch (\InvalidArgumentException $e) {
+                $this->fail(sprintf(
+                    'Config definition %s::%s did not convert to a ConfigKey: %s',
+                    $configKeysClass,
+                    $name,
+                    $e->getMessage()
+                ));
+            }
+
+            $this->assertSame(
+                $value['key'],
+                $configKey->key,
+                "ConfigKey built from {$configKeysClass}::{$name} should preserve the 'key'"
+            );
+            $converted++;
+        }
+
+        return $converted;
+    }
+}

--- a/tests/Infrastructure/Config/ConfigKeyTest.php
+++ b/tests/Infrastructure/Config/ConfigKeyTest.php
@@ -83,4 +83,207 @@ class ConfigKeyTest extends TestBase
 
         new ConfigKey(key: 'some.key', type: 'int', default: 0);
     }
+
+    public function testFromArrayMapsSnakeCaseKeysToCamelCaseProperties(): void
+    {
+        $key = ConfigKey::fromArray([
+            'key' => 'app.title',
+            'type' => 'string',
+            'default' => 'LibreBooking',
+            'section' => 'app',
+            'label' => 'App title',
+            'description' => 'The title of the application',
+            'choices' => ['a' => 'A', 'b' => 'B'],
+            'config_file_comment' => 'The public name of the application',
+            'legacy' => 'old.app.title',
+            'is_private' => true,
+            'is_hidden' => true,
+            'allow_custom' => true,
+            'is_protected' => true,
+        ]);
+
+        $this->assertEquals('app.title', $key->key);
+        $this->assertEquals('string', $key->type);
+        $this->assertEquals('LibreBooking', $key->default);
+        $this->assertEquals('app', $key->section);
+        $this->assertEquals('App title', $key->label);
+        $this->assertEquals('The title of the application', $key->description);
+        $this->assertEquals(['a' => 'A', 'b' => 'B'], $key->choices);
+        $this->assertEquals('The public name of the application', $key->configFileComment);
+        $this->assertEquals('old.app.title', $key->legacy);
+        $this->assertTrue($key->isPrivate);
+        $this->assertTrue($key->isHidden);
+        $this->assertTrue($key->allowCustom);
+        $this->assertTrue($key->isProtected);
+    }
+
+    public function testFromArrayAppliesDefaultsForOmittedOptionalFields(): void
+    {
+        $key = ConfigKey::fromArray([
+            'key' => 'some.key',
+            'type' => 'string',
+            'default' => '',
+        ]);
+
+        $this->assertNull($key->section);
+        $this->assertNull($key->label);
+        $this->assertNull($key->description);
+        $this->assertNull($key->choices);
+        $this->assertNull($key->configFileComment);
+        $this->assertNull($key->legacy);
+        $this->assertFalse($key->isPrivate);
+        $this->assertFalse($key->isHidden);
+        $this->assertFalse($key->allowCustom);
+        $this->assertFalse($key->isProtected);
+    }
+
+    public function testFromArrayRejectsMissingDefault(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Config key "some.key" is missing a required "default" value');
+
+        ConfigKey::fromArray([
+            'key' => 'some.key',
+            'type' => 'string',
+        ]);
+    }
+
+    public function testFromArrayRejectsMissingKey(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Config key "" is missing a required "key" value');
+
+        ConfigKey::fromArray([
+            'type' => 'string',
+            'default' => '',
+        ]);
+    }
+
+    public function testFromArrayRejectsMissingType(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Config key "some.key" is missing a required "type" value');
+
+        ConfigKey::fromArray([
+            'key' => 'some.key',
+            'default' => '',
+        ]);
+    }
+
+    public function testFromArrayAllowsExplicitNullDefault(): void
+    {
+        $key = ConfigKey::fromArray([
+            'key' => 'some.key',
+            'type' => 'string',
+            'default' => null,
+        ]);
+
+        $this->assertNull($key->default);
+    }
+
+    public function testFromArrayRejectsUnknownKey(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Unknown config definition key(s) [allow_cusotm] for config key "some.key"');
+
+        ConfigKey::fromArray([
+            'key' => 'some.key',
+            'type' => 'string',
+            'default' => '',
+            'allow_cusotm' => true,
+        ]);
+    }
+
+    public function testFromArrayRejectsNonBooleanAllowCustom(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Config key "some.key" has an invalid "allow_custom" value: must be true or false (boolean), got string');
+
+        ConfigKey::fromArray([
+            'key' => 'some.key',
+            'type' => 'string',
+            'default' => '',
+            'allow_custom' => 'yes',
+        ]);
+    }
+
+    public function testFromArrayRejectsInvalidType(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage("Invalid config type 'bool' for key 'some.key'");
+
+        ConfigKey::fromArray([
+            'key' => 'some.key',
+            'type' => 'bool',
+            'default' => '',
+        ]);
+    }
+
+    public function testFromArrayRejectsNonStringKey(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('has an invalid "key" value: must be a string, got integer');
+
+        ConfigKey::fromArray([
+            'key' => 123,
+            'type' => 'string',
+            'default' => '',
+        ]);
+    }
+
+    public function testFromArrayRejectsNonStringNullableMetadata(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Config key "some.key" has an invalid "label" value: must be a string or null, got integer');
+
+        ConfigKey::fromArray([
+            'key' => 'some.key',
+            'type' => 'string',
+            'default' => '',
+            'label' => 123,
+        ]);
+    }
+
+    public function testFromArrayAllowsNullNullableMetadata(): void
+    {
+        $key = ConfigKey::fromArray([
+            'key' => 'some.key',
+            'type' => 'string',
+            'default' => '',
+            'label' => null,
+            'section' => null,
+        ]);
+
+        $this->assertNull($key->label);
+        $this->assertNull($key->section);
+    }
+
+    public function testFromArrayRejectsNonArrayChoices(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Config key "some.key" has an invalid "choices" value: must be an array or null, got string');
+
+        ConfigKey::fromArray([
+            'key' => 'some.key',
+            'type' => 'string',
+            'default' => '',
+            'choices' => 'not-an-array',
+        ]);
+    }
+
+    public function testFromArrayErrorMessageIncludesSectionToDisambiguateSameNamedKeys(): void
+    {
+        // Plugin definitions can share the same bare 'key' across sections, so the
+        // section must appear in the message to identify the offending definition.
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Config key "key" (section "server1") has an invalid "allow_custom" value: must be true or false (boolean), got string');
+
+        ConfigKey::fromArray([
+            'key' => 'key',
+            'type' => 'string',
+            'default' => '',
+            'section' => 'server1',
+            'allow_custom' => 'yes',
+        ]);
+    }
 }


### PR DESCRIPTION
Add a runtime factory that builds a ConfigKey from an associative-array config definition, mapping the snake_case array keys to the camelCase constructor parameters. This is the conversion point the read boundary (AbstractConfigKeys::all()/findByKey(), Configuration::GetKey()) will use to emit typed ConfigKey objects while the constant definitions remain arrays.

fromArray() is a complete validating gate, run at this single point so a malformed definition fails loudly the first time the registry is built:

- rejects unknown array keys (surfacing typos such as 'allow_cusotm')
- rejects non-boolean flag values (is_private, is_hidden, allow_custom, is_protected)
- rejects non-string key/type and non-string nullable metadata (section, label, description, config_file_comment, legacy), and non-array choices

The explicit scalar checks are necessary because ConfigKey.php is not strict_types, so otherwise 'key' => 123 would silently coerce to "123" and allow_custom => 'yes' to true. Error messages include the section when present, since plugin definitions can share the same bare key across sections (e.g. SERVER1_KEY and SERVER2_KEY) and the key alone would not identify the offender.

The class docblock is updated to describe runtime construction.

Add ConfigKeyDefinitionsTest, which reflects every core and plugin ConfigKeys class and runs fromArray() over all defined constants, failing with the exact Class::CONSTANT name. This proves all current definitions convert and guards against future malformed ones in CI.

Assisted-by: Claude:claude-opus-4-8