### PR TITLE
fix(auth): limit and classify Microsoft OAuth callback logging

### DIFF
--- a/Web/microsoft-auth.php
+++ b/Web/microsoft-auth.php
@@ -11,7 +11,7 @@ $result = (new MicrosoftOAuthCallback())->handle(
     failureRedirectURL: ROOT_DIR . 'Web',
 );
 
-if ($result->isError()) {
+if ($result->hasOAuthErrorResponse()) {
     Log::Error('Microsoft OAuth error: %s - %s', $result->error, $result->getErrorDescription());
 }
 

--- a/lib/Application/Authentication/MicrosoftOAuthCallback.php
+++ b/lib/Application/Authentication/MicrosoftOAuthCallback.php
@@ -1,13 +1,29 @@
 <?php
 
 declare(strict_types=1);
+
+/**
+ * Classification of a Microsoft OAuth callback request.
+ */
+enum MicrosoftOAuthCallbackOutcome
+{
+    case SUCCESS;
+    case OAUTH_ERROR;
+    case MALFORMED_REQUEST;
+}
+
 /**
  * Microsoft's OAuth callback outcome — either a redirect to external-auth or a redirect to home on error.
+ *
+ * The error fields exist only for logging and are bounded/normalized at
+ * construction; a feature that displays them to users should add a separate
+ * raw accessor rather than widen the caps.
  */
 class MicrosoftOAuthCallbackResult
 {
     private function __construct(
         public readonly string $redirectURL,
+        private readonly MicrosoftOAuthCallbackOutcome $outcome,
         public readonly ?string $error = null,
         private readonly ?string $errorDescription = null,
     ) {
@@ -15,17 +31,33 @@ class MicrosoftOAuthCallbackResult
 
     public static function success(string $redirectURL): self
     {
-        return new self($redirectURL);
+        return new self($redirectURL, MicrosoftOAuthCallbackOutcome::SUCCESS);
     }
 
-    public static function failed(string $failureRedirectURL, string $error, ?string $errorDescription = null): self
+    public static function oauthError(string $failureRedirectURL, string $error, ?string $errorDescription = null): self
     {
-        return new self($failureRedirectURL, $error, $errorDescription);
+        return new self($failureRedirectURL, MicrosoftOAuthCallbackOutcome::OAUTH_ERROR, $error, $errorDescription);
     }
 
-    public function isError(): bool
+    public static function malformedRequest(string $failureRedirectURL): self
     {
-        return $this->error !== null;
+        return new self($failureRedirectURL, MicrosoftOAuthCallbackOutcome::MALFORMED_REQUEST);
+    }
+
+    /**
+     * True when the provider reported an error (?error=...). This is the only
+     * outcome worth logging: malformed requests to this unauthenticated
+     * endpoint are dominated by scanner noise, so they are deliberately not
+     * logged; the web server access log is the diagnostic fallback.
+     */
+    public function hasOAuthErrorResponse(): bool
+    {
+        return $this->outcome === MicrosoftOAuthCallbackOutcome::OAUTH_ERROR;
+    }
+
+    public function isMalformedRequest(): bool
+    {
+        return $this->outcome === MicrosoftOAuthCallbackOutcome::MALFORMED_REQUEST;
     }
 
     public function getErrorDescription(): string
@@ -38,6 +70,10 @@ class MicrosoftOAuthCallbackResult
  */
 class MicrosoftOAuthCallback
 {
+    /** Byte caps for attacker-suppliable callback values destined for the log. */
+    private const MAX_ERROR_BYTES = 100;
+    private const MAX_DESCRIPTION_BYTES = 500;
+
     /**
      * Resolves the redirect target from Microsoft's OAuth callback parameters.
      *
@@ -52,21 +88,46 @@ class MicrosoftOAuthCallback
     public function handle(array $params, string $externalAuthUrl, string $failureRedirectURL): MicrosoftOAuthCallbackResult
     {
         $error = $params['error'] ?? null;
+        $code = $params['code'] ?? null;
+
+        // A non-string value for a recognized parameter (e.g. ?error[]=x) is
+        // not a shape Azure sends; treat the whole request as malformed
+        // instead of interpreting the remaining parameters.
+        if (($error !== null && !is_string($error)) || ($code !== null && !is_string($code))) {
+            return MicrosoftOAuthCallbackResult::malformedRequest($failureRedirectURL);
+        }
+
         if (is_string($error) && $error !== '') {
             $description = $params['error_description'] ?? null;
-            return MicrosoftOAuthCallbackResult::failed(
+            return MicrosoftOAuthCallbackResult::oauthError(
                 $failureRedirectURL,
-                $error,
-                is_string($description) ? $description : null,
+                $this->sanitizeForLog($error, self::MAX_ERROR_BYTES),
+                is_string($description) ? $this->sanitizeForLog($description, self::MAX_DESCRIPTION_BYTES) : null,
             );
         }
 
-        $code = $params['code'] ?? null;
         if (is_string($code) && $code !== '') {
             $url = $externalAuthUrl . '?type=microsoft&code=' . urlencode($code);
             return MicrosoftOAuthCallbackResult::success($url);
         }
 
-        return MicrosoftOAuthCallbackResult::failed($failureRedirectURL, 'missing_code');
+        return MicrosoftOAuthCallbackResult::malformedRequest($failureRedirectURL);
+    }
+
+    /**
+     * Makes a query-controlled value safe to log: the result is always valid
+     * UTF-8, free of control characters, and within the byte cap. Invalid byte
+     * sequences are scrubbed first so the control replacement can operate
+     * byte-wise on C0 + DEL (never part of a UTF-8 multibyte sequence) and on
+     * the UTF-8 encoding of C1 controls; raw bytes \x80-\x9F are legitimate
+     * UTF-8 continuation bytes and must not be touched. mb_strcut() enforces
+     * the byte cap without splitting a multibyte character.
+     */
+    private function sanitizeForLog(string $value, int $maxBytes): string
+    {
+        $value = mb_scrub($value, 'UTF-8');
+        $value = preg_replace('/[\x00-\x1F\x7F]|\xC2[\x80-\x9F]/', ' ', $value) ?? '';
+
+        return mb_strcut($value, 0, $maxBytes, 'UTF-8');
     }
 }

--- a/tests/Application/Authentication/MicrosoftOAuthCallbackTest.php
+++ b/tests/Application/Authentication/MicrosoftOAuthCallbackTest.php
@@ -24,7 +24,8 @@ class MicrosoftOAuthCallbackTest extends TestBase
             $this->failureRedirectURL,
         );
 
-        $this->assertFalse($result->isError());
+        $this->assertFalse($result->hasOAuthErrorResponse());
+        $this->assertFalse($result->isMalformedRequest());
         $this->assertEquals(
             'http://localhost/external-auth.php?type=microsoft&code=abc123',
             $result->redirectURL,
@@ -42,6 +43,19 @@ class MicrosoftOAuthCallbackTest extends TestBase
         $this->assertStringContainsString('code=code+with+spaces+%26+special%3Dchars', $result->redirectURL);
     }
 
+    public function testEmptyErrorWithValidCodeIsSuccess(): void
+    {
+        $result = $this->msAuthHandler->handle(
+            ['error' => '', 'code' => 'abc123'],
+            $this->externalAuthUrl,
+            $this->failureRedirectURL,
+        );
+
+        $this->assertFalse($result->hasOAuthErrorResponse());
+        $this->assertFalse($result->isMalformedRequest());
+        $this->assertStringContainsString('code=abc123', $result->redirectURL);
+    }
+
     public function testErrorRedirectsHome(): void
     {
         $result = $this->msAuthHandler->handle(
@@ -50,7 +64,7 @@ class MicrosoftOAuthCallbackTest extends TestBase
             $this->failureRedirectURL,
         );
 
-        $this->assertTrue($result->isError());
+        $this->assertTrue($result->hasOAuthErrorResponse());
         $this->assertEquals($this->failureRedirectURL, $result->redirectURL);
         $this->assertEquals('access_denied', $result->error);
         $this->assertEquals('the user canceled the authentication', $result->getErrorDescription());
@@ -64,10 +78,12 @@ class MicrosoftOAuthCallbackTest extends TestBase
             $this->failureRedirectURL,
         );
 
-        $this->assertTrue($result->isError());
+        $this->assertTrue($result->hasOAuthErrorResponse());
         $this->assertEquals('server_error', $result->error);
+        $this->assertEquals('No error description was provided.', $result->getErrorDescription());
         $this->assertEquals($this->failureRedirectURL, $result->redirectURL);
     }
+
     // Azure shouldn't send both, but we defensively treat error as authoritative
     // in case of malformed/tampered query strings.
     public function testErrorTakesPrecedenceOverCode(): void
@@ -78,11 +94,24 @@ class MicrosoftOAuthCallbackTest extends TestBase
             $this->failureRedirectURL,
         );
 
