### PR TITLE
refactor(ics): extract shared subscription page base

### DIFF
--- a/Pages/Export/AtomSubscriptionPage.php
+++ b/Pages/Export/AtomSubscriptionPage.php
@@ -1,48 +1,14 @@
 <?php
 
-require_once(ROOT_DIR . 'Presenters/CalendarSubscriptionPresenter.php');
-require_once(ROOT_DIR . 'lib/Application/Schedule/namespace.php');
-require_once(ROOT_DIR . 'lib/Application/Reservation/namespace.php');
-require_once(ROOT_DIR . 'Domain/Access/namespace.php');
-require_once(ROOT_DIR . 'Pages/Export/CalendarSubscriptionPage.php');
+require_once(ROOT_DIR . 'Pages/Export/SubscriptionPage.php');
 
 use FeedWriter\ATOM;
 
-class AtomSubscriptionPage extends Page implements ICalendarSubscriptionPage
+class AtomSubscriptionPage extends SubscriptionPage
 {
-    /**
-     * @var CalendarSubscriptionPresenter
-     */
-    private $presenter;
-
-    /**
-     * @var iCalendarReservationView[]
-     */
-    private $reservations = [];
-
     public function __construct()
     {
-        $authorization = new ReservationAuthorization(PluginManager::Instance()->LoadAuthorization());
-        $service = new CalendarSubscriptionService(new UserRepository(), new ResourceRepository(), new ScheduleRepository());
-        $subscriptionValidator = new CalendarSubscriptionValidator($this, $service);
-        $this->presenter = new CalendarSubscriptionPresenter(
-            $this,
-            new ReservationViewRepository(),
-            $subscriptionValidator,
-            $service,
-            new PrivacyFilter($authorization)
-        );
-        parent::__construct('', 1);
-    }
-
-    public function GetSubscriptionKey()
-    {
-        return $this->GetQuerystring(QueryStringKeys::SUBSCRIPTION_KEY);
-    }
-
-    public function GetUserId()
-    {
-        return $this->GetQuerystring(QueryStringKeys::USER_ID);
+        parent::__construct();
     }
 
     public function PageLoad(): void
@@ -85,45 +51,15 @@ class AtomSubscriptionPage extends Page implements ICalendarSubscriptionPage
         $feed->printFeed();
     }
 
-    public function SetReservations($reservations)
-    {
-        $this->reservations = $reservations;
-    }
-
-    public function GetScheduleId()
-    {
-        return $this->GetQuerystring(QueryStringKeys::SCHEDULE_ID);
-    }
-
-    public function GetResourceId()
-    {
-        return $this->GetQuerystring(QueryStringKeys::RESOURCE_ID);
-    }
-
     public function GetAccessoryIds()
     {
-        // no op
+        // Atom feed does not support accessory filtering
         return 0;
-    }
-
-    public function GetResourceGroupId()
-    {
-        return $this->GetQuerystring(QueryStringKeys::RESOURCE_GROUP_ID);
     }
 
     public function FormatReservationDescription(iCalendarReservationView $reservation, UserSession $user)
     {
         $factory = new SlotLabelFactory($user);
         return $factory->Format($reservation->ReservationItemView, Configuration::Instance()->GetKey(ConfigKeys::RESERVATION_LABELS_RSS_DESCRIPTION));
-    }
-
-    public function GetPastNumberOfDays()
-    {
-        return intval($this->GetQuerystring(QueryStringKeys::SUBSCRIPTION_DAYS_PAST));
-    }
-
-    public function GetFutureNumberOfDays()
-    {
-        return intval($this->GetQuerystring(QueryStringKeys::SUBSCRIPTION_DAYS_FUTURE));
     }
 }

--- a/Pages/Export/CalendarSubscriptionPage.php
+++ b/Pages/Export/CalendarSubscriptionPage.php
@@ -1,48 +1,13 @@
 <?php
 
+require_once(ROOT_DIR . 'Pages/Export/SubscriptionPage.php');
 require_once(ROOT_DIR . 'Pages/Export/CalendarExportDisplay.php');
-require_once(ROOT_DIR . 'lib/Application/Schedule/CalendarSubscriptionService.php');
-require_once(ROOT_DIR . 'lib/Application/Schedule/namespace.php');
-require_once(ROOT_DIR . 'lib/Application/Reservation/namespace.php');
-require_once(ROOT_DIR . 'Domain/Access/namespace.php');
-require_once(ROOT_DIR . 'Pages/Export/ICalendarSubscriptionPage.php');
-require_once(ROOT_DIR . 'Presenters/CalendarSubscriptionPresenter.php');
 
