### PR TITLE
feat(ics): add global config switch to enable/disable ICS/Atom feeds

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -438,6 +438,9 @@ LB_TABLET_VIEW_AUTO_SUGGEST_EMAILS=false
 # ICS Settings
 ##############
 
+# Enable or disable ICS calendar subscription feeds entirely (true/false)
+LB_ICS_ENABLED=true
+
 # Subscription key secret used for ICS calendar feeds
 LB_ICS_SUBSCRIPTION_KEY=
 

--- a/Pages/Admin/ManageResourcesPage.php
+++ b/Pages/Admin/ManageResourcesPage.php
@@ -506,6 +506,7 @@ class ManageResourcesPage extends ActionPage implements IManageResourcesPage
         );
 
         $this->Set('CreditsEnabled', Configuration::Instance()->GetKey(ConfigKeys::CREDITS_ENABLED, new BooleanConverter()));
+        $this->Set('IcsEnabled', Configuration::Instance()->GetKey(ConfigKeys::ICS_ENABLED, new BooleanConverter()));
 
         $url = $this->server->GetUrl();
         $exportUrl = BookedStringHelper::Contains($url, '?') ? $url . '&dr=export' : $this->server->GetRequestUri() . '?dr=export';

--- a/Pages/Admin/ManageSchedulesPage.php
+++ b/Pages/Admin/ManageSchedulesPage.php
@@ -274,6 +274,7 @@ class ManageSchedulesPage extends ActionPage implements IManageSchedulesPage
         );
 
         $this->Set('CreditsEnabled', Configuration::Instance()->GetKey(ConfigKeys::CREDITS_ENABLED, new BooleanConverter()));
+        $this->Set('IcsEnabled', Configuration::Instance()->GetKey(ConfigKeys::ICS_ENABLED, new BooleanConverter()));
     }
 
     public function ProcessPageLoad()

--- a/Pages/Export/AtomSubscriptionPage.php
+++ b/Pages/Export/AtomSubscriptionPage.php
@@ -45,10 +45,13 @@ class AtomSubscriptionPage extends Page implements ICalendarSubscriptionPage
         return $this->GetQuerystring(QueryStringKeys::USER_ID);
     }
 
-    public function PageLoad()
+    public function PageLoad(): void
     {
         ob_clean();
-        $this->presenter->PageLoad();
+        if (!$this->presenter->PageLoad()) {
+            http_response_code(404);
+            return;
+        }
 
         $config = Configuration::Instance();
 

--- a/Pages/Export/CalendarSubscriptionPage.php
+++ b/Pages/Export/CalendarSubscriptionPage.php
@@ -45,9 +45,12 @@ class CalendarSubscriptionPage extends Page implements ICalendarSubscriptionPage
         return $this->GetQuerystring(QueryStringKeys::USER_ID);
     }
 
-    public function PageLoad()
+    public function PageLoad(): void
     {
-        $this->presenter->PageLoad();
+        if (!$this->presenter->PageLoad()) {
+            http_response_code(404);
+            return;
+        }
 
         header('Content-Type: text/Calendar');
         header('Content-Disposition: inline; filename=calendar.ics');

--- a/Presenters/CalendarSubscriptionPresenter.php
+++ b/Presenters/CalendarSubscriptionPresenter.php
@@ -45,10 +45,10 @@ class CalendarSubscriptionPresenter
         $this->privacyFilter = $filter;
     }
 
-    public function PageLoad()
+    public function PageLoad(): bool
     {
         if (!$this->validator->IsValid()) {
-            return;
+            return false;
         }
 
         $userId = $this->page->GetUserId();
@@ -136,5 +136,7 @@ class CalendarSubscriptionPresenter
         }
 
         $this->page->SetReservations($reservations);
+
+        return true;
     }
 }

--- a/Presenters/Schedule/SchedulePageBuilder.php
+++ b/Presenters/Schedule/SchedulePageBuilder.php
@@ -104,7 +104,10 @@ class SchedulePageBuilder implements ISchedulePageBuilder
         $page->SetFirstWeekday($currentSchedule->GetWeekdayStart());
         $style = $page->GetScheduleStyle($scheduleId);
         $page->SetScheduleStyle($style ?? $currentSchedule->GetDefaultStyle());
-        if ($currentSchedule->GetIsCalendarSubscriptionAllowed()) {
+        if (
+            Configuration::Instance()->GetKey(ConfigKeys::ICS_ENABLED, new BooleanConverter()) &&
+            $currentSchedule->GetIsCalendarSubscriptionAllowed()
+        ) {
             $page->SetSubscriptionUrl(new CalendarSubscriptionUrl(null, $currentSchedule->GetPublicId(), null));
         }
     }