-        $this->assertTrue($result->isError());
+        $this->assertTrue($result->hasOAuthErrorResponse());
         $this->assertEquals($this->failureRedirectURL, $result->redirectURL);
     }
 
-    public function testMissingParamsRedirectsHome(): void
+    public function testErrorWithNonStringDescriptionKeepsErrorAndDiscardsDescription(): void
+    {
+        $result = $this->msAuthHandler->handle(
+            ['error' => 'access_denied', 'error_description' => ['not' => 'a string']],
+            $this->externalAuthUrl,
+            $this->failureRedirectURL,
+        );
+
+        $this->assertTrue($result->hasOAuthErrorResponse());
+        $this->assertEquals('access_denied', $result->error);
+        $this->assertEquals('No error description was provided.', $result->getErrorDescription());
+    }
+
+    public function testMissingParamsIsMalformedRequest(): void
     {
         $result = $this->msAuthHandler->handle(
             [],
@@ -90,8 +119,105 @@ class MicrosoftOAuthCallbackTest extends TestBase
             $this->failureRedirectURL,
         );
 
-        $this->assertTrue($result->isError());
+        $this->assertTrue($result->isMalformedRequest());
+        $this->assertFalse($result->hasOAuthErrorResponse());
+        $this->assertNull($result->error);
         $this->assertEquals($this->failureRedirectURL, $result->redirectURL);
-        $this->assertEquals('missing_code', $result->error);
+    }
+
+    public function testNonStringCodeIsMalformedRequest(): void
+    {
+        $result = $this->msAuthHandler->handle(
+            ['code' => ['x']],
+            $this->externalAuthUrl,
+            $this->failureRedirectURL,
+        );
+
+        $this->assertTrue($result->isMalformedRequest());
+        $this->assertEquals($this->failureRedirectURL, $result->redirectURL);
+    }
+
+    public function testNonStringErrorWithValidCodeIsMalformedRequest(): void
+    {
+        $result = $this->msAuthHandler->handle(
+            ['error' => ['x'], 'code' => 'abc123'],
+            $this->externalAuthUrl,
+            $this->failureRedirectURL,
+        );
+
+        $this->assertTrue($result->isMalformedRequest());
+        $this->assertFalse($result->hasOAuthErrorResponse());
+        $this->assertEquals($this->failureRedirectURL, $result->redirectURL);
+    }
+
+    public function testErrorFieldsAreTruncatedForLogging(): void
+    {
+        $result = $this->msAuthHandler->handle(
+            ['error' => str_repeat('e', 200), 'error_description' => str_repeat('d', 1000)],
+            $this->externalAuthUrl,
+            $this->failureRedirectURL,
+        );
+
+        $this->assertTrue($result->hasOAuthErrorResponse());
+        $this->assertEquals(100, strlen($result->error));
+        $this->assertEquals(500, strlen($result->getErrorDescription()));
+    }
+
+    public function testControlCharactersAreReplacedWithSpacesForLogging(): void
+    {
+        $result = $this->msAuthHandler->handle(
+            [
+                'error' => "access\x00denied",
+                // C0 newline, ANSI escape, DEL, and a UTF-8-encoded C1 control
+                'error_description' => "line1\nline2\x1b[31mred\x7f\xC2\x85end",
+            ],
+            $this->externalAuthUrl,
+            $this->failureRedirectURL,
+        );
+
+        $this->assertEquals('access denied', $result->error);
+        $this->assertEquals('line1 line2 [31mred  end', $result->getErrorDescription());
+    }
+
+    public function testTruncationDoesNotSplitMultibyteCharacter(): void
+    {
+        // 499 ASCII bytes followed by a 3-byte character: a plain byte cap at
+        // 500 would leave a dangling lead byte and invalid UTF-8.
+        $result = $this->msAuthHandler->handle(
+            ['error' => 'e', 'error_description' => str_repeat('d', 499) . '€'],
+            $this->externalAuthUrl,
+            $this->failureRedirectURL,
+        );
+
+        $description = $result->getErrorDescription();
+        $this->assertEquals(str_repeat('d', 499), $description);
+        $this->assertTrue(mb_check_encoding($description, 'UTF-8'));
+    }
+
+    public function testInvalidUtf8BytesAreScrubbedForLogging(): void
+    {
+        $result = $this->msAuthHandler->handle(
+            ['error' => "bad\xFF\xFEbytes", 'error_description' => "trailing lead byte\xE2"],
+            $this->externalAuthUrl,
+            $this->failureRedirectURL,
+        );
+
+        $this->assertTrue(mb_check_encoding($result->error, 'UTF-8'));
+        $this->assertTrue(mb_check_encoding($result->getErrorDescription(), 'UTF-8'));
+        $this->assertStringNotContainsString("\xFF", $result->error);
+        $this->assertStringContainsString('bad', $result->error);
+        $this->assertStringContainsString('bytes', $result->error);
+    }
+
+    public function testMultibyteUtf8SurvivesLogSanitization(): void
+    {
+        $result = $this->msAuthHandler->handle(
+            ['error' => 'accès_refusé', 'error_description' => 'coûte 100 €'],
+            $this->externalAuthUrl,
+            $this->failureRedirectURL,
+        );
+
+        $this->assertEquals('accès_refusé', $result->error);
+        $this->assertEquals('coûte 100 €', $result->getErrorDescription());
     }
 }


