### PR TITLE
feat(ics): add HTTP Basic Authentication for subscription feeds

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -450,6 +450,9 @@ LB_ICS_FUTURE_DAYS=30
 # Number of past days to include in ICS feeds
 LB_ICS_PAST_DAYS=0
 
+# Enable HTTP Basic Authentication on ICS calendar subscription URLs (true/false)
+LB_ICS_BASIC_AUTH=false
+
 #############################
 # Data Retention and Deletion
 #############################

--- a/Pages/Export/AtomSubscriptionPage.php
+++ b/Pages/Export/AtomSubscriptionPage.php
@@ -11,13 +11,9 @@ class AtomSubscriptionPage extends SubscriptionPage
         parent::__construct();
     }
 
-    public function PageLoad(): void
+    protected function renderFeed(): void
     {
         ob_clean();
-        if (!$this->presenter->PageLoad()) {
-            http_response_code(404);
-            return;
-        }
 
         $config = Configuration::Instance();
 

--- a/Pages/Export/CalendarSubscriptionPage.php
+++ b/Pages/Export/CalendarSubscriptionPage.php
@@ -10,13 +10,8 @@ class CalendarSubscriptionPage extends SubscriptionPage
         parent::__construct();
     }
 
-    public function PageLoad(): void
+    protected function renderFeed(): void
     {
-        if (!$this->presenter->PageLoad()) {
-            http_response_code(404);
-            return;
-        }
-
         header('Content-Type: text/Calendar');
         header('Content-Disposition: inline; filename=calendar.ics');
 

--- a/Pages/Export/ICalendarSubscriptionPage.php
+++ b/Pages/Export/ICalendarSubscriptionPage.php
@@ -18,6 +18,14 @@ interface ICalendarSubscriptionPage
     public function SetReservations($reservations);
 
     /**
+     * Signal that the current request should be aborted. Implementations set a
+     * flag that PageLoad() checks after each step; the HTTP status code (404 for
+     * an invalid subscription key, 401 for a Basic Auth failure) is set by the
+     * caller before invoking this method.
+     */
+    public function SetIsNotFound(): void;
+
+    /**
      * @return string
      */
     public function GetScheduleId();
@@ -46,4 +54,12 @@ interface ICalendarSubscriptionPage
      * @return int
      */
     public function GetFutureNumberOfDays();
+
+    /**
+     * Returns the per-request UserSession established by Basic Auth, or null when
+     * the request is icskey-only / no Basic Auth occurred. The presenter uses this
+     * as the active session when set, instead of consulting the server session —
+     * the feed session is intentionally NOT persisted to $_SESSION.
+     */
+    public function GetFeedUserSession(): ?UserSession;
 }

--- a/Pages/Export/SubscriptionPage.php
+++ b/Pages/Export/SubscriptionPage.php
@@ -6,6 +6,7 @@ require_once(ROOT_DIR . 'Presenters/CalendarSubscriptionPresenter.php');
 require_once(ROOT_DIR . 'lib/Application/Schedule/CalendarSubscriptionService.php');
 require_once(ROOT_DIR . 'lib/Application/Schedule/namespace.php');
 require_once(ROOT_DIR . 'lib/Application/Reservation/namespace.php');
+require_once(ROOT_DIR . 'lib/Application/Authentication/namespace.php');
 require_once(ROOT_DIR . 'Domain/Access/namespace.php');
 
 /**
@@ -13,7 +14,8 @@ require_once(ROOT_DIR . 'Domain/Access/namespace.php');
  *
  * Provides:
  *  - Shared presenter/service constructor wiring
- *  - Common QueryString accessors used by CalendarSubscriptionValidator and the presenter
+ *  - A deferred $notFound flag with a unified SetIsNotFound() implementation
+ *  - Optional HTTP Basic Authentication via tryBasicAuth()
  *
  * Subclasses must implement PageLoad() to render the specific feed format.
  */
@@ -23,6 +25,15 @@ abstract class SubscriptionPage extends Page implements ICalendarSubscriptionPag
 
     /** @var iCalendarReservationView[] */
     protected array $reservations = [];