--- a/config/config.dist.php
+++ b/config/config.dist.php
@@ -480,6 +480,9 @@ return [
         ##############
 
         'ics' => [
+            # Enable or disable ICS calendar subscription feeds entirely (true/false)
+            'enabled' => true,
+
             # Subscription key secret used for ICS calendar feeds
             'subscription.key' => '',
 

--- a/lib/Application/Schedule/CalendarSubscriptionService.php
+++ b/lib/Application/Schedule/CalendarSubscriptionService.php
@@ -84,6 +84,9 @@ class CalendarSubscriptionDetails
      */
     public function IsEnabled()
     {
+        if (!Configuration::Instance()->GetKey(ConfigKeys::ICS_ENABLED, new BooleanConverter())) {
+            return false;
+        }
         $key = Configuration::Instance()->GetKey(ConfigKeys::ICS_SUBSCRIPTION_KEY);
         return !empty($key);
     }

--- a/lib/Application/Schedule/CalendarSubscriptionValidator.php
+++ b/lib/Application/Schedule/CalendarSubscriptionValidator.php
@@ -29,6 +29,12 @@ class CalendarSubscriptionValidator implements ICalendarExportValidator
 
     public function IsValid()
     {
+        if (!Configuration::Instance()->GetKey(ConfigKeys::ICS_ENABLED, new BooleanConverter())) {
+            Log::Debug('ICS calendar subscriptions are disabled via config (ics.enabled).');
+
+            return false;
+        }
+
         $key = Configuration::Instance()->GetKey(ConfigKeys::ICS_SUBSCRIPTION_KEY);
         $providedKey = $this->page->GetSubscriptionKey();
 

--- a/lib/Config/ConfigKeys.php
+++ b/lib/Config/ConfigKeys.php
@@ -1081,6 +1081,15 @@ class ConfigKeys extends AbstractConfigKeys
 
     // ICS Settings
 
+    public const ICS_ENABLED = [
+        'key' => 'ics.enabled',
+        'type' => 'boolean',
+        'default' => true,
+        'label' => 'ICS Enabled',
+        'description' => 'Enable ICS/Atom calendar subscription feeds. When disabled, all ICS/Atom subscription requests return 404 and the subscription link is hidden in the UI.',
+        'config_file_comment' => 'Enable or disable ICS calendar subscription feeds entirely',
+        'section' => 'ics'
+    ];
     public const ICS_SUBSCRIPTION_KEY = [
         'key' => 'ics.subscription.key',
         'type' => 'string',

--- a/tests/Application/Schedule/CalendarSubscriptionServiceTest.php
+++ b/tests/Application/Schedule/CalendarSubscriptionServiceTest.php
@@ -81,4 +81,24 @@ class CalendarSubscriptionServiceTest extends TestBase
 
         $this->assertEquals($expected, $actual);
     }
+
+    public function testSubscriptionDetailsAreNotEnabledWhenIcsFeatureIsDisabled()
+    {
+        $this->fakeConfig->SetKey(ConfigKeys::ICS_ENABLED, false);
+        $this->fakeConfig->SetKey(ConfigKeys::ICS_SUBSCRIPTION_KEY, '123');
+
+        $details = new CalendarSubscriptionDetails(true);
+
+        $this->assertFalse($details->IsEnabled());
+    }
+
+    public function testSubscriptionDetailsAreEnabledWhenIcsFeatureAndSubscriptionKeyAreConfigured()
+    {
+        $this->fakeConfig->SetKey(ConfigKeys::ICS_ENABLED, true);
+        $this->fakeConfig->SetKey(ConfigKeys::ICS_SUBSCRIPTION_KEY, '123');
+
+        $details = new CalendarSubscriptionDetails(true);
+
+        $this->assertTrue($details->IsEnabled());
+    }
 }

--- a/tests/Presenters/CalendarSubscriptionPresenterTest.php
+++ b/tests/Presenters/CalendarSubscriptionPresenterTest.php
@@ -47,7 +47,7 @@ class CalendarSubscriptionPresenterTest extends TestBase
         $this->service = $this->createMock('ICalendarSubscriptionService');
         $this->privacyFilter = new FakePrivacyFilter();
 
-        $this->validator->expects($this->atLeastOnce())
+        $this->validator
                 ->method('IsValid')
                 ->willReturn(true);
 
@@ -172,6 +172,30 @@ class CalendarSubscriptionPresenterTest extends TestBase
         $this->presenter->PageLoad();
 
         $this->assertCount(1, $this->page->Reservations);
+    }
+
+    public function testPageLoadReturnsFalseAndDoesNotLoadReservationsWhenValidationFails()
+    {
+        $validator = $this->createMock('ICalendarExportValidator');
+        $validator->expects($this->once())
+                ->method('IsValid')
+                ->willReturn(false);
+
+        $this->repo->expects($this->never())->method('GetReservations');
+        $this->service->expects($this->never())->method('GetSchedule');
+        $this->service->expects($this->never())->method('GetResource');
+        $this->service->expects($this->never())->method('GetUser');
+
+        $presenter = new CalendarSubscriptionPresenter(
+            $this->page,
+            $this->repo,
+            $validator,
+            $this->service,
+            $this->privacyFilter
+        );
+
+        $this->assertFalse($presenter->PageLoad());
+        $this->assertNull($this->page->Reservations);
     }
 }
 

