### PR TITLE
refactor(config): drop dead array branches from the typed boundary

### DIFF
--- a/lib/Config/AbstractConfigKeys.php
+++ b/lib/Config/AbstractConfigKeys.php
@@ -132,28 +132,20 @@ abstract class AbstractConfigKeys
         return getenv($envKey) !== false;
     }
 
-    /** @param ConfigKey|array<string, mixed> $config */
-    protected static function getCanonicalLookupKey(ConfigKey|array $config): ?string
+    protected static function getCanonicalLookupKey(ConfigKey $config): ?string
     {
-        if ($config instanceof ConfigKey) {
-            return $config->key !== '' ? $config->key : null;
-        }
-        $key = $config['key'] ?? null;
-
-        return is_string($key) && $key !== '' ? $key : null;
+        return $config->key !== '' ? $config->key : null;
     }
 
     /**
-     * @param array<string, ConfigKey|array<string, mixed>> $configsWithIds
+     * @param array<string, ConfigKey> $configsWithIds
      */
     private static function assertNoCaseInsensitiveLookupCollisions(array $configsWithIds): void
     {
         $seen = [];
 
         foreach ($configsWithIds as $entryId => $configWithId) {
-            $legacyKey = $configWithId instanceof ConfigKey
-                ? $configWithId->legacy
-                : ($configWithId['legacy'] ?? null);
+            $legacyKey = $configWithId->legacy;
 
             // Validate both the canonical lookup key and any legacy alias because
             // either one can collide once lookups become case-insensitive.
@@ -176,15 +168,14 @@ abstract class AbstractConfigKeys
 
     /**
      * @param array<string, mixed> $seen
-     * @param ConfigKey|array<string, mixed> $configWithId
      */
-    private static function assertUniqueCaseInsensitiveKey(array &$seen, ?string $rawKey, string $entryId, ConfigKey|array $configWithId, string $source): void
+    private static function assertUniqueCaseInsensitiveKey(array &$seen, ?string $rawKey, string $entryId, ConfigKey $configWithId, string $source): void
     {
         if (!is_string($rawKey) || $rawKey === '') {
             return;
         }
 
-        $configKey = $configWithId instanceof ConfigKey ? $configWithId->key : $configWithId['key'];
+        $configKey = $configWithId->key;
 
         $normalizedKey = strtolower($rawKey);
         if (!isset($seen[$normalizedKey])) {

--- a/lib/Config/PluginConfigKeys.php
+++ b/lib/Config/PluginConfigKeys.php
@@ -4,20 +4,15 @@ require_once(ROOT_DIR . 'lib/Config/AbstractConfigKeys.php');
 
 abstract class PluginConfigKeys extends AbstractConfigKeys
 {
-    protected static function getCanonicalLookupKey(ConfigKey|array $config): ?string
+    protected static function getCanonicalLookupKey(ConfigKey $config): ?string
     {
-        if ($config instanceof ConfigKey) {
-            $configKey = $config->key;
-            $section = $config->section;
-        } else {
-            $configKey = $config['key'] ?? null;
-            $section = $config['section'] ?? null;
-        }
+        $configKey = $config->key;
+        $section = $config->section;
 
-        if (is_string($section) && $section !== '' && is_string($configKey) && $configKey !== '') {
+        if (is_string($section) && $section !== '' && $configKey !== '') {
             return "{$section}.{$configKey}";
         }
 
-        return is_string($configKey) && $configKey !== '' ? $configKey : null;
+        return $configKey !== '' ? $configKey : null;
     }
 }

--- a/tests/Infrastructure/Config/ConfigTest.php
+++ b/tests/Infrastructure/Config/ConfigTest.php
@@ -340,24 +340,6 @@ PHP
         TestPluginConfigKeysCollisionLegacyVsLegacy::findByKey('server1.key1');
     }
 
-    public function testConfigKeyRejectsNonBooleanAllowCustom()
-    {
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('"allow_custom" value: must be true or false (boolean)');
-
-        $invalidClass = new class () extends \PluginConfigKeys {
-            public const CONFIG_ID = 'invalid-allow-custom-test';
-            public const KEY1 = [
-                'key' => 'key1',
-                'type' => 'string',
-                'default' => '',
-                'allow_custom' => 'yes',
-            ];
-        };
-
-        $invalidClass::all();
-    }
-
     public function testPluginConfigValidation()
     {
         $errorLogs = $this->captureErrorLog(function () {


### PR DESCRIPTION
With the read boundary now always emitting ConfigKey (allWithEntryIds() builds every entry via fromArray()), the ConfigKey|array tolerance in the internal lookup and collision helpers only ever sees ConfigKey input. Remove the dead array branches and narrow the signatures:

- getCanonicalLookupKey() in AbstractConfigKeys and its PluginConfigKeys override take ConfigKey (the override stays signature-compatible with the base) and drop the $config['key']/$config['section'] handling.
- assertNoCaseInsensitiveLookupCollisions() and assertUniqueCaseInsensitiveKey() take ConfigKey and read $config->legacy/$config->key directly.

Delete testConfigKeyRejectsNonBooleanAllowCustom from ConfigTest: the inline allow_custom array check it targeted was replaced by fromArray() in the boundary flip, so it survived only because fromArray()'s message contains the same substring. Its coverage now lives in
ConfigKeyTest::testFromArrayRejectsNonBooleanAllowCustom.

The public methods that still receive raw array constants are deliberately left ConfigKey|array-tolerant and unchanged: isPrivate(), hasEnv(), and the ConfigKeysMeta helpers (canonicalKeyName/getComment/envKeyForConfig).

No behavior change. The full unit suite and PHPStan level 2 pass, and the generated config.dist.php and .env.example are byte-identical.

Assisted-by: Claude:claude-opus-4-8