### PR TITLE
fix(schedule): allow explicit label visibility bypass

### DIFF
--- a/lib/Application/Schedule/SlotLabelFactory.php
+++ b/lib/Application/Schedule/SlotLabelFactory.php
@@ -48,10 +48,15 @@ class SlotLabelFactory
 
     /**
      * @param ReservationItemView $reservation
-     * @param string $format
+     * @param string|null $format
+     * @param bool $skipVisibilityChecks When true, the privacy and permission gates
+     *        that normally suppress the label are not applied. The caller takes full
+     *        responsibility for having verified the viewer may see this reservation
+     *        (e.g. an ICS feed authorized by the user's secret subscription URL).
+     *        User-detail redaction from privacy.hide.user.details still applies.
      * @return string
      */
-    public function Format(ReservationItemView $reservation, $format = null)
+    public function Format(ReservationItemView $reservation, ?string $format = null, bool $skipVisibilityChecks = false)
     {
         $shouldHideUser = Configuration::Instance()->GetKey(ConfigKeys::PRIVACY_HIDE_USER_DETAILS, new BooleanConverter());
         $shouldHideDetails = ReservationDetailsFilter::HideReservationDetails($reservation->StartDate, $reservation->EndDate);
@@ -64,16 +69,18 @@ class SlotLabelFactory
             $shouldHideDetails = $shouldHideDetails && !$canEditResource && !$canSeeUserDetails;
         }
 