--- a/tests/Presenters/CalendarSubscriptionValidatorTest.php
+++ b/tests/Presenters/CalendarSubscriptionValidatorTest.php
@@ -102,6 +102,7 @@ class CalendarSubscriptionValidatorTest extends TestBase
 
     public function testIsNotValidWhenSubscriptionKeyDoesNotMatch()
     {
+        $this->fakeConfig->SetKey(ConfigKeys::ICS_ENABLED, true);
         $this->page->expects($this->once())
             ->method('GetSubscriptionKey')
             ->willReturn('12');
@@ -115,7 +116,23 @@ class CalendarSubscriptionValidatorTest extends TestBase
 
     public function testIsNotValidWhenSubscriptionKeyIsNotConfigured()
     {
+        $this->fakeConfig->SetKey(ConfigKeys::ICS_ENABLED, true);
         $this->fakeConfig->SetKey(ConfigKeys::ICS_SUBSCRIPTION_KEY, '');
+
+        $isValid = $this->validator->IsValid();
+
+        $this->assertFalse($isValid);
+    }
+
+    public function testIsNotValidWhenIcsFeatureIsDisabled()
+    {
+        $this->fakeConfig->SetKey(ConfigKeys::ICS_ENABLED, false);
+        $this->fakeConfig->SetKey(ConfigKeys::ICS_SUBSCRIPTION_KEY, '123');
+
+        $this->page->expects($this->never())->method('GetSubscriptionKey');
+        $this->subscriptionService->expects($this->never())->method('GetResource');
+        $this->subscriptionService->expects($this->never())->method('GetSchedule');
+        $this->subscriptionService->expects($this->never())->method('GetUser');
 
         $isValid = $this->validator->IsValid();
 
@@ -124,6 +141,7 @@ class CalendarSubscriptionValidatorTest extends TestBase
 
     private function StubSubscriptionKey()
     {
+        $this->fakeConfig->SetKey(ConfigKeys::ICS_ENABLED, true);
         $this->page->expects($this->once())
             ->method('GetSubscriptionKey')
             ->willReturn('123');

--- a/tests/Presenters/SchedulePresenterTest.php
+++ b/tests/Presenters/SchedulePresenterTest.php
@@ -27,6 +27,7 @@ class SchedulePresenterTest extends TestBase
             ConfigKeys::SCHEDULE_SHOW_INACCESSIBLE_RESOURCES,
             $this->showInaccessibleResources
         );
+        $this->fakeConfig->SetKey(ConfigKeys::ICS_ENABLED, true);
     }
 
     public function teardown(): void
@@ -208,6 +209,33 @@ class SchedulePresenterTest extends TestBase
 
         $pageBuilder = new SchedulePageBuilder();
         $pageBuilder->BindSchedules($page, $this->schedules, $schedule);
+    }
+
+    public function testScheduleBuilderBindsSubscriptionUrlWhenIcsFeatureIsEnabled()
+    {
+        $schedule = new FakeSchedule();
+        $schedule->EnableSubscription();
+
+        $page = new FakeSchedulePage();
+        $pageBuilder = new SchedulePageBuilder();
+
+        $pageBuilder->BindSchedules($page, $this->schedules, $schedule);
+
+        $this->assertNotNull($page->_SubscriptionUrl);
+    }
+
+    public function testScheduleBuilderDoesNotBindSubscriptionUrlWhenIcsFeatureIsDisabled()
+    {
+        $this->fakeConfig->SetKey(ConfigKeys::ICS_ENABLED, false);
+        $schedule = new FakeSchedule();
+        $schedule->EnableSubscription();
+
+        $page = new FakeSchedulePage();
+        $pageBuilder = new SchedulePageBuilder();
+
+        $pageBuilder->BindSchedules($page, $this->schedules, $schedule);
+
+        $this->assertNull($page->_SubscriptionUrl);
     }
 
     public function testScheduleBuilderGetCurrentScheduleReturnsSelectedScheduleOnPostBack()