+
+    protected bool $notFound = false;
+
+    /**
+     * Session built from successful Basic Auth credentials. Request-scoped only:
+     * never persisted to $_SESSION, never emits a PHPSESSID cookie. Consumed by
+     * the presenter as an override when synthesizing slot labels.
+     */
+    protected ?UserSession $feedUserSession = null;
 
     protected function __construct()
     {
@@ -39,9 +50,25 @@ abstract class SubscriptionPage extends Page implements ICalendarSubscriptionPag
         parent::__construct('', 1);
     }
 
+    public function GetFeedUserSession(): ?UserSession
+    {
+        return $this->feedUserSession;
+    }
+
     public function SetReservations($reservations): void
     {
         $this->reservations = $reservations;
+    }
+
+    /**
+     * Signals that the request should be aborted. SetIsNotFound() may be called
+     * by the presenter (invalid subscription key) or by tryBasicAuth() (bad
+     * credentials). PageLoad() implementations must check $this->notFound after
+     * each step and return early if it is true.
+     */
+    public function SetIsNotFound(): void
+    {
+        $this->notFound = true;
     }
 
     public function GetSubscriptionKey()
@@ -83,4 +110,103 @@ abstract class SubscriptionPage extends Page implements ICalendarSubscriptionPag
     {
         return intval($this->GetQuerystring(QueryStringKeys::SUBSCRIPTION_DAYS_FUTURE));
     }
+
+    /**
+     * Gate the request and optionally perform HTTP Basic Authentication.
+     *
+     * Order of checks (fail-closed):
+     *  1. If ICS is disabled, set 404 + notFound. Never reach password code.
+     *  2. If no subscription key is supplied, set 404 + notFound. The
+     *     endpoint must not act as a generic credential oracle for callers
+     *     who don't know the feed secret.
+     *  3. If basic.auth is disabled, return — the validator will still enforce
+     *     icskey downstream and emit the feed for icskey-only clients.
+     *  4. Validate Authorization header. On success, capture the UserSession
+     *     on $this->feedUserSession (request-scoped only; the session is NOT
+     *     written to $_SESSION and no PHPSESSID cookie is emitted).
+     *  5. On failure or missing credentials, 401 + WWW-Authenticate and abort.
+     *
+     * HTTP status is set here for every fail-closed path so callers can rely
+     * on a definite status code after tryBasicAuth() returns; subclasses just
+     * check $this->notFound and short-circuit without emitting a body.
+     */
+    protected function tryBasicAuth(): void
+    {
+        if (!Configuration::Instance()->GetKey(ConfigKeys::ICS_ENABLED, new BooleanConverter())) {
+            http_response_code(404);
+            $this->notFound = true;
+            return;
+        }
+
+        if (empty($this->GetSubscriptionKey())) {
+            http_response_code(404);
+            $this->notFound = true;
+            return;
+        }
+
+        if (!Configuration::Instance()->GetKey(ConfigKeys::ICS_BASIC_AUTH, new BooleanConverter())) {
+            return;
+        }
+
+        $username = $_SERVER['PHP_AUTH_USER'] ?? null;
+        $password = $_SERVER['PHP_AUTH_PW'] ?? null;
+
+        if ($username === null || $password === null) {
+            http_response_code(401);
+            header('WWW-Authenticate: Basic realm="LibreBooking"');
+            $this->notFound = true;
+            return;
+        }
+
+        $authentication = $this->createWebAuthentication();
+
+        if ($authentication->Validate($username, $password)) {
+            $this->feedUserSession = $authentication->LoginForFeed($username);
+        } else {
+            http_response_code(401);
+            header('WWW-Authenticate: Basic realm="LibreBooking"');
+            $this->notFound = true;
+        }
+    }
+
+    /**
+     * Returns the IWebAuthentication implementation to use for Basic Auth.
+     * Overridable in tests to inject a fake without touching the real plugin stack.
+     */
+    protected function createWebAuthentication(): IWebAuthentication
+    {
+        return new WebAuthentication(PluginManager::Instance()->LoadAuthentication());
+    }
+
+    /**
+     * Template method enforcing the shared request lifecycle:
+     *   1. tryBasicAuth() — fail-closed gates + optional Basic Auth (sets 404/401).
+     *   2. presenter->PageLoad() — validator + reservation fetch.
+     *   3. If still valid, renderFeed() emits the format-specific output.
+     *
+     * Subclasses must NOT override PageLoad() — they implement renderFeed()
+     * instead so the gate boilerplate cannot be bypassed by accident.
+     */
+    public function PageLoad()
+    {
+        $this->tryBasicAuth();
+        if ($this->notFound) {
+            return;
+        }
+
+        $this->presenter->PageLoad();
+        if ($this->notFound) {
+            http_response_code(404);
+            return;
+        }
+
+        $this->renderFeed();
+    }
+
+    /**
+     * Emit the format-specific body (and any Content-Type / Content-Disposition
+     * headers). Called only after all gates have passed and reservations have
+     * been loaded. Implementations should write to stdout via header()/echo.
+     */
+    abstract protected function renderFeed(): void;
 }