-        if ($shouldHideDetails) {
-            return '';
-        }
+        if (!$skipVisibilityChecks) {
+            if ($shouldHideDetails) {
+                return '';
+            }
 
-        if (!$shouldHideReservations && !$this->user->IsLoggedIn()) {
-            return '';
-        }
+            if (!$shouldHideReservations && !$this->user->IsLoggedIn()) {
+                return '';
+            }
 
-        if (!in_array($reservation->ResourceId, $this->UserResourcePermissions($this->user->UserId)) && !$reservation->IsUserOwner($this->user->UserId) && !$reservation->IsUserInvited($this->user->UserId) && !$reservation->IsUserParticipating($this->user->UserId)) {
-            return '';
+            if (!in_array($reservation->ResourceId, $this->UserResourcePermissions($this->user->UserId)) && !$reservation->IsUserOwner($this->user->UserId) && !$reservation->IsUserInvited($this->user->UserId) && !$reservation->IsUserParticipating($this->user->UserId)) {
+                return '';
+            }
         }
 
         if (empty($format)) {
@@ -84,7 +91,12 @@ class SlotLabelFactory
             return '';
         }
 
-        $name = $shouldHideUser ? Resources::GetInstance()->GetString('Private') : $this->GetFullName($reservation);
+        $privateNotice = Resources::GetInstance()->GetString('Private');
+        $name = $shouldHideUser ? $privateNotice : $this->GetFullName($reservation);
+        $email = $shouldHideUser ? $privateNotice : ($reservation->OwnerEmailAddress ?? '');
+        $organization = $shouldHideUser ? $privateNotice : ($reservation->OwnerOrganization ?? '');
+        $phone = $shouldHideUser ? $privateNotice : ($reservation->OwnerPhone ?? '');
+        $position = $shouldHideUser ? $privateNotice : ($reservation->OwnerPosition ?? '');
 
         $timezone = 'UTC';
         $dateFormat = Resources::GetInstance()->GetDateFormat('res_popup');
@@ -95,16 +107,19 @@ class SlotLabelFactory
         $label = str_replace('{name}', $name ?? '', $label);
         $label = str_replace('{title}', $reservation->Title ?? '', $label);
         $label = str_replace('{description}', $reservation->Description ?? '', $label);
-        $label = str_replace('{email}', $reservation->OwnerEmailAddress, $label);
-        $label = str_replace('{organization}', $reservation->OwnerOrganization ?? '', $label);
-        $label = str_replace('{phone}', $reservation->OwnerPhone ?? '', $label);
-        $label = str_replace('{position}', $reservation->OwnerPosition ?? '', $label);
+        $label = str_replace('{email}', $email, $label);
+        $label = str_replace('{organization}', $organization, $label);
+        $label = str_replace('{phone}', $phone, $label);
+        $label = str_replace('{position}', $position, $label);
         $label = str_replace('{startdate}', $reservation->StartDate->ToTimezone($timezone)->Format($dateFormat), $label);
         $label = str_replace('{enddate}', $reservation->EndDate->ToTimezone($timezone)->Format($dateFormat), $label);
         $label = str_replace('{resourcename}', implode(', ', $reservation->ResourceNames), $label);
         if (!$shouldHideUser) {
             $label = str_replace('{participants}', trim(implode(', ', $reservation->ParticipantNames)), $label);
             $label = str_replace('{invitees}', trim(implode(', ', $reservation->InviteeNames)), $label);
+        } else {
+            $label = str_replace('{participants}', '', $label);
+            $label = str_replace('{invitees}', '', $label);
         }
 
         $matches = [];
@@ -171,7 +186,7 @@ class SlotLabelFactory
 
 class NullSlotLabelFactory extends SlotLabelFactory
 {
-    public function Format(ReservationItemView $reservation, $format = null)
+    public function Format(ReservationItemView $reservation, ?string $format = null, bool $skipVisibilityChecks = false)
     {
         return '';
     }

--- a/tests/Presenters/CalendarExportPresenterTest.php
+++ b/tests/Presenters/CalendarExportPresenterTest.php
@@ -247,6 +247,70 @@ class CalendarExportPresenterTest extends TestBase
         $this->assertEquals('a\\\\b\\;c\\,d', $reservationView->Description);
     }
 
+    public function testSlotLabelFormatCanExplicitlySkipVisibilityChecks()
+    {
+        $user = new NullUserSession();
+        $res = new ReservationItemView();
+        $res->Title = 'Public Meeting';
+        $res->StartDate = Date::Now();
+        $res->EndDate = Date::Now()->AddHours(1);
+
+        $this->fakeConfig->SetKey(ConfigKeys::PRIVACY_VIEW_RESERVATIONS, false);
+
+        $factory = new SlotLabelFactory($user, new FakeAuthorizationService());
+
+        $this->assertEquals('', $factory->Format($res, '{title}'));
+        $this->assertEquals('Public Meeting', $factory->Format($res, '{title}', skipVisibilityChecks: true));
+    }
+
+    public function testSlotLabelFormatStillRedactsUserTokensWhenSkippingVisibilityChecks()
+    {
+        $user = new FakeUserSession(false, 'America/New_York', 7);
+        $auth = new FakeAuthorizationService();
+        $auth->_CanEditForResource = false;
+
+        $res = new ReservationItemView();
+        $res->OwnerId = 42;
+        $res->FirstName = 'Alice';
+        $res->LastName = 'Smith';
+        $res->OwnerEmailAddress = 'alice@example.com';
+        $res->OwnerPhone = '555-1234';
+        $res->OwnerOrganization = 'Engineering';
+        $res->OwnerPosition = 'Manager';
+        $res->ParticipantNames = ['Participant One'];
+        $res->InviteeNames = ['Invitee One'];
+        $res->StartDate = Date::Now();
+        $res->EndDate = Date::Now()->AddHours(1);
+
+        $this->fakeConfig->SetKey(ConfigKeys::PRIVACY_HIDE_USER_DETAILS, true);
+
+        $factory = new SlotLabelFactory($user, $auth);
+        $label = $factory->Format(
+            $res,
+            '{name} {email} {phone} {organization} {position} {participants} {invitees}',
+            skipVisibilityChecks: true
+        );
+
+        $this->assertStringContainsString('Private', $label);
+        $this->assertStringNotContainsString('Alice', $label);
+        $this->assertStringNotContainsString('alice@example.com', $label);
+        $this->assertStringNotContainsString('555-1234', $label);
+        $this->assertStringNotContainsString('Engineering', $label);
+        $this->assertStringNotContainsString('Manager', $label);
+        $this->assertStringNotContainsString('Participant One', $label);
+        $this->assertStringNotContainsString('Invitee One', $label);
+    }
+
+    public function testNullSlotLabelFactoryRemainsFailClosedWhenSkippingVisibilityChecks()
+    {
+        $res = new ReservationItemView();
+        $res->Title = 'Public Meeting';
+
+        $factory = new NullSlotLabelFactory();
+
+        $this->assertEquals('', $factory->Format($res, '{title}', skipVisibilityChecks: true));
+    }
+
     public function testCalendarExportProdIdUsesApplicationVersionInsteadOfConfigValue()
     {
         $this->fakeConfig->SetKey('version', '9.9.9-user-config');


### PR DESCRIPTION
Add an explicit skipVisibilityChecks argument to
SlotLabelFactory::Format for callers that have already authorized reservation details. Keep the default path unchanged and keep NullSlotLabelFactory fail-closed.


Assisted-by: Codex:GPT-5