@@ -892,6 +920,7 @@ class FakeSchedulePage implements ISchedulePage
     public $_ScheduleAvailability;
     public $_ScheduleTooEarly;
     public $_ScheduleTooLate;
+    public $_SubscriptionUrl;
     /**
      * @var LoadReservationRequest
      */
@@ -1164,6 +1193,7 @@ class FakeSchedulePage implements ISchedulePage
 
     public function SetSubscriptionUrl(CalendarSubscriptionUrl $subscriptionUrl)
     {
+        $this->_SubscriptionUrl = $subscriptionUrl;
     }
 
     public function ShowPermissionError($shouldShow)

--- a/tpl/Admin/Resources/manage_resources.tpl
+++ b/tpl/Admin/Resources/manage_resources.tpl
@@ -610,11 +610,11 @@
 														<div class="publicSettingsPlaceHolder">
 															{include file="Admin/Resources/manage_resources_public.tpl" resource=$resource}
 														</div>
-													</div>
-													<div class="">
-														<a href="{$smarty.server.SCRIPT_NAME}?action={ManageResourcesActions::ActionPrintQR}&rid={$id}"
-															target="_blank" class="link-primary">{translate key=PrintQRCode}
-															<i class="bi bi-qr-code"></i></a>
+														<div class="">
+															<a href="{$smarty.server.SCRIPT_NAME}?action={ManageResourcesActions::ActionPrintQR}&rid={$id}"
+																target="_blank" class="link-primary">{translate key=PrintQRCode}
+																<i class="bi bi-qr-code"></i></a>
+														</div>
 													</div>
 												</div>
 											</div>
@@ -1741,14 +1741,16 @@
 											</div>
 										</div>
 
-										<div class="form-group">
-											<label for="bulkEditAllowSubscriptions"
-												class="fw-bold">{translate key='TurnOnSubscription'}</label>
-											<select id="bulkEditAllowSubscriptions" class="form-select form-select-sm"
-												{formname key=ALLOW_CALENDAR_SUBSCRIPTIONS}>
-												{html_options options=$YesNoUnchangedOptions}
-											</select>
-										</div>
+										{if $IcsEnabled}
+											<div class="form-group">
+												<label for="bulkEditAllowSubscriptions"
+													class="fw-bold">{translate key='TurnOnSubscription'}</label>
+												<select id="bulkEditAllowSubscriptions" class="form-select form-select-sm"
+													{formname key=ALLOW_CALENDAR_SUBSCRIPTIONS}>
+													{html_options options=$YesNoUnchangedOptions}
+												</select>
+											</div>
+										{/if}
 									</div>
 								</div>
 							</div>

--- a/tpl/Admin/Resources/manage_resources_public.tpl
+++ b/tpl/Admin/Resources/manage_resources_public.tpl
@@ -3,16 +3,20 @@
     <a href="{$ScriptUrl}/{Pages::DISPLAY_RESOURCE}?{QueryStringKeys::RESOURCE_ID}={$resource->GetPublicId()}"
         class="link-primary">{$ScriptUrl}/{Pages::DISPLAY_RESOURCE}?{QueryStringKeys::RESOURCE_ID}={$resource->GetPublicId()}</a>
 {elseif $resource->GetIsCalendarSubscriptionAllowed() && !$modeEdit}
-    <div><a class="update disableSubscription subscriptionButton link-primary"
-            href="#">{translate key=TurnOffSubscription}</a>
-    </div>
+    {if $IcsEnabled}
+        <div><a class="update disableSubscription subscriptionButton link-primary"
+                href="#">{translate key=TurnOffSubscription}</a>
+        </div>
+    {/if}
     <div>