--- a/Presenters/CalendarSubscriptionPresenter.php
+++ b/Presenters/CalendarSubscriptionPresenter.php
@@ -122,7 +122,13 @@ class CalendarSubscriptionPresenter
             count($res)
         );
 
-        $session = ServiceLocator::GetServer()->GetUserSession();
+        // Prefer the feed-scoped session built by Basic Auth (request-only,
+        // never persisted to $_SESSION). Falls back to the server session,
+        // which is NullUserSession for icskey-only requests — in that case
+        // SlotLabelFactory and PrivacyFilter apply the unauthenticated-viewer
+        // rules (PRIVACY_VIEW_RESERVATIONS / privacy hide-flags), which is the
+        // correct privacy posture when we cannot identify the caller.
+        $session = $this->page->GetFeedUserSession() ?? ServiceLocator::GetServer()->GetUserSession();
 
         foreach ($res as $r) {
             if (empty($resourceIds) || in_array($r->ResourceId, $resourceIds)) {

--- a/config/config.dist.php
+++ b/config/config.dist.php
@@ -491,6 +491,9 @@ return [
 
             # Number of past days to include in ICS feeds
             'past.days' => 0,
+
+            # Enable HTTP Basic Authentication on ICS calendar subscription URLs (true/false)
+            'basic.auth' => false,
         ],
 
         #############################

--- a/lib/Application/Authentication/Authentication.php
+++ b/lib/Application/Authentication/Authentication.php
@@ -146,12 +146,21 @@ class Authentication implements IAuthentication
         $loginPage->SetShowLoginError();
     }
 
+    public function BuildSession(string $username): UserSession
+    {
+        $user = $this->userRepository->LoadByUsername($username);
+        if ($user->StatusId() == AccountStatus::ACTIVE) {
+            return $this->GetUserSession($user, LoginTime::Now());
+        }
+        return new NullUserSession();
+    }
+
     /**
      * @param User $user
      * @param string $loginTime
      * @return UserSession
      */
-    private function GetUserSession(User $user, $loginTime)
+    protected function GetUserSession(User $user, $loginTime)
     {
         $userSession = new UserSession($user->Id());
         $userSession->Email = $user->EmailAddress();

--- a/lib/Application/Authentication/IAuthentication.php
+++ b/lib/Application/Authentication/IAuthentication.php
@@ -52,6 +52,17 @@ interface IAuthentication extends IAuthenticationPromptOptions, IAuthenticationA
      * @return void
      */
     public function HandleLoginFailure(IAuthenticationPage $loginPage);
+
+    /**
+     * Build a UserSession for the given username without recording the login event.
+     * Unlike Login(), this does NOT update the user's last-login timestamp in the
+     * database. Use this for machine-client endpoints (e.g. calendar feed pollers)
+     * that authenticate on every request.
+     *
+     * @param string $username
+     * @return UserSession
+     */
+    public function BuildSession(string $username): UserSession;
 }
 
 interface IAuthenticationPromptOptions

--- a/lib/Application/Authentication/WebAuthentication.php
+++ b/lib/Application/Authentication/WebAuthentication.php
@@ -62,6 +62,22 @@ interface IWebAuthentication extends IAuthenticationPromptOptions
      * @return string
      */
     public function GetPasswordResetUrl();
+
+    /**
+     * Build a request-scoped UserSession for the given username without recording
+     * the login event AND without writing to $_SESSION. Intended for machine
+     * clients polling feed endpoints (e.g. ICS subscriptions) where a normal
+     * Login() would (a) update the user's last-login timestamp on every poll and
+     * (b) emit a PHPSESSID cookie that would silently log the caller into the
+     * rest of the application.
+     *
+     * The returned session is the caller's responsibility — it must be passed to
+     * downstream services for this request only and discarded at the end of it.
+     *
+     * @param string $username
+     * @return UserSession
+     */
+    public function LoginForFeed(string $username): UserSession;
 }
 
 class WebAuthentication implements IWebAuthentication
