### PR TITLE
refactor(custom-attributes): replace ID column with name and prefixed…

### DIFF
--- a/tpl/Admin/Attributes/attribute-list.tpl
+++ b/tpl/Admin/Attributes/attribute-list.tpl
@@ -5,9 +5,9 @@
 		<table class="table table-striped table-hover border-top w-100" id="{$tableId}">
 			<thead>
 				<tr>
-					<th class="d-none">ID</th>
-					<th>{translate key=SortOrder}</th>
 					<th>{translate key=DisplayLabel}</th>
+					<th>ID</th>
+					<th>{translate key=SortOrder}</th>
 					<th>{translate key=Type}</th>
 					<th>{translate key=Required}</th>
 					{if $Category != CustomAttributeCategory::RESERVATION}
@@ -27,9 +27,9 @@
 			<tbody>
 				{foreach from=$Attributes item=attribute}
 					<tr attributeId="{$attribute->Id()}">
-						<td class="d-none">{$attribute->Id()}</td>
-						<td>{$attribute->SortOrder()}</td>
 						<td>{$attribute->Label()}</td>
+						<td data-order="{$attribute->Id()}">att{$attribute->Id()}</td>
+						<td>{$attribute->SortOrder()}</td>
 						<td>{translate key=$Types[$attribute->Type()]}</td>
 						<td>{if $attribute->Required()}
 								{translate key=Yes}


### PR DESCRIPTION
… identifier
<img width="450" height="252" alt="image" src="https://github.com/user-attachments/assets/68ad5025-c693-4836-ab17-dd96b5e289a9" />

- Show Name column as the primary human-readable identifier
- Display ID with "att" prefix (e.g. att123) for better usability in configuration contexts
- Improve usability of identifiers for potential use in config.php and other system configurations

This change improves table readability by removing low-value technical identifiers while preserving a functional and reusable reference format for developers and configuration usage.