### PR TITLE
fix(reservations): pass start/end dates to Reservation.init()

### DIFF
--- a/tpl/Reservation/view.tpl
+++ b/tpl/Reservation/view.tpl
@@ -419,7 +419,9 @@
             waitlistUrl: 'ajax/reservation_waitlist.php',
         };
         var reservation = new Reservation(reservationOpts);
-        reservation.init('{$UserId}');
+        var startStr = $('#BeginDate').val() + ' ' + $('#BeginPeriod').val();
+        var endStr = $('#EndDate').val() + ' ' + $('#EndPeriod').val();
+        reservation.init('{$UserId}', startStr, endStr);
 
         var ajaxOptions = {
             target: '#result', // target element(s) to be updated with server response


### PR DESCRIPTION
reservation.init() on the view page was only being passed the ownerId. startDateString was therefore undefined, and startDateString.replace(' ', 'T') threw a TypeError as soon as init() ran. This aborted the rest of initialization before it reached DisplayDuration(), so the reservation length never rendered on the view page.

Build the start/end datetime strings from the existing BeginDate/BeginPeriod and EndDate/EndPeriod hidden inputs and pass them into init(), matching the format init() already expects.

Closes: #1526
Assisted-by: Claude:claude-sonnet-4-6