@@ -109,6 +125,11 @@ class WebAuthentication implements IWebAuthentication
         if ($loginContext->GetData()->Persist) {
             $this->SetLoginCookie($userSession->UserId, $userSession->LoginTime);
         }
+    }
+
+    public function LoginForFeed(string $username): UserSession
+    {
+        return $this->authentication->BuildSession($username);
     }
 
     /**

--- a/lib/Config/ConfigKeys.php
+++ b/lib/Config/ConfigKeys.php
@@ -1115,6 +1115,15 @@ class ConfigKeys extends AbstractConfigKeys
         'description' => 'Number of past days to include in ICS feeds',
         'section' => 'ics'
     ];
+    public const ICS_BASIC_AUTH = [
+        'key' => 'ics.basic.auth',
+        'type' => 'boolean',
+        'default' => false,
+        'label' => 'ICS Subscription Basic Auth',
+        'description' => 'Allow HTTP Basic Authentication on ICS calendar subscription URLs. When enabled, clients may supply credentials to receive a fully authenticated feed.',
+        'config_file_comment' => 'Enable HTTP Basic Authentication on ICS calendar subscription URLs',
+        'section' => 'ics'
+    ];
 
     // Data Retention and Deletion
 

--- a/tests/Application/Authentication/AuthenticationTest.php
+++ b/tests/Application/Authentication/AuthenticationTest.php
@@ -25,10 +25,7 @@ class AuthenticationTest extends TestBase
     private $scheduleId;
     private $groups;
 
-    /**
-     * @var Authentication
-     */
-    private $auth;
+    private Authentication $auth;
 
     /**
      * @var FakePassword

--- a/tests/Pages/Export/CalendarSubscriptionPageTest.php
+++ b/tests/Pages/Export/CalendarSubscriptionPageTest.php
@@ -1,0 +1,164 @@
+<?php
+
+declare(strict_types=1);
+
+require_once(ROOT_DIR . 'Pages/Export/CalendarSubscriptionPage.php');
+
+/**
+ * Tests for SubscriptionPage::tryBasicAuth() via CalendarSubscriptionPage.
+ *
+ * tryBasicAuth() lives on the abstract SubscriptionPage base class and guards
+ * all calendar-feed pages. The verified scenarios cover the fail-closed gates
+ * (ICS disabled, missing icskey) as well as the original four basic-auth
+ * branches:
+ *
+ *   - ICS disabled              → notFound, no credential check
+ *   - Missing subscription key  → notFound, no credential check
+ *   - basic.auth flag off       → no-op, validator handles icskey downstream
+ *   - basic.auth on, no creds   → notFound (would-be 401 to the client)
+ *   - basic.auth on, bad creds  → notFound (would-be 401 to the client)
+ *   - basic.auth on, good creds → feedUserSession captured, notFound stays false
+ */
+class CalendarSubscriptionPageTest extends TestBase
+{
+    private TestableSubscriptionPage $page;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        unset($_SERVER['PHP_AUTH_USER'], $_SERVER['PHP_AUTH_PW']);
+        $this->page = new TestableSubscriptionPage();
+        $this->page->SubscriptionKey = 'feed-secret';
+        $this->fakeConfig->SetKey(ConfigKeys::ICS_ENABLED, true);
+    }
+
+    public function tearDown(): void
+    {
+        unset($_SERVER['PHP_AUTH_USER'], $_SERVER['PHP_AUTH_PW']);
+        parent::tearDown();
+    }
+
+    public function testFailsClosedWhenIcsIsDisabled(): void
+    {
+        $this->fakeConfig->SetKey(ConfigKeys::ICS_ENABLED, false);
+        $this->fakeConfig->SetKey(ConfigKeys::ICS_BASIC_AUTH, true);
+        $_SERVER['PHP_AUTH_USER'] = 'admin';
+        $_SERVER['PHP_AUTH_PW'] = 'correctpassword';
+        $this->page->fakeAuth->_ValidateResult = true;
+
+        $this->page->callTryBasicAuth();
+
+        $this->assertTrue($this->page->isNotFound(), 'notFound must be set when ICS is disabled');
+        $this->assertFalse($this->page->fakeAuth->_ValidateCalled, 'Validate() must not be invoked when ICS is disabled');
+        $this->assertFalse($this->page->fakeAuth->_LoginForFeedCalled, 'LoginForFeed must not be invoked when ICS is disabled');
+    }
+
+    public function testFailsClosedWhenSubscriptionKeyIsMissing(): void
+    {
+        $this->fakeConfig->SetKey(ConfigKeys::ICS_BASIC_AUTH, true);
+        $this->page->SubscriptionKey = '';
+        $_SERVER['PHP_AUTH_USER'] = 'admin';
+        $_SERVER['PHP_AUTH_PW'] = 'correctpassword';
+        $this->page->fakeAuth->_ValidateResult = true;
+
+        $this->page->callTryBasicAuth();
+
+        $this->assertTrue($this->page->isNotFound(), 'notFound must be set when subscription key is missing');
+        $this->assertFalse($this->page->fakeAuth->_ValidateCalled, 'Validate() must not be invoked without a subscription key');
+        $this->assertFalse($this->page->fakeAuth->_LoginForFeedCalled, 'LoginForFeed must not be invoked without a subscription key');
+    }
+
+    public function testBasicAuthIsNoopWhenDisabled(): void
+    {
+        // basic.auth defaults to false — tryBasicAuth() must be a no-op once
+        // the ICS_ENABLED and icskey gates have passed.
+        $_SERVER['PHP_AUTH_USER'] = 'user';
+        $_SERVER['PHP_AUTH_PW'] = 'pass';
+
+        $this->page->callTryBasicAuth();
+
+        $this->assertFalse($this->page->isNotFound(), 'notFound should stay false when Basic Auth is disabled');
+        $this->assertFalse($this->page->fakeAuth->_LoginForFeedCalled, 'LoginForFeed must not be called when feature is off');
+    }
+
+    public function testBasicAuthSets401WhenCredentialsMissing(): void
+    {
+        $this->fakeConfig->SetKey(ConfigKeys::ICS_BASIC_AUTH, true);
+        // No PHP_AUTH_USER / PHP_AUTH_PW in $_SERVER.
+
+        $this->page->callTryBasicAuth();
+
+        $this->assertTrue($this->page->isNotFound(), 'notFound should be set when credentials are absent');
+        $this->assertFalse($this->page->fakeAuth->_LoginForFeedCalled, 'LoginForFeed must not be called without credentials');
+    }
+
+    public function testBasicAuthSets401WhenCredentialsAreInvalid(): void
+    {
+        $this->fakeConfig->SetKey(ConfigKeys::ICS_BASIC_AUTH, true);
+        $_SERVER['PHP_AUTH_USER'] = 'user';
+        $_SERVER['PHP_AUTH_PW'] = 'wrongpassword';
+        $this->page->fakeAuth->_ValidateResult = false;
+
+        $this->page->callTryBasicAuth();
+
+        $this->assertTrue($this->page->isNotFound(), 'notFound should be set when credentials are invalid');
+        $this->assertFalse($this->page->fakeAuth->_LoginForFeedCalled, 'LoginForFeed must not be called on failed validation');
+    }
+
+    public function testBasicAuthSucceedsAndCapturesFeedSession(): void
+    {
+        $this->fakeConfig->SetKey(ConfigKeys::ICS_BASIC_AUTH, true);
+        $_SERVER['PHP_AUTH_USER'] = 'admin';
+        $_SERVER['PHP_AUTH_PW'] = 'correctpassword';
+        $this->page->fakeAuth->_ValidateResult = true;
+
+        $this->page->callTryBasicAuth();
+
+        $this->assertFalse($this->page->isNotFound(), 'notFound must stay false when credentials are valid');
+        $this->assertTrue($this->page->fakeAuth->_LoginForFeedCalled, 'LoginForFeed must be called to build the feed session');
+        $this->assertSame('admin', $this->page->fakeAuth->_LastLogin, 'LoginForFeed must receive the authenticated username');
+        $this->assertNotNull($this->page->GetFeedUserSession(), 'feedUserSession must be captured for the presenter');
+    }
+}
+
+/**
+ * Thin test double for CalendarSubscriptionPage.
+ *
+ * Skips the real constructor (which wires up DB repositories, the presenter,
+ * etc.) and injects a FakeWebAuthentication so that tryBasicAuth() can be
+ * exercised without any infrastructure.
+ */
+class TestableSubscriptionPage extends CalendarSubscriptionPage
+{
+    public FakeWebAuthentication $fakeAuth;
+    public string $SubscriptionKey = '';
+
+    public function __construct()
+    {
+        // Deliberately skip parent::__construct() — avoids DB / DI dependencies.
+        // Only the property defaults on SubscriptionPage ($notFound = false, etc.)
+        // are needed for these tests.
+        $this->fakeAuth = new FakeWebAuthentication();
+    }
+
+    public function GetSubscriptionKey()
+    {
+        return $this->SubscriptionKey;
+    }
+
+    protected function createWebAuthentication(): IWebAuthentication
+    {
+        return $this->fakeAuth;
+    }
+
+    /** Expose the protected method under test. */
+    public function callTryBasicAuth(): void
+    {
+        $this->tryBasicAuth();
+    }
+
+    public function isNotFound(): bool
+    {
+        return $this->notFound;
+    }
+}