### PR DESCRIPTION
The microsoft-auth.php callback endpoint logged every non-success request at error level, including parameterless requests from scanners and crawlers, and wrote the attacker-suppliable `error` and `error_description` query values to the log without length limits.

Classify callback outcomes explicitly with a unit enum (SUCCESS, OAUTH_ERROR, MALFORMED_REQUEST) instead of treating every failure as the same error:

- Only provider error responses (?error=...) are logged, at error level. Malformed requests (missing or non-string parameters) redirect home silently, matching the pre-#1500 behavior; the web server access log remains the diagnostic fallback.
- A non-string value for a recognized parameter (e.g. ?error[]=x) marks the whole request malformed rather than being partially interpreted. A non-string optional error_description is discarded while keeping the valid OAuth error.
- The synthetic 'missing_code' error value is removed; the entry point queries the classification instead of comparing sentinel strings.
- Logged fields are sanitized before reaching the log: invalid UTF-8 is scrubbed, C0/C1 control characters (including ANSI escapes) are replaced with spaces, and values are byte-capped (error 100, description 500) with mb_strcut() so output is always valid UTF-8.

Tests cover all three classifications, the precedence rules for crafted inputs, byte-cap truncation at a multibyte boundary, and invalid input bytes.

Closes: #1549
Assisted-by: Claude:claude-fable-5