### PR TITLE
fix(pages): delegate RedirectResume in page decorators to fix TypeError

### DIFF
--- a/Pages/Admin/AdminPage.php
+++ b/Pages/Admin/AdminPage.php
@@ -27,6 +27,11 @@ class AdminPageDecorator extends ActionPage implements IActionPage
         $this->page->PageLoad();
     }
 
+    public function RedirectResume($url)
+    {
+        $this->page->RedirectResume($url);
+    }
+
     public function IsValid()
     {
         return $this->page->IsValid();

--- a/Pages/SecurePage.php
+++ b/Pages/SecurePage.php
@@ -89,6 +89,11 @@ class SecureActionPageDecorator extends ActionPage
         $this->page->Redirect($url);
     }
 
+    public function RedirectResume($url)
+    {
+        $this->page->RedirectResume($url);
+    }
+
     public function RedirectToError($errorMessageId = ErrorMessages::UNKNOWN_ERROR, $lastPage = '')
     {
         $this->page->RedirectToError($errorMessageId, $lastPage);
@@ -174,6 +179,11 @@ class SecurePageDecorator extends Page implements IPage
     public function Redirect($url)
     {
         $this->page->Redirect($url);
+    }
+
+    public function RedirectResume($url)
+    {
+        $this->page->RedirectResume($url);
     }
 
     public function RedirectToError($errorMessageId = ErrorMessages::UNKNOWN_ERROR, $lastPage = '')

--- a/tests/Integration/SmokeTest.php
+++ b/tests/Integration/SmokeTest.php
@@ -323,6 +323,51 @@ class SmokeTest extends TestCase
         $this->assertPhpErrorFree(body: $body);
     }
 
+    #[\PHPUnit\Framework\Attributes\DataProvider('unauthenticatedSecurePagesProvider')]
+    public function testUnauthenticatedSecurePageRedirectsToLogin(string $path, string $label): void
+    {
+        $client = self::createClient(new CookieJar());
+
+        $response = $client->get($path);
+
+        $this->assertSame(
+            200,
+            $response->getStatusCode(),
+            "Unauthenticated request to $label ($path) did not return HTTP 200 (expected redirect to login)"
+        );
+
+        $redirectHistory = implode(' ', $response->getHeader('X-Guzzle-Redirect-History'));
+        $this->assertNotEmpty(
+            $redirectHistory,
+            "Unauthenticated request to $label ($path) did not issue an HTTP redirect (expected redirect to login)"
+        );
+        $this->assertStringContainsString(
+            '/Web/index.php',
+            $redirectHistory,
+            "Unauthenticated request to $label ($path) did not redirect to the login page"
+        );
+
+        $body = (string) $response->getBody();
+        $this->assertPhpErrorFree(body: $body);
+        $this->assertStringContainsString(
+            'name="login"',
+            $body,
+            "Unauthenticated request to $label ($path) did not redirect to the login form"
+        );
+    }
+
+    /**
+     * @return array<string, array{string, string}>
+     */
+    public static function unauthenticatedSecurePagesProvider(): array
+    {
+        return [
+            'schedule (SecurePageDecorator)' => ['/Web/schedule.php', 'Schedule'],
+            'profile (SecureActionPageDecorator)' => ['/Web/profile.php', 'Profile'],
+            'manage-groups admin (AdminPageDecorator)' => ['/Web/admin/manage_groups.php', 'Manage Groups'],
+        ];
+    }
+
     /**
      * @return array<string, array{string, string}>
      */


### PR DESCRIPTION
SecurePageDecorator, SecureActionPageDecorator, and AdminPageDecorator all extend Page but skip parent::__construct(), leaving $this->path as null. When an unauthenticated request triggers a redirect, the inherited Page::RedirectResume() calls SanitizeRedirectUrl() which passes null to RedirectUrlSanitizer::Sanitize(string $path), causing a fatal TypeError on PHP 8 and an HTTP 500 response instead of a redirect to login.

The fix overrides RedirectResume() in all three decorators to delegate to $this->page->RedirectResume(), consistent with how Redirect() and RedirectToError() are already handled in the same classes.

Adds an integration smoke test covering one unauthenticated request per decorator class to prevent regression.

Closes: #1506
Assisted-by: Claude:claude-opus-4-8