--- a/tests/Presenters/CalendarSubscriptionPresenterTest.php
+++ b/tests/Presenters/CalendarSubscriptionPresenterTest.php
@@ -260,4 +260,18 @@ class FakeCalendarSubscriptionPage implements ICalendarSubscriptionPage
     {
         return $this->FutureDays;
     }
+
+    public bool $NotFound = false;
+
+    public function SetIsNotFound(): void
+    {
+        $this->NotFound = true;
+    }
+
+    public ?UserSession $FeedUserSession = null;
+
+    public function GetFeedUserSession(): ?UserSession
+    {
+        return $this->FeedUserSession;
+    }
 }

--- a/tests/fakes/FakeAuth.php
+++ b/tests/fakes/FakeAuth.php
@@ -152,4 +152,9 @@ class FakeAuth implements IAuthentication
     {
         return true;
     }
+
+    public function BuildSession(string $username): UserSession
+    {
+        return $this->_Session;
+    }
 }

--- a/tests/fakes/FakeWebAuthentication.php
+++ b/tests/fakes/FakeWebAuthentication.php
@@ -53,6 +53,11 @@ class FakeAuthentication implements IAuthentication
         // TODO: Implement HandleLoginFailure() method.
     }
 
+    public function BuildSession(string $username): UserSession
+    {
+        return $this->_UserSession;
+    }
+
     /**
      * @return bool
      */
