### PR TITLE
fix(ics): escape calendar text fields for RFC 5545

### DIFF
--- a/lib/Application/Schedule/iCalendarReservationView.php
+++ b/lib/Application/Schedule/iCalendarReservationView.php
@@ -59,13 +59,13 @@ class iCalendarReservationView
 
         $this->DateEnd = $res->EndDate;
         $this->DateStart = $res->StartDate;
-        $this->Description =  $canViewDetails ? $factory->Format($res, $summaryFormat) : $privateNotice;
+        $this->Description =  $canViewDetails ? self::toRfc5545Text($factory->Format($res, $summaryFormat)) : $privateNotice;
         $fullName = new FullName($res->OwnerFirstName, $res->OwnerLastName);
         $this->Organizer = $canViewUser ? $fullName->__toString() : $privateNotice;
         $this->OrganizerEmail = $canViewUser ? $res->OwnerEmailAddress : $privateNotice;
         $this->RecurRule = $this->CreateRecurRule($res);
         $this->ReferenceNumber = $res->ReferenceNumber;
-        $this->Summary = $canViewDetails ? $res->Title : $privateNotice;
+        $this->Summary = $canViewDetails ? self::toRfc5545Text($res->Title ?? '') : $privateNotice;
         $this->ReservationUrl = sprintf(
             '%s/%s?%s=%s',
             Configuration::Instance()->GetScriptUrl(),
@@ -85,6 +85,19 @@ class iCalendarReservationView
         }
 
         $this->ExtraIcalLines = method_exists($this->ExportFactory, 'GetIcalendarExtraLines') ? $this->ExportFactory->GetIcalendarExtraLines($res) : null;
+    }
+
+    /**
+     * Escapes a plain-text value for use in an iCalendar TEXT property (RFC 5545 §3.3.11).
+     * Backslashes, semicolons, and commas are escaped first; then newline sequences
+     * (\r\n, \n, \r) are replaced with the literal two-character escape \n so that
+     * calendar clients parse SUMMARY, DESCRIPTION, and any other TEXT property correctly.
+     */
+    private static function toRfc5545Text(string $value): string
+    {
+        // addcslashes prefixes each of '\', ',', and ';' with a backslash in a single pass.
+        $value = addcslashes($value, '\\,;');
+        return str_replace(["\r\n", "\n", "\r"], '\\n', $value);
     }
 
     /**

--- a/tests/Presenters/CalendarExportPresenterTest.php
+++ b/tests/Presenters/CalendarExportPresenterTest.php
@@ -148,6 +148,44 @@ class CalendarExportPresenterTest extends TestBase
         $this->assertEquals('Private', $reservationView->Description);
     }
 
+    public function testViewEscapesNewlinesInTextPropertiesForICalCompliance()
+    {
+        $user = new FakeUserSession();
+        $res = new ReservationItemView();
+        $res->UserId = $user->UserId;
+        $res->UserLevelId = ReservationUserLevel::OWNER;
+        $res->Title = "First line\r\nSecond line\nThird line";
+        $res->Description = "Alpha\r\nBeta\nGamma";
+        $res->StartDate = Date::Now();
+        $res->EndDate = Date::Now()->AddHours(1);
+
+        $this->privacyFilter->_CanViewDetails = true;
+
+        $reservationView = new iCalendarReservationView($res, $user, $this->privacyFilter, '{description}');
+
+        $this->assertEquals('First line\\nSecond line\\nThird line', $reservationView->Summary);
+        $this->assertEquals('Alpha\\nBeta\\nGamma', $reservationView->Description);
+    }
+
+    public function testViewEscapesBackslashSemicolonAndCommaInTextPropertiesForICalCompliance()
+    {
+        $user = new FakeUserSession();
+        $res = new ReservationItemView();
+        $res->UserId = $user->UserId;
+        $res->UserLevelId = ReservationUserLevel::OWNER;
+        $res->Title = 'x\\y;z,w';
+        $res->Description = 'a\\b;c,d';
+        $res->StartDate = Date::Now();
+        $res->EndDate = Date::Now()->AddHours(1);
+
+        $this->privacyFilter->_CanViewDetails = true;
+
+        $reservationView = new iCalendarReservationView($res, $user, $this->privacyFilter, '{description}');
+
+        $this->assertEquals('x\\\\y\\;z\\,w', $reservationView->Summary);
+        $this->assertEquals('a\\\\b\\;c\\,d', $reservationView->Description);
+    }
+
     public function testCalendarExportProdIdUsesApplicationVersionInsteadOfConfigValue()
     {
         $this->fakeConfig->SetKey('version', '9.9.9-user-config');


### PR DESCRIPTION
Escape iCalendar SUMMARY and DESCRIPTION text values so embedded newlines, commas, semicolons, and backslashes are emitted as RFC 5545 TEXT escapes.


Assisted-by: Codex:GPT-5