### PR TITLE
fix(payments): require php-intl extension for currency formatting

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -39,7 +39,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: '8.5'
-          extensions: mysqli, pdo_mysql
+          extensions: intl, mysqli, pdo_mysql
 
       - name: Install Composer dependencies
         uses: ramsey/composer-install@v4

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,7 +48,7 @@ This file contains essential information for AI coding agents working on the Lib
 
 ### Prerequisites
 
-- PHP >= 8.2 with extensions: ctype, curl, fileinfo, json, ldap, mbstring, mysqli, openssl, pdo, pdo_mysql, tokenizer, xml
+- PHP >= 8.2 with extensions: ctype, curl, fileinfo, intl, json, ldap, mbstring, mysqli, openssl, pdo, pdo_mysql, tokenizer, xml
 - Optional PHP extensions: bcmath, gd
 - Composer for dependency management
 - MySQL >= 8.0 (2018) or MariaDB >= 10.6 (2021) for database

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Note: This instance is public and **resets every 20 minutes** to ensure a clean 
 
 To run LibreBooking from a prebuilt release, your server needs:
 
-- PHP >= 8.2 with the extensions: ctype, curl, fileinfo, json, mbstring, mysqli, openssl, pdo, pdo_mysql, tokenizer, xml
+- PHP >= 8.2 with the extensions: ctype, curl, fileinfo, intl, json, mbstring, mysqli, openssl, pdo, pdo_mysql, tokenizer, xml
 - Optional PHP extensions: bcmath (needed for Active Directory authentication), gd (image processing), ldap (LDAP authentication)
 - A web server like Apache or Nginx
 - MySQL >= 8.0 (2018) or MariaDB >= 10.6 (2021)

--- a/composer.json
+++ b/composer.json
@@ -32,6 +32,7 @@
         "mashape/unirest-php": "^3.0",
         "vlucas/phpdotenv": "^5.6",
         "pear/net_ldap2": "^2.3",
+        "ext-intl": "*",
         "ext-ldap": "*",
         "symfony/html-sanitizer": "^7.4",
         "league/uri": "^7.8"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c236483334b4c5dd27826937a4e4a305",
+    "content-hash": "917e3d4737dcad1c515bc0214f22f7c3",
     "packages": [
         {
             "name": "bacon/bacon-qr-code",
@@ -9208,6 +9208,7 @@
     "prefer-lowest": false,
     "platform": {
         "php": ">=8.2",
+        "ext-intl": "*",
         "ext-ldap": "*"
     },
     "platform-dev": {},

--- a/lib/preflight.php
+++ b/lib/preflight.php
@@ -43,6 +43,7 @@ class PreflightRunner
         'ctype',
         'curl',
         'fileinfo',
+        'intl',
         'json',
         'ldap',
         'mbstring',


### PR DESCRIPTION
The intl extension (NumberFormatter) is required for correct currency formatting of non-USD currencies. Without it, the Payments feature displayed a raw HTML error string in place of the formatted amount.

Make intl a hard requirement so the problem is caught at install time rather than silently producing a broken UI at runtime:

- Add ext-intl to composer.json require (Composer enforces on install)
- Add intl to REQUIRED_EXTENSIONS in lib/preflight.php
- Add intl to the extensions list in integration-tests.yml CI workflow
- Update README.md and AGENTS.md prerequisites to include intl

Closes: #800
Assisted-by: Claude:claude-sonnet-4-6