@@ -161,7 +166,9 @@ class FakeWebAuthentication implements IWebAuthentication
     public $_LoginCalled = false;
 
     public $_ValidateResult = false;
+    public $_ValidateCalled = false;
     public $_ValidateException = null;
+    public ?UserSession $_FeedUserSession = null;
 
     public $_ShowUsernamePrompt = false;
     public $_ShowPasswordPrompt = false;
@@ -177,6 +184,7 @@ class FakeWebAuthentication implements IWebAuthentication
 
     public function Validate($username, $password)
     {
+        $this->_ValidateCalled = true;
         $this->_LastLogin = $username;
         $this->_LastPassword = $password;
 
@@ -271,5 +279,14 @@ class FakeWebAuthentication implements IWebAuthentication
     public function GetPasswordResetUrl()
     {
         return '';
+    }
+
+    public $_LoginForFeedCalled = false;
+
+    public function LoginForFeed(string $username): UserSession
+    {
+        $this->_LoginForFeedCalled = true;
+        $this->_LastLogin = $username;
+        return $this->_FeedUserSession ?? new UserSession(0);
     }
 }


### PR DESCRIPTION
Introduce an optional Basic Auth gate on the ICS and Atom subscription endpoints, controlled by the new ics.subscription.basic.auth config key

When enabled, SubscriptionPage::tryBasicAuth() runs before the presenter: on missing or invalid credentials it sets a 401 with WWW-Authenticate so calendar clients can prompt; on success it establishes a real server-side session via IWebAuthentication::LoginForFeed(). LoginForFeed reuses the normal user-session construction but skips the last-login database write, since feed clients poll on every refresh.