### PR TITLE
fix(reservations): prevent false success for no-op updates

### DIFF
--- a/lib/Application/Reservation/Validation/PreReservationFactory.php
+++ b/lib/Application/Reservation/Validation/PreReservationFactory.php
@@ -149,6 +149,7 @@ class PreReservationFactory implements IPreReservationFactory
 
     private function CreateUpdateService(ReservationValidationRuleProcessor $ruleProcessor, UserSession $userSession)
     {
+        $ruleProcessor->AddRule(new ReservationInstancesRule());
         if (Configuration::Instance()->GetKey(ConfigKeys::RESERVATION_UPDATES_REQUIRE_APPROVAL, new BooleanConverter())) {
             $ruleProcessor->AddRule(new AdminExcludedRule(new RequiresApprovalRule(PluginManager::Instance()->LoadAuthorization()), $userSession, $this->userRepository));
         }
@@ -160,6 +161,7 @@ class PreReservationFactory implements IPreReservationFactory
 
     private function CreateDeleteService(ReservationValidationRuleProcessor $ruleProcessor, UserSession $userSession)
     {
+        $ruleProcessor->AddRule(new ReservationInstancesRule());
         $ruleProcessor->AddRule(new AdminExcludedRule(new ResourceMinimumNoticeRuleDelete($userSession), $userSession, $this->userRepository));
         $ruleProcessor->AddRule(new AdminExcludedRule(new CurrentUserIsReservationUserRule($userSession), $userSession, $this->userRepository));
         return new DeleteReservationValidationService($ruleProcessor);

--- a/lib/Application/Reservation/Validation/ReservationInstancesRule.php
+++ b/lib/Application/Reservation/Validation/ReservationInstancesRule.php
@@ -1,0 +1,13 @@
+<?php
+
+class ReservationInstancesRule implements IReservationValidationRule
+{
+    public function Validate($reservationSeries, $retryParameters)
+    {
+        if (count($reservationSeries->Instances()) === 0) {
+            return new ReservationRuleResult(false, Resources::GetInstance()->GetString('StartIsInPast'));
+        }
+
+        return new ReservationRuleResult();
+    }
+}

--- a/lib/Application/Reservation/Validation/namespace.php
+++ b/lib/Application/Reservation/Validation/namespace.php
@@ -16,6 +16,7 @@ require_once(ROOT_DIR . 'lib/Application/Reservation/Validation/ResourceAvailabi
 require_once(ROOT_DIR . 'lib/Application/Reservation/Validation/ExistingResourceAvailabilityRule.php');
 require_once(ROOT_DIR . 'lib/Application/Reservation/Validation/ReservationDateTimeRule.php');
 require_once(ROOT_DIR . 'lib/Application/Reservation/Validation/ReservationOverlappingRule.php');
+require_once(ROOT_DIR . 'lib/Application/Reservation/Validation/ReservationInstancesRule.php');
 require_once(ROOT_DIR . 'lib/Application/Reservation/Validation/ReservationStartTimeRule.php');
 require_once(ROOT_DIR . 'lib/Application/Reservation/Validation/PermissionValidationRule.php');
 require_once(ROOT_DIR . 'lib/Application/Reservation/Validation/ReservationRuleResult.php');

--- a/tests/Application/Reservation/ReservationInstancesRuleTest.php
+++ b/tests/Application/Reservation/ReservationInstancesRuleTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+class ReservationInstancesRuleTest extends TestBase
+{
+    public function testInvalidIfSelectedScopeHasNoReservationInstances()
+    {
+        Date::_SetNow(Date::Parse('2026-06-14 12:00:00', 'UTC'));
+        $this->fakeConfig->SetKey(ConfigKeys::RESERVATION_START_TIME_CONSTRAINT, ReservationStartTimeConstraint::FUTURE);
+
+        $series = $this->BuildExistingSeries(
+            Date::Parse('2026-06-14 11:00:00', 'UTC'),
+            Date::Parse('2026-06-14 11:30:00', 'UTC')
+        );
+        $series->ApplyChangesTo(SeriesUpdateScope::FullSeries);
+
+        $result = (new ReservationInstancesRule())->Validate($series, null);
+
+        $this->assertFalse($result->IsValid());
+        $this->assertEquals('StartIsInPast', $result->ErrorMessage());
+    }
+
+    public function testValidIfSelectedScopeHasReservationInstances()
+    {
+        Date::_SetNow(Date::Parse('2026-06-14 12:00:00', 'UTC'));
+        $this->fakeConfig->SetKey(ConfigKeys::RESERVATION_START_TIME_CONSTRAINT, ReservationStartTimeConstraint::FUTURE);
+
+        $series = $this->BuildExistingSeries(
+            Date::Parse('2026-06-14 13:00:00', 'UTC'),
+            Date::Parse('2026-06-14 13:30:00', 'UTC')
+        );
+        $series->ApplyChangesTo(SeriesUpdateScope::FullSeries);
+
+        $result = (new ReservationInstancesRule())->Validate($series, null);
+
+        $this->assertTrue($result->IsValid());
+    }
+
+    private function BuildExistingSeries(Date $start, Date $end): ExistingReservationSeries
+    {
+        $series = new ExistingReservationSeries();
+        $reservation = new Reservation($series, new DateRange($start, $end));
+
+        $series->WithCurrentInstance($reservation);
+        $series->WithRepeatOptions(new RepeatNone());
+        $series->WithPrimaryResource(new FakeBookableResource(1));
+        $series->UpdateBookedBy($this->fakeUser);
+
+        return $series;
+    }
+}


### PR DESCRIPTION
When start time constraints filter all selected reservation instances out of an update or delete operation, validation still passed and the UI reported success even though nothing was changed.

Add a validation rule for update and delete operations that fails when the selected scope contains no affected reservation instances. This preserves the current restriction for active or past reservations while showing the existing start-time constraint error instead of a misleading success message.

Note: this does not grant resource administrators the ability to act on active reservations — that requires extending the Instances() bypass (currently limited to application admins) to cover resource admins as well.

Closes: #1430
Assisted-by: Codex:GPT-5