### PR TITLE
refactor(config): emit typed ConfigKey from the read boundary

### DIFF
--- a/Presenters/Admin/ManageConfigurationPresenter.php
+++ b/Presenters/Admin/ManageConfigurationPresenter.php
@@ -159,13 +159,13 @@ class ManageConfigurationPresenter extends ActionPresenter
             Key: $displayKey,
             Section: $section ?: null,
             Value: (string)$value,
-            Type: $meta['type'] ?? 'string',
-            Choices: $meta['choices'] ?? '',
-            Label: $meta['label'] ?? '',
-            Description: $meta['description'] ?? '',
+            Type: $meta->type,
+            Choices: $meta->choices ?? '',
+            Label: $meta->label ?? '',
+            Description: $meta->description ?? '',
             IsPrivate: $isPrivate,
             hasEnv: $hasEnv,
-            AllowCustom: $meta['allow_custom'] ?? false
+            AllowCustom: $meta->allowCustom
         );
 
         if ($section) {
@@ -242,14 +242,14 @@ class ManageConfigurationPresenter extends ActionPresenter
         ServiceLocator::GetDatabase()->Execute($command);
     }
 
-    private function ShouldBeSkipped(string $key, ?array $meta): bool
+    private function ShouldBeSkipped(string $key, ?ConfigKey $meta): bool
     {
         if ($meta === null) {
             Log::Debug("[CONFIG] No metadata found for key '%s'. Not skipped.", $key);
             return false;
         }
 
-        if ($meta['is_hidden'] ?? false) {
+        if ($meta->isHidden) {
             Log::Debug("[CONFIG] Skipping hidden config key '%s'.", $key);
             return true;
         }

--- a/lib/Config/AbstractConfigKeys.php
+++ b/lib/Config/AbstractConfigKeys.php
@@ -1,17 +1,18 @@
 <?php
 
+require_once(ROOT_DIR . 'lib/Config/ConfigKey.php');
 require_once(ROOT_DIR . 'lib/Config/ConfigKeysMeta.php');
 
 abstract class AbstractConfigKeys
 {
-    /** @var array<class-string, list<ConfigKey|array<string, mixed>>> */
+    /** @var array<class-string, list<ConfigKey>> */
     private static array $allCache = [];
-    /** @var array<class-string, array<string, ConfigKey|array<string, mixed>>> */
+    /** @var array<class-string, array<string, ConfigKey>> */
     private static array $allWithEntryIdsCache = [];
 
     /**
      * Returns all configuration entries defined in the class.
-     * @return list<ConfigKey|array<string, mixed>>
+     * @return list<ConfigKey>
      */
     public static function all(): array
     {
@@ -34,7 +35,7 @@ abstract class AbstractConfigKeys
      * different schema entries that may share the same key text, e.g. SERVER1_KEY
      * and SERVER2_KEY both using 'key' => 'key' in different sections.
      *
-     * @return array<string, ConfigKey|array<string, mixed>>
+     * @return array<string, ConfigKey>
      */
     private static function allWithEntryIds(): array
     {
@@ -49,16 +50,11 @@ abstract class AbstractConfigKeys
         foreach ($constants as $name => $value) {
             if ($value instanceof ConfigKey) {
                 $configsWithIds[$name] = $value;
-            } elseif (is_array($value) && isset($value['key'])) {
-                if (array_key_exists('allow_custom', $value) && !is_bool($value['allow_custom'])) {
-                    throw new \InvalidArgumentException(sprintf(
-                        'Config key "%s" in %s has an invalid "allow_custom" value: must be true or false (boolean), got %s',
-                        $value['key'],
-                        static::class,
-                        gettype($value['allow_custom'])
-                    ));
-                }
-                $configsWithIds[$name] = $value;
+            } elseif (is_array($value) && array_key_exists('key', $value)) {
+                // Build the typed ConfigKey at this single read boundary. fromArray()
+                // validates the definition (unknown keys, missing required fields,
+                // non-boolean flags, mistyped scalars) and fails with the offending key.
+                $configsWithIds[$name] = ConfigKey::fromArray($value);
             }
         }
 
@@ -70,9 +66,8 @@ abstract class AbstractConfigKeys
 
     /**
      * Finds a configuration entry by its key.
-     * @return ConfigKey|array<string, mixed>|null
      */
-    public static function findByKey(string $key): ConfigKey|array|null
+    public static function findByKey(string $key): ?ConfigKey
     {
         $normalizedKey = strtolower($key);
 
@@ -88,9 +83,8 @@ abstract class AbstractConfigKeys
 
     /**
      * Finds a configuration entry by its legacy key.
-     * @return ConfigKey|array<string, mixed>|null
      */
-    public static function findByLegacyKey(string $legacyKey): ConfigKey|array|null
+    public static function findByLegacyKey(string $legacyKey): ?ConfigKey
     {
         if ($legacyKey === '') {
             return null;
@@ -99,7 +93,7 @@ abstract class AbstractConfigKeys
         $normalizedLegacyKey = strtolower($legacyKey);
 
         foreach (static::all() as $config) {
-            $legacy = $config instanceof ConfigKey ? $config->legacy : ($config['legacy'] ?? null);
+            $legacy = $config->legacy;
             if (!is_string($legacy) || $legacy === '') {
                 continue;
             }
@@ -130,11 +124,7 @@ abstract class AbstractConfigKeys
     /** @param ConfigKey|array<string, mixed> $config */
     public static function hasEnv(ConfigKey|array $config): bool
     {
-        if ($config instanceof ConfigKey) {
-            $envKey = ConfigKeysMeta::envKeyForConfig(config: ['key' => $config->key, 'section' => $config->section]);
-        } else {
-            $envKey = ConfigKeysMeta::envKeyForConfig(config: $config);
-        }
+        $envKey = ConfigKeysMeta::envKeyForConfig(config: $config);
         if ($envKey === null) {
             return false;
         }

--- a/lib/Config/ConfigDistGenerator.php
+++ b/lib/Config/ConfigDistGenerator.php
@@ -31,7 +31,7 @@ PHP;
      * Flat keys (no section) and sectioned keys are separated
      * but maintain their relative declaration order within each group.
      *
-     * @return array{flat: array<string, array>, sections: array<string, array<string, array>>}
+     * @return array{flat: array<string, ConfigKey>, sections: array<string, array<string, ConfigKey>>}
      */
     public static function generateSettingsArray(): array
     {
@@ -39,8 +39,8 @@ PHP;
         $sections = [];
 
         foreach (ConfigKeys::all() as $entry) {
-            $key = $entry['key'];
-            $section = $entry['section'] ?? null;
+            $key = $entry->key;
+            $section = $entry->section;
 
             if ($section === null || $section === '') {
                 $flat[$key] = $entry;
@@ -190,15 +190,15 @@ PHP;
         $lines[] = "{$pad}{$border}";
     }
 
-    private static function appendEntry(array &$lines, string $key, array $entry, int $indent): void
+    private static function appendEntry(array &$lines, string $key, ConfigKey $entry, int $indent): void
     {
         $pad = str_repeat(string: '    ', times: $indent);
         $comment = ConfigKeysMeta::getComment(entry: $entry);
-        $choices = $entry['choices'] ?? null;
-        $type = $entry['type'] ?? 'string';
+        $choices = $entry->choices;
+        $type = $entry->type;
 
         if ($comment !== '') {
-            $hasExplicitComment = isset($entry['config_file_comment']) && $entry['config_file_comment'] !== '';
+            $hasExplicitComment = $entry->configFileComment !== null && $entry->configFileComment !== '';
             foreach (explode(separator: "\n", string: $comment) as $paragraph) {
                 if ($hasExplicitComment) {
                     // config_file_comment is pre-formatted, don't re-wrap
@@ -226,7 +226,7 @@ PHP;
             }
         }
 
-        $rendered = self::renderValue(value: $entry['default'], type: $type);
+        $rendered = self::renderValue(value: $entry->default, type: $type);
         $lines[] = "{$pad}'{$key}' => {$rendered},";
         $lines[] = '';
     }

--- a/lib/Config/ConfigKeysMeta.php
+++ b/lib/Config/ConfigKeysMeta.php
@@ -7,14 +7,20 @@ class ConfigKeysMeta
      *
      * Plugin entries with a section use the fully qualified section.key name.
      */
-    public static function canonicalKeyName(array $config): ?string
+    public static function canonicalKeyName(ConfigKey|array $config): ?string
     {
-        $key = $config['key'] ?? null;
+        if ($config instanceof ConfigKey) {
+            $key = $config->key;
+            $section = $config->section;
+        } else {
+            $key = $config['key'] ?? null;
+            $section = $config['section'] ?? null;
+        }
+
         if (!is_string($key) || $key === '') {
             return null;
         }
 
-        $section = $config['section'] ?? null;
         if (is_string($section) && $section !== '') {
             // Main config entries already store fully qualified keys like
             // "reservation.start.time.constraint" and use "section" only for grouping.
@@ -35,14 +41,21 @@ class ConfigKeysMeta
      *
      * Prefers 'config_file_comment' field, falls back to 'description'.
      */
-    public static function getComment(array $entry): string
+    public static function getComment(ConfigKey|array $entry): string
     {
-        $comment = $entry['config_file_comment'] ?? null;
+        if ($entry instanceof ConfigKey) {
+            $comment = $entry->configFileComment;
+            $description = $entry->description;
+        } else {
+            $comment = $entry['config_file_comment'] ?? null;
+            $description = $entry['description'] ?? null;
+        }
+
         if (is_string($comment) && $comment !== '') {
             return $comment;
         }
 
-        return $entry['description'] ?? '';
+        return is_string($description) ? $description : '';
     }
 
     /**
@@ -57,8 +70,8 @@ class ConfigKeysMeta
     /**
      * Group flat config entries according to TOP_LEVEL_GROUPS ordering.
      *
-     * @param array<string, array> $flatEntries
-     * @return array<string, array<string, array>>
+     * @param array<string, ConfigKey> $flatEntries
+     * @return array<string, array<string, ConfigKey>>
      *
      * @throws \LogicException if a group references an unknown key, a key is in multiple groups,
      *                         or flat keys are not covered by any group
@@ -99,7 +112,7 @@ class ConfigKeysMeta
     /**
      * Derive the environment variable name for a config entry definition.
      */
-    public static function envKeyForConfig(array $config): ?string
+    public static function envKeyForConfig(ConfigKey|array $config): ?string
     {
         $canonicalKey = self::canonicalKeyName(config: $config);
         if ($canonicalKey === null) {

--- a/lib/Config/Configuration.php
+++ b/lib/Config/Configuration.php
@@ -369,9 +369,9 @@ class ConfigurationFile implements IConfigurationFile
                     $entry = $match['entry'];
                     $isLegacyKey = $match['isLegacy'];
 
-                    if ($entry && !empty($entry['key'])) {
-                        $section = $entry['section'] ?? null;
-                        $finalKey = $entry['key'];
+                    if ($entry !== null) {
+                        $section = $entry->section;
+                        $finalKey = $entry->key;
 
                         if ($section !== null && $section !== '') {
                             // Always rewrite sectioned keys into the canonical section bucket,
@@ -406,9 +406,9 @@ class ConfigurationFile implements IConfigurationFile
             $entry = $match['entry'];
             $isLegacyKey = $match['isLegacy'];
 
-            if ($entry && !empty($entry['key'])) {
-                $finalKey = $entry['key'];
-                $section = $entry['section'] ?? null;
+            if ($entry !== null) {
+                $finalKey = $entry->key;
+                $section = $entry->section;
 
                 if ($section !== null && $section !== '' && str_starts_with($finalKey, $section . '.')) {
                     $keyWithinSection = substr($finalKey, strlen($section) + 1);
@@ -437,7 +437,7 @@ class ConfigurationFile implements IConfigurationFile
     }
 
     /**
-     * @return array{entry: ?array, isLegacy: bool}
+     * @return array{entry: ?ConfigKey, isLegacy: bool}
      */
     private function FindConfigEntry(string $key): array
     {
@@ -485,16 +485,16 @@ class ConfigurationFile implements IConfigurationFile
 
             $converter = $this->GetDefaultConverter($configDef);
             if (!$converter->IsValid($value)) {
-                error_log("[CONFIG] Invalid type for '{$fullKey}'. Should be '{$configDef['type']}', using default.");
-                $validated[$key] = $configDef['default'];
+                error_log("[CONFIG] Invalid type for '{$fullKey}'. Should be '{$configDef->type}', using default.");
+                $validated[$key] = $configDef->default;
                 continue;
             }
 
-            if (isset($configDef['choices'])
-                && !($configDef['allow_custom'] ?? false)
-                && !array_key_exists($value, $configDef['choices'])) {
-                error_log("[CONFIG] Invalid value '$value' for '{$fullKey}'. Should be one of the following options: [" . implode(', ', array_map(fn ($key, $value) => "{$key} => {$value}", array_keys($configDef['choices']), $configDef['choices'])) . ']');
-                $validated[$key] = $configDef['default'];
+            if ($configDef->choices !== null
+                && !$configDef->allowCustom
+                && !array_key_exists($value, $configDef->choices)) {
+                error_log("[CONFIG] Invalid value '$value' for '{$fullKey}'. Should be one of the following options: [" . implode(', ', array_map(fn ($key, $value) => "{$key} => {$value}", array_keys($configDef->choices), $configDef->choices)) . ']');
+                $validated[$key] = $configDef->default;
                 continue;
             }
 
@@ -515,19 +515,14 @@ class ConfigurationFile implements IConfigurationFile
      */
     public function GetKey($configDef, $converter = null)
     {
-        if (!is_array($configDef) || !isset($configDef['key'])) {
-            throw new InvalidArgumentException(sprintf(
-                'Config definition not found for: %s',
-                json_encode($configDef, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE)
-            ));
-        }
+        $configKey = $this->NormalizeConfigDef($configDef);
 
         $value = null;
-        $fullKey = $configDef['key'];
-        $section = $configDef['section'] ?? null;
-        $converter = $converter ?? $this->GetDefaultConverter($configDef);
+        $fullKey = $configKey->key;
+        $section = $configKey->section;
+        $converter = $converter ?? $this->GetDefaultConverter($configKey);
 
-        $envKey = ConfigKeysMeta::envKeyForConfig(config: $configDef);
+        $envKey = ConfigKeysMeta::envKeyForConfig(config: $configKey);
         $envValue = $envKey !== null ? env($envKey) : null;
 
         if (!empty($envValue)) {
@@ -544,19 +539,40 @@ class ConfigurationFile implements IConfigurationFile
         }
 
         if ($value === null || $value === '') {
-            if (array_key_exists('default', $configDef)) {
-                $value = $configDef['default'];
-            } else {
-                $value = null;
-            }
+            $value = $configKey->default;
         }
 
         return $this->Convert($value, $converter);
     }
 
-    private function GetDefaultConverter(array $config): ?IConvert
+    /**
+     * Normalizes a config definition into a typed ConfigKey.
+     *
+     * Accepts either a ConfigKey or a legacy associative-array definition such as
+     * ConfigKeys::APP_TITLE. Left untyped so anything else falls through to the
+     * descriptive InvalidArgumentException rather than a raw TypeError.
+     *
+     * @param ConfigKey|array<string, mixed>|mixed $configDef
+     */
+    protected function NormalizeConfigDef($configDef): ConfigKey
     {
-        return match ($config['type'] ?? ConfigSettingType::String) {
+        if ($configDef instanceof ConfigKey) {
+            return $configDef;
+        }
+
+        if (is_array($configDef) && array_key_exists('key', $configDef)) {
+            return ConfigKey::fromArray($configDef);
+        }
+
+        throw new InvalidArgumentException(sprintf(
+            'Config definition not found for: %s',
+            json_encode($configDef, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE)
+        ));
+    }
+
+    private function GetDefaultConverter(ConfigKey $config): ?IConvert
+    {
+        return match ($config->type) {
             ConfigSettingType::Integer => new IntConverter(),
             ConfigSettingType::Boolean => new BooleanConverter(),
             ConfigSettingType::String => new StringConverter(),

--- a/lib/Config/EnvExampleGenerator.php
+++ b/lib/Config/EnvExampleGenerator.php
@@ -133,18 +133,18 @@ class EnvExampleGenerator
         $lines[] = $border;
     }
 
-    private static function appendEntry(array &$lines, array $entry): void
+    private static function appendEntry(array &$lines, ConfigKey $entry): void
     {
         $comment = ConfigKeysMeta::getComment(entry: $entry);
-        $choices = $entry['choices'] ?? null;
-        $type = $entry['type'] ?? 'string';
+        $choices = $entry->choices;
+        $type = $entry->type;
         $envKey = ConfigKeysMeta::envKeyForConfig(config: $entry);
         if ($envKey === null) {
             throw new \LogicException('Env example entry is missing a canonical config key name.');
         }
 
         if ($comment !== '') {
-            $hasExplicitComment = isset($entry['config_file_comment']) && $entry['config_file_comment'] !== '';
+            $hasExplicitComment = $entry->configFileComment !== null && $entry->configFileComment !== '';
             foreach (explode(separator: "\n", string: $comment) as $paragraph) {
                 if ($hasExplicitComment) {
                     $lines[] = "# {$paragraph}";
@@ -170,7 +170,7 @@ class EnvExampleGenerator
             }
         }
 
-        $rendered = self::renderValue(value: $entry['default'], type: $type);
+        $rendered = self::renderValue(value: $entry->default, type: $type);
         $lines[] = "{$envKey}={$rendered}";
         $lines[] = '';
     }

--- a/lib/Config/MigrateConfig.php
+++ b/lib/Config/MigrateConfig.php
@@ -17,9 +17,9 @@ class MigrateConfig
         self::WriteStderr('If output.php is omitted, a sibling file ending in .migrated.php is written.');
     }
 
-    public static function ExportValue(mixed $value, ?array $configDef = null): string
+    public static function ExportValue(mixed $value, ?ConfigKey $configDef = null): string
     {
-        $configType = is_array($configDef) ? ($configDef['type'] ?? null) : null;
+        $configType = $configDef?->type;
 
         if (is_bool($value)) {
             return $value ? 'true' : 'false';

--- a/tests/Infrastructure/Config/ConfigTest.php
+++ b/tests/Infrastructure/Config/ConfigTest.php
@@ -303,14 +303,15 @@ PHP
 
     public function testPluginConfigAllowsTheSameKeyNameInDifferentSections()
     {
-        $this->assertSame(
-            TestPluginConfigKeysNoCollisionSameKeyDifferentSections::SERVER1_KEY,
-            TestPluginConfigKeysNoCollisionSameKeyDifferentSections::findByKey('server1.key')
-        );
-        $this->assertSame(
-            TestPluginConfigKeysNoCollisionSameKeyDifferentSections::SERVER2_KEY,
-            TestPluginConfigKeysNoCollisionSameKeyDifferentSections::findByKey('server2.key')
-        );
+        $server1 = TestPluginConfigKeysNoCollisionSameKeyDifferentSections::findByKey('server1.key');
+        $this->assertNotNull($server1);
+        $this->assertSame('key', $server1->key);
+        $this->assertSame('server1', $server1->section);
+
+        $server2 = TestPluginConfigKeysNoCollisionSameKeyDifferentSections::findByKey('server2.key');
+        $this->assertNotNull($server2);
+        $this->assertSame('key', $server2->key);
+        $this->assertSame('server2', $server2->section);
     }
 
     public function testPluginConfigRejectsCaseInsensitiveLegacyToCanonicalCollisions()

--- a/tests/Plugins/Authentication/PluginConfigLoadingTest.php
+++ b/tests/Plugins/Authentication/PluginConfigLoadingTest.php
@@ -134,11 +134,11 @@ class PluginConfigLoadingTest extends TestBase
             $this->assertNotEmpty($allKeys, "{$configKeysClass} should have config key definitions");
 
             foreach ($allKeys as $keyDef) {
-                $this->assertArrayHasKey('section', $keyDef, "Config key in {$configKeysClass} must have 'section'");
+                $this->assertNotNull($keyDef->section, "Config key in {$configKeysClass} must have 'section'");
                 $this->assertEquals(
                     $expectedSection,
-                    $keyDef['section'],
-                    "Config key in {$configKeysClass} must have section '{$expectedSection}', got '{$keyDef['section']}'"
+                    $keyDef->section,
+                    "Config key in {$configKeysClass} must have section '{$expectedSection}', got '{$keyDef->section}'"
                 );
             }
         }
@@ -201,7 +201,7 @@ class PluginConfigLoadingTest extends TestBase
             $allKeys = $configKeysClass::all();
 
             foreach ($allKeys as $keyDef) {
-                $bareKey = $keyDef['key'];
+                $bareKey = $keyDef->key;
                 $fullKey = $expectedSection . '.' . $bareKey;
 
                 // Test that findByKey with bare key returns null (because it has a section)
@@ -221,12 +221,12 @@ class PluginConfigLoadingTest extends TestBase
                 // Verify it's the same config definition
                 $this->assertEquals(
                     $bareKey,
-                    $foundWithFullKey['key'],
+                    $foundWithFullKey->key,
                     "Found config should have bare key '{$bareKey}'"
                 );
                 $this->assertEquals(
                     $expectedSection,
-                    $foundWithFullKey['section'],
+                    $foundWithFullKey->section,
                     "Found config should have section '{$expectedSection}'"
                 );
             }
@@ -323,8 +323,8 @@ class PluginConfigLoadingTest extends TestBase
             $expectedSection = strtolower($plugin['name']);
 
             foreach ($allKeys as $keyDef) {
-                $keyName = $keyDef['key'];
-                $section = $keyDef['section'] ?? null;
+                $keyName = $keyDef->key;
+                $section = $keyDef->section;
 
                 // Test that the value can be retrieved
                 try {
@@ -432,7 +432,7 @@ class PluginConfigLoadingTest extends TestBase
             // Build list of expected keys from ConfigKeys
             $expectedKeys = [];
             foreach ($definedKeys as $keyDef) {
-                $expectedKeys[] = $keyDef['key'];
+                $expectedKeys[] = $keyDef->key;
             }
 
             // Check for extra keys in config file that aren't in ConfigKeys
@@ -453,12 +453,12 @@ class PluginConfigLoadingTest extends TestBase
                 // Filter out keys that have defaults - those are optional
                 $criticalMissing = [];
                 foreach ($missingKeys as $missingKey) {
-                    $keyDef = array_filter($definedKeys, function ($k) use ($missingKey) {
-                        return $k['key'] === $missingKey;
+                    $keyDef = array_filter($definedKeys, function (ConfigKey $k) use ($missingKey) {
+                        return $k->key === $missingKey;
                     });
                     $keyDef = reset($keyDef);
                     // If no default is set, it's critical
-                    if (!isset($keyDef['default']) || $keyDef['default'] === null) {
+                    if (!$keyDef instanceof ConfigKey || $keyDef->default === null) {
                         $criticalMissing[] = $missingKey;
                     }
                 }

--- a/tests/data/test_plugin_configclass.php
+++ b/tests/data/test_plugin_configclass.php
@@ -33,7 +33,7 @@ class TestPluginConfigKeys extends PluginConfigKeys
         ]
     ];
 
-    public static function findByLegacyKey(string $legacyKey): ?array
+    public static function findByLegacyKey(string $legacyKey): ?ConfigKey
     {
         return null;
     }

--- a/tests/fakes/FakeConfig.php
+++ b/tests/fakes/FakeConfig.php
@@ -58,16 +58,14 @@ class FakeConfigFile extends ConfigurationFile implements IConfigurationFile
 
     public function GetKey($configDef, $converter = null)
     {
-        if (!is_array($configDef) || !isset($configDef['key'])) {
-            throw new InvalidArgumentException('Config definition not found');
-        }
+        $configKey = $this->NormalizeConfigDef($configDef);
 
         $value = null;
-        $fullKey = $configDef['key'];
-        $section = $configDef['section'] ?? null;
-        $converter = $converter ?? $this->GetDefaultConverter($configDef);
+        $fullKey = $configKey->key;
+        $section = $configKey->section;
+        $converter = $converter ?? $this->GetDefaultConverter($configKey);
 
-        if ($section !== null) {
+        if ($section !== null && $section !== '') {
             $sectionKey = str_starts_with($fullKey, $section . '.') ? substr($fullKey, strlen($section) + 1) : $fullKey;
             if (isset($this->_values[$section][$sectionKey])) {
                 $value = $this->_values[$section][$sectionKey];
@@ -86,9 +84,9 @@ class FakeConfigFile extends ConfigurationFile implements IConfigurationFile
         return $this->GetKey($keyName, $converter);
     }
 
-    private function GetDefaultConverter(array $config): ?IConvert
+    private function GetDefaultConverter(ConfigKey $config): ?IConvert
     {
-        return match ($config['type'] ?? ConfigSettingType::String) {
+        return match ($config->type) {
             ConfigSettingType::Integer => new IntConverter(),
             ConfigSettingType::Boolean => new BooleanConverter(),
             ConfigSettingType::String => new StringConverter(),
@@ -120,24 +118,28 @@ class FakeConfigFile extends ConfigurationFile implements IConfigurationFile
 
     public function SetKey($configDef, $value)
     {
-        if (is_array($configDef) && isset($configDef['key'])) {
+        if ($configDef instanceof ConfigKey) {
+            $fullKey = $configDef->key;
+            $section = $configDef->section;
+        } elseif (is_array($configDef) && array_key_exists('key', $configDef)) {
             $fullKey = $configDef['key'];
             $section = $configDef['section'] ?? null;
-
-            if ($section !== null) {
-                $sectionKey = str_starts_with($fullKey, $section . '.') ?
-                    substr($fullKey, strlen($section) + 1) :
-                    $fullKey;
-
-                if (!isset($this->_values[$section])) {
-                    $this->_values[$section] = [];
-                }
-                $this->_values[$section][$sectionKey] = $value;
-            } else {
-                $this->_values[$fullKey] = $value;
-            }
         } else {
             $this->_values[$configDef] = $value;
+            return;
+        }
+
+        if ($section !== null && $section !== '') {
+            $sectionKey = str_starts_with($fullKey, $section . '.') ?
+                substr($fullKey, strlen($section) + 1) :
+                $fullKey;
+
+            if (!isset($this->_values[$section])) {
+                $this->_values[$section] = [];
+            }
+            $this->_values[$section][$sectionKey] = $value;
+        } else {
+            $this->_values[$fullKey] = $value;
         }
     }
 

--- a/tests/lib/Config/EnvExampleGeneratorTest.php
+++ b/tests/lib/Config/EnvExampleGeneratorTest.php
@@ -27,7 +27,7 @@ class EnvExampleGeneratorTest extends TestBase
             $this->assertStringContainsString(
                 $envKey . '=',
                 $content,
-                "Missing env key: {$envKey} (from config key: {$entry['key']})"
+                "Missing env key: {$envKey} (from config key: {$entry->key})"
             );
         }
     }
@@ -36,7 +36,7 @@ class EnvExampleGeneratorTest extends TestBase
     {
         // Verify canonical env keys follow the expected LB_* naming convention
         foreach (ConfigKeys::all() as $entry) {
-            $key = $entry['key'];
+            $key = $entry->key;
             $expected = strtoupper('LB_' . preg_replace('/[.\-]+/', '_', $key));
             $actual = ConfigKeysMeta::envKeyForConfig(config: $entry);
 


### PR DESCRIPTION
Convert the array config definitions to typed ConfigKey objects at the single read boundary and have the readers that go through it consume the typed object, replacing the array-index accesses with property accesses.

AbstractConfigKeys::allWithEntryIds() now builds each entry with ConfigKey::fromArray() (matching constants via array_key_exists('key', ...) so a 'key' => null definition is still validated rather than skipped). all(), findByKey(), and findByLegacyKey() therefore return ConfigKey, and the inline allow_custom check is dropped because fromArray() already validates it (and the other fields).

Configuration::GetKey() normalizes its argument through a new protected NormalizeConfigDef(): a ConfigKey passes through and a legacy array such as ConfigKeys::APP_TITLE is converted via fromArray(), so the ~800 GetKey(ConfigKeys::X) call sites are unchanged. Anything else still throws the descriptive InvalidArgumentException rather than a TypeError, so the helper is left untyped on purpose; GetDefaultConverter() is typed ConfigKey. The boundary readers move from $def['field'] to $def->field: ValidateConfig(), RewriteLegacyKeys()/FindConfigEntry(), ConfigDistGenerator, EnvExampleGenerator, MigrateConfig::ExportValue(), and ManageConfigurationPresenter. The ConfigKeysMeta helpers (canonicalKeyName/getComment/envKeyForConfig) accept ConfigKey|array since they still receive raw constants from the env path and a couple of tests.

FakeConfig reuses the parent normalizer, types its GetDefaultConverter(), and handles ConfigKey in SetKey(). The tests and fixtures that read config definitions or override findByLegacyKey() are updated to the typed shape.

The raw-constant direct-indexers (the Ldap/Shibboleth plugin sites, PluginManager, etc.) keep indexing arrays and are untouched. No behavior change: the generated config.dist.php and .env.example are byte-identical, and the full unit suite and PHPStan level 2 pass.

Assisted-by: Claude:claude-opus-4-8