### PR TITLE
fix(ics): use reservation notes as description

### DIFF
--- a/lib/Application/Schedule/iCalendarReservationView.php
+++ b/lib/Application/Schedule/iCalendarReservationView.php
@@ -46,6 +46,17 @@ class iCalendarReservationView
         $canViewUser = $privacyFilter->CanViewUser($currentUser, $res, $res->OwnerId);
         $canViewDetails = $privacyFilter->CanViewDetails($currentUser, $res, $res->OwnerId);
 
+        // PrivacyFilter only gates on privacy.hide.reservation.details and privacy.hide.user.details.
+        // For anonymous (not logged-in) callers, also enforce privacy.view.reservations, which is the
+        // site-wide switch that controls whether unauthenticated visitors may see reservation details at all.
+        if (!$currentUser->IsLoggedIn()) {
+            $publicViewAllowed = Configuration::Instance()->GetKey(ConfigKeys::PRIVACY_VIEW_RESERVATIONS, new BooleanConverter());
+            if (!$publicViewAllowed) {
+                $canViewUser = false;
+                $canViewDetails = false;
+            }
+        }
+
         $this->ExportFactory = PluginManager::Instance()->LoadExport();
 
         $privateNotice = 'Private';
@@ -59,13 +70,13 @@ class iCalendarReservationView
 
         $this->DateEnd = $res->EndDate;
         $this->DateStart = $res->StartDate;
-        $this->Description =  $canViewDetails ? self::toRfc5545Text($factory->Format($res, $summaryFormat)) : $privateNotice;
+        $this->Summary = $canViewDetails ? self::toRfc5545Text($factory->Format($res, $summaryFormat)) : $privateNotice;
+        $this->Description = $canViewDetails ? self::toRfc5545Text($res->Description ?? '') : $privateNotice;
         $fullName = new FullName($res->OwnerFirstName, $res->OwnerLastName);
         $this->Organizer = $canViewUser ? $fullName->__toString() : $privateNotice;
         $this->OrganizerEmail = $canViewUser ? $res->OwnerEmailAddress : $privateNotice;
         $this->RecurRule = $this->CreateRecurRule($res);
         $this->ReferenceNumber = $res->ReferenceNumber;
-        $this->Summary = $canViewDetails ? self::toRfc5545Text($res->Title ?? '') : $privateNotice;
         $this->ReservationUrl = sprintf(
             '%s/%s?%s=%s',
             Configuration::Instance()->GetScriptUrl(),
@@ -80,7 +91,7 @@ class iCalendarReservationView
         $this->LastModified = empty($res->ModifiedDate) || $res->ModifiedDate->ToString() == '' ? $this->DateCreated : $res->ModifiedDate;
         $this->IsPending = $res->RequiresApproval;
 
-        if ($res->OwnerId == $currentUser->UserId) {
+        if ($canViewUser && $res->OwnerId == $currentUser->UserId) {
             $this->OrganizerEmail = str_replace('@', '-noreply@', $res->OwnerEmailAddress);
         }
 

--- a/tests/Presenters/CalendarExportPresenterTest.php
+++ b/tests/Presenters/CalendarExportPresenterTest.php
@@ -148,6 +148,67 @@ class CalendarExportPresenterTest extends TestBase
         $this->assertEquals('Private', $reservationView->Description);
     }
 
+    public function testViewShowsFormattedSummaryWhenDetailsVisible()
+    {
+        $user = new FakeUserSession();
+        $res = new ReservationItemView();
+        $res->UserId = $user->UserId;
+        $res->UserLevelId = ReservationUserLevel::OWNER;
+        $res->Title = 'My Booking Title';
+        $res->StartDate = Date::Now();
+        $res->EndDate = Date::Now()->AddHours(1);
+        $res->OwnerFirstName = 'Test';
+        $res->OwnerLastName = 'User';
+        $res->OwnerEmailAddress = 'test@example.com';
+
+        $this->privacyFilter->_CanViewDetails = true;
+
+        $reservationView = new iCalendarReservationView($res, $user, $this->privacyFilter, '{title}');
+
+        $this->assertEquals('My Booking Title', $reservationView->Summary);
+    }
+
+    public function testViewShowsDescriptionFromReservationNotesWhenDetailsVisible()
+    {
+        $user = new FakeUserSession();
+        $res = new ReservationItemView();
+        $res->Description = 'Booking notes';
+        $res->StartDate = Date::Now();
+        $res->EndDate = Date::Now()->AddHours(1);
+
+        $this->privacyFilter->_CanViewDetails = true;
+
+        $reservationView = new iCalendarReservationView($res, $user, $this->privacyFilter);
+
+        $this->assertEquals('Booking notes', $reservationView->Description);
+    }
+
+    public function testAnonymousUserSeesPrivateWhenPublicReservationViewingIsDisabled()
+    {
+        $user = new NullUserSession();
+        $res = new ReservationItemView();
+        $res->OwnerId = 42;
+        $res->OwnerFirstName = 'Alice';
+        $res->OwnerLastName = 'Smith';
+        $res->OwnerEmailAddress = 'alice@example.com';
+        $res->Title = 'Secret title';
+        $res->Description = 'Secret notes';
+        $res->StartDate = Date::Now();
+        $res->EndDate = Date::Now()->AddHours(1);
+
+        // privacy.view.reservations=false (default) means anonymous users must not see any details
+        $this->fakeConfig->SetKey(ConfigKeys::PRIVACY_VIEW_RESERVATIONS, false);
+        $this->privacyFilter->_CanViewDetails = true;
+        $this->privacyFilter->_CanViewUser = true;
+
+        $reservationView = new iCalendarReservationView($res, $user, $this->privacyFilter);
+
+        $this->assertEquals('Private', $reservationView->Summary);
+        $this->assertEquals('Private', $reservationView->Description);
+        $this->assertEquals('Private', $reservationView->Organizer);
+        $this->assertEquals('Private', $reservationView->OrganizerEmail);
+    }
+
     public function testViewEscapesNewlinesInTextPropertiesForICalCompliance()
     {
         $user = new FakeUserSession();
@@ -161,7 +222,7 @@ class CalendarExportPresenterTest extends TestBase
 
         $this->privacyFilter->_CanViewDetails = true;
 
-        $reservationView = new iCalendarReservationView($res, $user, $this->privacyFilter, '{description}');
+        $reservationView = new iCalendarReservationView($res, $user, $this->privacyFilter, '{title}');
 
         $this->assertEquals('First line\\nSecond line\\nThird line', $reservationView->Summary);
         $this->assertEquals('Alpha\\nBeta\\nGamma', $reservationView->Description);
@@ -180,7 +241,7 @@ class CalendarExportPresenterTest extends TestBase
 
         $this->privacyFilter->_CanViewDetails = true;
 
-        $reservationView = new iCalendarReservationView($res, $user, $this->privacyFilter, '{description}');
+        $reservationView = new iCalendarReservationView($res, $user, $this->privacyFilter, '{title}');
 
         $this->assertEquals('x\\\\y\\;z\\,w', $reservationView->Summary);
         $this->assertEquals('a\\\\b\\;c\\,d', $reservationView->Description);


### PR DESCRIPTION
Move the configured ICS label format into SUMMARY and emit reservation notes in DESCRIPTION so calendar clients receive the title/label and notes in their expected fields.

Assisted-by: Codex:GPT-5