-        <i class="bi bi-calendar link-primary"></i>
-        <a target="_blank" href="{$resource->GetSubscriptionUrl()->GetWebcalUrl()}" class="link-primary">{translate key=SubscribeToCalendar}</a>
-        <div class="vr mx-1"></div>
-        <i class="bi bi-rss-fill link-primary"></i>
-        <a target="_blank" href="{$resource->GetSubscriptionUrl()->GetAtomUrl()}" class="link-primary">Atom</a>
-        <div class="vr mx-1"></div>
+        {if $IcsEnabled}
+            <i class="bi bi-calendar link-primary"></i>
+            <a target="_blank" href="{$resource->GetSubscriptionUrl()->GetWebcalUrl()}" class="link-primary">{translate key=SubscribeToCalendar}</a>
+            <div class="vr mx-1"></div>
+            <i class="bi bi-rss-fill link-primary"></i>
+            <a target="_blank" href="{$resource->GetSubscriptionUrl()->GetAtomUrl()}" class="link-primary">Atom</a>
+            <div class="vr mx-1"></div>
+        {/if}
         <i class="bi bi-display link-primary"></i>
         <a href="{$ScriptUrl}/{Pages::DISPLAY_RESOURCE}?{QueryStringKeys::RESOURCE_ID}={$resource->GetPublicId()}"
             class="link-primary">Display</a>
@@ -21,7 +25,7 @@
         <span>{translate key=PublicId}</span>
         <span class="propertyValue fw-bold">{$resource->GetPublicId()}</span>
     </div>
-{elseif !$resource->GetIsCalendarSubscriptionAllowed() && !$modeEdit}
+{elseif !$resource->GetIsCalendarSubscriptionAllowed() && !$modeEdit && $IcsEnabled}
     <div>
         <a class="update enableSubscription subscriptionButton link-primary" href="#">{translate key=TurnOnSubscription}</a>
     </div>

--- a/tpl/Admin/Schedules/manage_schedules.tpl
+++ b/tpl/Admin/Schedules/manage_schedules.tpl
@@ -263,21 +263,23 @@
 																	href="#">{translate key=Delete}</a>
 																<div class="vr"></div>
 															{/if}
-															{if $schedule->GetIsCalendarSubscriptionAllowed()}
-																<a class="update disableSubscription link-primary"
-																	href="#">{translate key=TurnOffSubscription}</a>
-																<div class="vr"></div>
-															{else}
-																<a class="update enableSubscription link-primary"
-																	href="#">{translate key=TurnOnSubscription}</a>
-															{/if}
-															{if $schedule->GetIsCalendarSubscriptionAllowed()}
-																<a target="_blank" class="link-primary"
-																	href="{$schedule->GetSubscriptionUrl()->GetAtomUrl()}"> <i
-																		class="bi bi-rss-fill link-primary me-1"></i>Atom</a>
-																<div class="vr"></div>
-																<a target="_blank" class="link-primary"
-																	href="{$schedule->GetSubscriptionUrl()->GetWebcalUrl()}">iCalendar</a>
+															{if $IcsEnabled}
+																{if $schedule->GetIsCalendarSubscriptionAllowed()}
+																	<a class="update disableSubscription link-primary"
+																		href="#">{translate key=TurnOffSubscription}</a>
+																	<div class="vr"></div>
+																{else}
+																	<a class="update enableSubscription link-primary"
+																		href="#">{translate key=TurnOnSubscription}</a>
+																{/if}
+																{if $schedule->GetIsCalendarSubscriptionAllowed()}
+																	<a target="_blank" class="link-primary"
+																		href="{$schedule->GetSubscriptionUrl()->GetAtomUrl()}"> <i
+																			class="bi bi-rss-fill link-primary me-1"></i>Atom</a>
+																	<div class="vr"></div>
+																	<a target="_blank" class="link-primary"
+																		href="{$schedule->GetSubscriptionUrl()->GetWebcalUrl()}">iCalendar</a>
+																{/if}
 															{/if}
 															{indicator id="action-indicator"}
 														</div>


### PR DESCRIPTION
NOTE: @lucs7 is the original author of this. Splitting PR #1425 into multiple commits to make reviewing easier.

Add a new `ics.enabled` boolean config key (default: true) that acts as a master on/off switch for ICS/Atom calendar subscription feeds.

When set to false:
- CalendarSubscriptionValidator returns false immediately, resulting in
  a 404 for any subscription request, with a debug log entry
- CalendarSubscriptionDetails::IsEnabled() short-circuits to false
- Subscription links and the bulk-edit "Turn On Subscription" control
  are hidden in the Manage Resources and Manage Schedules admin UIs
- SchedulePageBuilder suppresses the subscription URL, hiding
  subscription links in the end-user schedule view

Also fix indentation of the QR code link block in manage_resources.tpl.