-class CalendarSubscriptionPage extends Page implements ICalendarSubscriptionPage
+class CalendarSubscriptionPage extends SubscriptionPage
 {
-    /**
-     * @var CalendarSubscriptionPresenter
-     */
-    private $presenter;
-
-    /**
-     * @var array|iCalendarReservationView[]
-     */
-    private $reservations = [];
-
     public function __construct()
     {
-        $authorization = new ReservationAuthorization(PluginManager::Instance()->LoadAuthorization());
-        $service = new CalendarSubscriptionService(new UserRepository(), new ResourceRepository(), new ScheduleRepository());
-        $icalSubscriptionValidator = new CalendarSubscriptionValidator($this, $service);
-        $this->presenter = new CalendarSubscriptionPresenter(
-            $this,
-            new ReservationViewRepository(),
-            $icalSubscriptionValidator,
-            $service,
-            new PrivacyFilter($authorization)
-        );
-        parent::__construct('', 1);
-    }
-
-    public function GetSubscriptionKey()
-    {
-        return $this->GetQuerystring(QueryStringKeys::SUBSCRIPTION_KEY);
-    }
-
-    public function GetUserId()
-    {
-        return $this->GetQuerystring(QueryStringKeys::USER_ID);
+        parent::__construct();
     }
 
     public function PageLoad(): void
@@ -57,40 +22,5 @@ class CalendarSubscriptionPage extends Page implements ICalendarSubscriptionPage
 
         $display = new CalendarExportDisplay();
         echo preg_replace('~\R~u', "\r\n", $display->Render($this->reservations));
-    }
-
-    public function SetReservations($reservations)
-    {
-        $this->reservations = $reservations;
-    }
-
-    public function GetScheduleId()
-    {
-        return $this->GetQuerystring(QueryStringKeys::SCHEDULE_ID);
-    }
-
-    public function GetResourceId()
-    {
-        return $this->GetQuerystring(QueryStringKeys::RESOURCE_ID);
-    }
-
-    public function GetAccessoryIds()
-    {
-        return intval($this->GetQuerystring(QueryStringKeys::ACCESSORY_ID));
-    }
-
-    public function GetResourceGroupId()
-    {
-        return $this->GetQuerystring(QueryStringKeys::RESOURCE_GROUP_ID);
-    }
-
-    public function GetPastNumberOfDays()
-    {
-        return intval($this->GetQuerystring(QueryStringKeys::SUBSCRIPTION_DAYS_PAST));
-    }
-
-    public function GetFutureNumberOfDays()
-    {
-        return intval($this->GetQuerystring(QueryStringKeys::SUBSCRIPTION_DAYS_FUTURE));
     }
 }

--- a/Pages/Export/SubscriptionPage.php
+++ b/Pages/Export/SubscriptionPage.php
@@ -1,0 +1,86 @@
+<?php
+
+require_once(ROOT_DIR . 'Pages/Page.php');
+require_once(ROOT_DIR . 'Pages/Export/ICalendarSubscriptionPage.php');
+require_once(ROOT_DIR . 'Presenters/CalendarSubscriptionPresenter.php');
+require_once(ROOT_DIR . 'lib/Application/Schedule/CalendarSubscriptionService.php');
+require_once(ROOT_DIR . 'lib/Application/Schedule/namespace.php');
+require_once(ROOT_DIR . 'lib/Application/Reservation/namespace.php');
+require_once(ROOT_DIR . 'Domain/Access/namespace.php');
+
+/**
+ * Abstract base class for calendar subscription feed pages (ICS, Atom, etc.).
+ *
+ * Provides:
+ *  - Shared presenter/service constructor wiring
+ *  - Common QueryString accessors used by CalendarSubscriptionValidator and the presenter
+ *
+ * Subclasses must implement PageLoad() to render the specific feed format.
+ */
+abstract class SubscriptionPage extends Page implements ICalendarSubscriptionPage
+{
+    protected CalendarSubscriptionPresenter $presenter;
+
+    /** @var iCalendarReservationView[] */
+    protected array $reservations = [];
+
+    protected function __construct()
+    {
+        $authorization = new ReservationAuthorization(PluginManager::Instance()->LoadAuthorization());
+        $service = new CalendarSubscriptionService(new UserRepository(), new ResourceRepository(), new ScheduleRepository());
+        $validator = new CalendarSubscriptionValidator($this, $service);
+        $this->presenter = new CalendarSubscriptionPresenter(
+            $this,
+            new ReservationViewRepository(),
+            $validator,
+            $service,
+            new PrivacyFilter($authorization)
+        );
+        parent::__construct('', 1);
+    }
+
+    public function SetReservations($reservations): void
+    {
+        $this->reservations = $reservations;
+    }
+
+    public function GetSubscriptionKey()
+    {
+        return $this->GetQuerystring(QueryStringKeys::SUBSCRIPTION_KEY);
+    }
+
+    public function GetUserId()
+    {
+        return $this->GetQuerystring(QueryStringKeys::USER_ID);
+    }
+
+    public function GetScheduleId()
+    {
+        return $this->GetQuerystring(QueryStringKeys::SCHEDULE_ID);
+    }
+
+    public function GetResourceId()
+    {
+        return $this->GetQuerystring(QueryStringKeys::RESOURCE_ID);
+    }
+
+    public function GetResourceGroupId()
+    {
+        return $this->GetQuerystring(QueryStringKeys::RESOURCE_GROUP_ID);
+    }
+
+    public function GetAccessoryIds()
+    {
+        return intval($this->GetQuerystring(QueryStringKeys::ACCESSORY_ID));
+    }
+
+    public function GetPastNumberOfDays()
+    {
+        return intval($this->GetQuerystring(QueryStringKeys::SUBSCRIPTION_DAYS_PAST));
+    }
+
+    public function GetFutureNumberOfDays()
+    {
+        return intval($this->GetQuerystring(QueryStringKeys::SUBSCRIPTION_DAYS_FUTURE));
+    }
+}


### PR DESCRIPTION
Move the duplicated constructor wiring, query-string accessors, and reservation buffer out of CalendarSubscriptionPage and AtomSubscriptionPage into a new abstract SubscriptionPage base class. Subclasses now contain only their format-specific PageLoad() logic.


Assisted-by: Claude:claude-sonnet-4-6