### PR TITLE
Refactor Microsoft Auth into a testable class with expanded error handling

### DIFF
--- a/Web/microsoft-auth.php
+++ b/Web/microsoft-auth.php
@@ -3,13 +3,17 @@
 define('ROOT_DIR', '../');
 
 require_once(ROOT_DIR . 'lib/Common/namespace.php');
+require_once(ROOT_DIR . 'lib/Application/Authentication/MicrosoftOAuthCallback.php');
 
-//Checks if the user was authenticated by microsoft and redirects to external authentication page
-if (isset($_GET['code'])) {
-    $code = filter_input(INPUT_GET, 'code');
-    header('Location: '.ROOT_DIR.'Web/external-auth.php?type=microsoft&code='.$code);
-    exit;
-} else {
-    header('Location:'.ROOT_DIR.'Web');
-    exit();
+$result = (new MicrosoftOAuthCallback())->handle(
+    params: $_GET,
+    externalAuthUrl: ROOT_DIR . 'Web/external-auth.php',
+    failureRedirectURL: ROOT_DIR . 'Web',
+);
+
+if ($result->isError()) {
+    Log::Error('Microsoft OAuth error: %s - %s', $result->error, $result->getErrorDescription());
 }
+
+header('Location: ' . $result->redirectURL);
+exit;

--- a/lib/Application/Authentication/MicrosoftOAuthCallback.php
+++ b/lib/Application/Authentication/MicrosoftOAuthCallback.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * Microsoft's OAuth callback outcome — either a redirect to external-auth or a redirect to home on error.
+ */
+class MicrosoftOAuthCallbackResult
+{
+    private function __construct(
+        public readonly string $redirectURL,
+        public readonly ?string $error = null,
+        private readonly ?string $errorDescription = null,
+    ) {
+    }
+
+    public static function success(string $redirectURL): self
+    {
+        return new self($redirectURL);
+    }
+
+    public static function failed(string $failureRedirectURL, string $error, ?string $errorDescription = null): self
+    {
+        return new self($failureRedirectURL, $error, $errorDescription);
+    }
+
+    public function isError(): bool
+    {
+        return $this->error !== null;
+    }
+
+    public function getErrorDescription(): string
+    {
+        return $this->errorDescription ?? 'No error description was provided.';
+    }
+}
+/**
+ * Handler for Microsoft OAuth workflows.
+ */
+class MicrosoftOAuthCallback
+{
+    /**
+     * Resolves the redirect target from Microsoft's OAuth callback parameters.
+     *
+     * Microsoft sends either:
+     *   - success: ?code=...&state=...
+     *   - error:   ?error=...&error_description=...
+     *
+     * @param array<string, mixed>  $params        Usually $_GET; values may be non-strings (e.g. arrays)
+     * @param string                $externalAuthUrl  URL of external-auth handler (without query string)
+     * @param string                $failureRedirectURL           Fallback URL for errors or missing params
+     */
+    public function handle(array $params, string $externalAuthUrl, string $failureRedirectURL): MicrosoftOAuthCallbackResult
+    {
+        $error = $params['error'] ?? null;
+        if (is_string($error) && $error !== '') {
+            $description = $params['error_description'] ?? null;
+            return MicrosoftOAuthCallbackResult::failed(
+                $failureRedirectURL,
+                $error,
+                is_string($description) ? $description : null,
+            );
+        }
+
+        $code = $params['code'] ?? null;
+        if (is_string($code) && $code !== '') {
+            $url = $externalAuthUrl . '?type=microsoft&code=' . urlencode($code);
+            return MicrosoftOAuthCallbackResult::success($url);
+        }
+
+        return MicrosoftOAuthCallbackResult::failed($failureRedirectURL, 'missing_code');
+    }
+}

--- a/tests/Application/Authentication/MicrosoftOAuthCallbackTest.php
+++ b/tests/Application/Authentication/MicrosoftOAuthCallbackTest.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+require_once(ROOT_DIR . 'lib/Application/Authentication/MicrosoftOAuthCallback.php');
+
+class MicrosoftOAuthCallbackTest extends TestBase
+{
+    private MicrosoftOAuthCallback $msAuthHandler;
+    private string $externalAuthUrl = 'http://localhost/external-auth.php';
+    private string $failureRedirectURL = 'http://localhost/Web';
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->msAuthHandler = new MicrosoftOAuthCallback();
+    }
+
+    public function testSuccessRedirectsToExternalAuthWithCode(): void
+    {
+        $result = $this->msAuthHandler->handle(
+            ['code' => 'abc123', 'state' => 'xyz'],
+            $this->externalAuthUrl,
+            $this->failureRedirectURL,
+        );
+
+        $this->assertFalse($result->isError());
+        $this->assertEquals(
+            'http://localhost/external-auth.php?type=microsoft&code=abc123',
+            $result->redirectURL,
+        );
+    }
+
+    public function testSuccessUrlEncodesCode(): void
+    {
+        $result = $this->msAuthHandler->handle(
+            ['code' => 'code with spaces & special=chars'],
+            $this->externalAuthUrl,
+            $this->failureRedirectURL,
+        );
+
+        $this->assertStringContainsString('code=code+with+spaces+%26+special%3Dchars', $result->redirectURL);
+    }
+
+    public function testErrorRedirectsHome(): void
+    {
+        $result = $this->msAuthHandler->handle(
+            ['error' => 'access_denied', 'error_description' => 'the user canceled the authentication'],
+            $this->externalAuthUrl,
+            $this->failureRedirectURL,
+        );
+
+        $this->assertTrue($result->isError());
+        $this->assertEquals($this->failureRedirectURL, $result->redirectURL);
+        $this->assertEquals('access_denied', $result->error);
+        $this->assertEquals('the user canceled the authentication', $result->getErrorDescription());
+    }
+
+    public function testErrorWithoutDescriptionReturnsHomeAsTarget(): void
+    {
+        $result = $this->msAuthHandler->handle(
+            ['error' => 'server_error'],
+            $this->externalAuthUrl,
+            $this->failureRedirectURL,
+        );
+
+        $this->assertTrue($result->isError());
+        $this->assertEquals('server_error', $result->error);
+        $this->assertEquals($this->failureRedirectURL, $result->redirectURL);
+    }
+    // Azure shouldn't send both, but we defensively treat error as authoritative
+    // in case of malformed/tampered query strings.
+    public function testErrorTakesPrecedenceOverCode(): void
+    {
+        $result = $this->msAuthHandler->handle(
+            ['error' => 'access_denied', 'code' => 'abc123'],
+            $this->externalAuthUrl,
+            $this->failureRedirectURL,
+        );
+
+        $this->assertTrue($result->isError());
+        $this->assertEquals($this->failureRedirectURL, $result->redirectURL);
+    }
+
+    public function testMissingParamsRedirectsHome(): void
+    {
+        $result = $this->msAuthHandler->handle(
+            [],
+            $this->externalAuthUrl,
+            $this->failureRedirectURL,
+        );
+
+        $this->assertTrue($result->isError());
+        $this->assertEquals($this->failureRedirectURL, $result->redirectURL);
+        $this->assertEquals('missing_code', $result->error);
+    }
+}


### PR DESCRIPTION
## Summary

`Web/microsoft-auth.php` previously handled only the success path of
Microsoft's OAuth 2.0 authorization code flow. Per the Microsoft identity
platform docs, the callback endpoint receives two distinct response shapes:

- Success: `?code=...&state=...`
- Error:   `?error=...&error_description=...`

Error responses were silently ignored — the page would redirect to
`Web` with no `error` header, causing a confusing failure
downstream with no diagnostic information.

## Changes

- Extract callback logic into `MicrosoftOAuthCallback` (lib/Application/Authentication/)
  with a `MicrosoftOAuthCallbackResult` value object representing the two
  outcome cases. This makes the code more testable.
- Handle error responses from Azure: redirect to home and log the error/description
- unit tests covering success, URL encoding, error with/without description,
  error-takes-precedence-over-code, and missing params
- Add `workflow_dispatch` trigger to CI workflows to allow manual runs on forks so contributors can make sure PRs will pass CI before submitting to upstream

## Not addressed in this PR

- `state` parameter verification — the Microsoft docs recommend verifying the
  returned `state` matches the value sent in the authorization request as a
  CSRF mitigation. This would require storing the state server-side before the
  redirect, which is a larger change.

Any feedback on testing & class design would be appreicated.
