### PR TITLE
refactor(reservations): initialize reservation with rendered $StartDa…

### DIFF
--- a/tpl/Reservation/view.tpl
+++ b/tpl/Reservation/view.tpl
@@ -419,9 +419,10 @@
             waitlistUrl: 'ajax/reservation_waitlist.php',
         };
         var reservation = new Reservation(reservationOpts);
-        var startStr = $('#BeginDate').val() + ' ' + $('#BeginPeriod').val();
-        var endStr = $('#EndDate').val() + ' ' + $('#EndPeriod').val();
-        reservation.init('{$UserId}', startStr, endStr);
+        reservation.init('{$UserId}',
+            '{format_date date=$StartDate key=system_datetime timezone=$Timezone}',
+            '{format_date date=$EndDate key=system_datetime timezone=$Timezone}'
+        );
 
         var ajaxOptions = {
             target: '#result', // target element(s) to be updated with server response


### PR DESCRIPTION
…te and $EndDate

- Replace the use of values ​​read from #BeginDate and #EndDate with dates rendered by Smarty, avoiding reliance on the DOM state during reservation initialization.
- Maintains consistency with Reservation/create.tpl
- Avoids the use of jQuery