### PR TITLE
fix(email): render resource description/notes as rich text in confirm…

### DIFF
--- a/lang/bg_bg/ReservationCreated.tpl
+++ b/lang/bg_bg/ReservationCreated.tpl
@@ -16,8 +16,8 @@
 		<strong>Идентификатор на ресурс:</strong> {$resource.id}<br/>
 		{if $resource.location}<strong>Местоположение:</strong> {$resource.location|escape}<br/>{/if}
 		{if $resource.contact}<strong>Контакт:</strong> {$resource.contact|escape}<br/>{/if}
-		{if $resource.description}<strong>Описание:</strong> {$resource.description|escape|nl2br}<br/>{/if}
-		{if $resource.notes}<strong>Бележки:</strong> {$resource.notes|escape|nl2br}<br/>{/if}
+		{if $resource.description}<strong>Описание:</strong> {$resource.description|sanitize_rich_text|url2link|nl2br}<br/>{/if}
+		{if $resource.notes}<strong>Бележки:</strong> {$resource.notes|sanitize_rich_text|url2link|nl2br}<br/>{/if}
 		{if $resource.resourceAdministrator}<strong>Администратор на ресурса:</strong> {$resource.resourceAdministrator|escape}<br/>{/if}
 
 		{if $resource.attributeRows|default:array()|count > 0}

--- a/lang/bg_bg/ReservationCreatedAdmin.tpl
+++ b/lang/bg_bg/ReservationCreatedAdmin.tpl
@@ -17,8 +17,8 @@
 		<strong>Идентификатор на ресурс:</strong> {$resource.id}<br/>
 		{if $resource.location}<strong>Местоположение:</strong> {$resource.location|escape}<br/>{/if}
 		{if $resource.contact}<strong>Контакт:</strong> {$resource.contact|escape}<br/>{/if}
-		{if $resource.description}<strong>Описание:</strong> {$resource.description|escape|nl2br}<br/>{/if}
-		{if $resource.notes}<strong>Бележки:</strong> {$resource.notes|escape|nl2br}<br/>{/if}
+		{if $resource.description}<strong>Описание:</strong> {$resource.description|sanitize_rich_text|url2link|nl2br}<br/>{/if}
+		{if $resource.notes}<strong>Бележки:</strong> {$resource.notes|sanitize_rich_text|url2link|nl2br}<br/>{/if}
 		{if $resource.resourceAdministrator}<strong>Администратор на ресурса:</strong> {$resource.resourceAdministrator|escape}<br/>{/if}
 
 		{if $resource.attributeRows|default:array()|count > 0}

--- a/lang/cz/ReservationCreated.tpl
+++ b/lang/cz/ReservationCreated.tpl
@@ -16,8 +16,8 @@
 		<strong>ID zdroje:</strong> {$resource.id}<br/>
 		{if $resource.location}<strong>Umístění:</strong> {$resource.location|escape}<br/>{/if}
 		{if $resource.contact}<strong>Kontakt:</strong> {$resource.contact|escape}<br/>{/if}
-		{if $resource.description}<strong>Popis:</strong> {$resource.description|escape|nl2br}<br/>{/if}
-		{if $resource.notes}<strong>Poznámky:</strong> {$resource.notes|escape|nl2br}<br/>{/if}
+		{if $resource.description}<strong>Popis:</strong> {$resource.description|sanitize_rich_text|url2link|nl2br}<br/>{/if}
+		{if $resource.notes}<strong>Poznámky:</strong> {$resource.notes|sanitize_rich_text|url2link|nl2br}<br/>{/if}
 		{if $resource.resourceAdministrator}<strong>Správce zdroje:</strong> {$resource.resourceAdministrator|escape}<br/>{/if}
 
 		{if $resource.attributeRows|default:array()|count > 0}

--- a/lang/cz/ReservationCreatedAdmin.tpl
+++ b/lang/cz/ReservationCreatedAdmin.tpl
@@ -17,8 +17,8 @@ Konec: {formatdate date=$EndDate key=reservation_email}<br/>
 		<strong>ID zdroje:</strong> {$resource.id}<br/>
 		{if $resource.location}<strong>Umístění:</strong> {$resource.location|escape}<br/>{/if}
 		{if $resource.contact}<strong>Kontakt:</strong> {$resource.contact|escape}<br/>{/if}
-		{if $resource.description}<strong>Popis:</strong> {$resource.description|escape|nl2br}<br/>{/if}
-		{if $resource.notes}<strong>Poznámky:</strong> {$resource.notes|escape|nl2br}<br/>{/if}
+		{if $resource.description}<strong>Popis:</strong> {$resource.description|sanitize_rich_text|url2link|nl2br}<br/>{/if}
+		{if $resource.notes}<strong>Poznámky:</strong> {$resource.notes|sanitize_rich_text|url2link|nl2br}<br/>{/if}
 		{if $resource.resourceAdministrator}<strong>Správce zdroje:</strong> {$resource.resourceAdministrator|escape}<br/>{/if}
 
 		{if $resource.attributeRows|default:array()|count > 0}

--- a/lang/da_da/ReservationCreated.tpl
+++ b/lang/da_da/ReservationCreated.tpl
@@ -16,8 +16,8 @@ Slutter: {formatdate date=$EndDate key=reservation_email}<br/>
         <strong>Facilitets-ID:</strong> {$resource.id}<br/>
         {if $resource.location}<strong>Placering:</strong> {$resource.location|escape}<br/>{/if}
         {if $resource.contact}<strong>Kontakt:</strong> {$resource.contact|escape}<br/>{/if}
-        {if $resource.description}<strong>Beskrivelse:</strong> {$resource.description|escape|nl2br}<br/>{/if}
-        {if $resource.notes}<strong>Noter:</strong> {$resource.notes|escape|nl2br}<br/>{/if}
+        {if $resource.description}<strong>Beskrivelse:</strong> {$resource.description|sanitize_rich_text|url2link|nl2br}<br/>{/if}
+        {if $resource.notes}<strong>Noter:</strong> {$resource.notes|sanitize_rich_text|url2link|nl2br}<br/>{/if}
         {if $resource.resourceAdministrator}<strong>Facilitetsadministrator:</strong> {$resource.resourceAdministrator|escape}<br/>{/if}
 
         {if $resource.attributeRows|default:array()|count > 0}

--- a/lang/da_da/ReservationCreatedAdmin.tpl
+++ b/lang/da_da/ReservationCreatedAdmin.tpl
@@ -22,8 +22,8 @@ Slutter: {formatdate date=$EndDate key=reservation_email}<br/>
         <strong>Facilitets-ID:</strong> {$resource.id}<br/>
         {if $resource.location}<strong>Placering:</strong> {$resource.location|escape}<br/>{/if}
         {if $resource.contact}<strong>Kontakt:</strong> {$resource.contact|escape}<br/>{/if}
-        {if $resource.description}<strong>Beskrivelse:</strong> {$resource.description|escape|nl2br}<br/>{/if}
-        {if $resource.notes}<strong>Noter:</strong> {$resource.notes|escape|nl2br}<br/>{/if}
+        {if $resource.description}<strong>Beskrivelse:</strong> {$resource.description|sanitize_rich_text|url2link|nl2br}<br/>{/if}
+        {if $resource.notes}<strong>Noter:</strong> {$resource.notes|sanitize_rich_text|url2link|nl2br}<br/>{/if}
         {if $resource.resourceAdministrator}<strong>Facilitetsadministrator:</strong> {$resource.resourceAdministrator|escape}<br/>{/if}
 
         {if $resource.attributeRows|default:array()|count > 0}

--- a/lang/de_de/ReservationCreated.tpl
+++ b/lang/de_de/ReservationCreated.tpl
@@ -18,8 +18,8 @@ Sie haben die folgende Reservierung erstellt.<br/>
 		<strong>Ressourcen-ID:</strong> {$resource.id}<br/>
 		{if $resource.location}<strong>Standort:</strong> {$resource.location|escape}<br/>{/if}
 		{if $resource.contact}<strong>Kontakt:</strong> {$resource.contact|escape}<br/>{/if}
-		{if $resource.description}<strong>Beschreibung:</strong> {$resource.description|escape|nl2br}<br/>{/if}
-		{if $resource.notes}<strong>Notizen:</strong> {$resource.notes|escape|nl2br}<br/>{/if}
+		{if $resource.description}<strong>Beschreibung:</strong> {$resource.description|sanitize_rich_text|url2link|nl2br}<br/>{/if}
+		{if $resource.notes}<strong>Notizen:</strong> {$resource.notes|sanitize_rich_text|url2link|nl2br}<br/>{/if}
 		{if $resource.resourceAdministrator}<strong>Ressourcenadministrator:</strong> {$resource.resourceAdministrator|escape}<br/>{/if}
 
 		{if $resource.attributeRows|default:array()|count > 0}

--- a/lang/de_de/ReservationCreatedAdmin.tpl
+++ b/lang/de_de/ReservationCreatedAdmin.tpl
@@ -18,8 +18,8 @@ Reservierungsdetails:<br/>
 		<strong>Ressourcen-ID:</strong> {$resource.id}<br/>
 		{if $resource.location}<strong>Standort:</strong> {$resource.location|escape}<br/>{/if}
 		{if $resource.contact}<strong>Kontakt:</strong> {$resource.contact|escape}<br/>{/if}
-		{if $resource.description}<strong>Beschreibung:</strong> {$resource.description|escape|nl2br}<br/>{/if}
-		{if $resource.notes}<strong>Notizen:</strong> {$resource.notes|escape|nl2br}<br/>{/if}
+		{if $resource.description}<strong>Beschreibung:</strong> {$resource.description|sanitize_rich_text|url2link|nl2br}<br/>{/if}
+		{if $resource.notes}<strong>Notizen:</strong> {$resource.notes|sanitize_rich_text|url2link|nl2br}<br/>{/if}
 		{if $resource.resourceAdministrator}<strong>Ressourcenadministrator:</strong> {$resource.resourceAdministrator|escape}<br/>{/if}
 
 		{if $resource.attributeRows|default:array()|count > 0}

--- a/lang/du_nl/ReservationCreated.tpl
+++ b/lang/du_nl/ReservationCreated.tpl
@@ -16,8 +16,8 @@
 		<strong>Resource-ID:</strong> {$resource.id}<br/>
 		{if $resource.location}<strong>Locatie:</strong> {$resource.location|escape}<br/>{/if}
 		{if $resource.contact}<strong>Contactpersoon:</strong> {$resource.contact|escape}<br/>{/if}
-		{if $resource.description}<strong>Beschrijving:</strong> {$resource.description|escape|nl2br}<br/>{/if}
-		{if $resource.notes}<strong>Notities:</strong> {$resource.notes|escape|nl2br}<br/>{/if}
+		{if $resource.description}<strong>Beschrijving:</strong> {$resource.description|sanitize_rich_text|url2link|nl2br}<br/>{/if}
+		{if $resource.notes}<strong>Notities:</strong> {$resource.notes|sanitize_rich_text|url2link|nl2br}<br/>{/if}
 		{if $resource.resourceAdministrator}<strong>Resourcebeheerder:</strong> {$resource.resourceAdministrator|escape}<br/>{/if}
 
 		{if $resource.attributeRows|default:array()|count > 0}

--- a/lang/du_nl/ReservationCreatedAdmin.tpl
+++ b/lang/du_nl/ReservationCreatedAdmin.tpl
@@ -17,8 +17,8 @@
 		<strong>Resource-ID:</strong> {$resource.id}<br/>
 		{if $resource.location}<strong>Locatie:</strong> {$resource.location|escape}<br/>{/if}
 		{if $resource.contact}<strong>Contactpersoon:</strong> {$resource.contact|escape}<br/>{/if}
-		{if $resource.description}<strong>Beschrijving:</strong> {$resource.description|escape|nl2br}<br/>{/if}
-		{if $resource.notes}<strong>Notities:</strong> {$resource.notes|escape|nl2br}<br/>{/if}
+		{if $resource.description}<strong>Beschrijving:</strong> {$resource.description|sanitize_rich_text|url2link|nl2br}<br/>{/if}
+		{if $resource.notes}<strong>Notities:</strong> {$resource.notes|sanitize_rich_text|url2link|nl2br}<br/>{/if}
 		{if $resource.resourceAdministrator}<strong>Resourcebeheerder:</strong> {$resource.resourceAdministrator|escape}<br/>{/if}
 
 		{if $resource.attributeRows|default:array()|count > 0}

--- a/lang/ee_ee/ReservationCreated.tpl
+++ b/lang/ee_ee/ReservationCreated.tpl
@@ -16,8 +16,8 @@
 		<strong>Ressursi ID:</strong> {$resource.id}<br/>
 		{if $resource.location}<strong>Asukoht:</strong> {$resource.location|escape}<br/>{/if}
 		{if $resource.contact}<strong>Kontakt:</strong> {$resource.contact|escape}<br/>{/if}
-		{if $resource.description}<strong>Kirjeldus:</strong> {$resource.description|escape|nl2br}<br/>{/if}
-		{if $resource.notes}<strong>Märkused:</strong> {$resource.notes|escape|nl2br}<br/>{/if}
+		{if $resource.description}<strong>Kirjeldus:</strong> {$resource.description|sanitize_rich_text|url2link|nl2br}<br/>{/if}
+		{if $resource.notes}<strong>Märkused:</strong> {$resource.notes|sanitize_rich_text|url2link|nl2br}<br/>{/if}
 		{if $resource.resourceAdministrator}<strong>Ressursi administraator:</strong> {$resource.resourceAdministrator|escape}<br/>{/if}
 
 		{if $resource.attributeRows|default:array()|count > 0}

--- a/lang/ee_ee/ReservationCreatedAdmin.tpl
+++ b/lang/ee_ee/ReservationCreatedAdmin.tpl
@@ -21,8 +21,8 @@
 		<strong>Ressursi ID:</strong> {$resource.id}<br/>
 		{if $resource.location}<strong>Asukoht:</strong> {$resource.location|escape}<br/>{/if}
 		{if $resource.contact}<strong>Kontakt:</strong> {$resource.contact|escape}<br/>{/if}
-		{if $resource.description}<strong>Kirjeldus:</strong> {$resource.description|escape|nl2br}<br/>{/if}
-		{if $resource.notes}<strong>Märkused:</strong> {$resource.notes|escape|nl2br}<br/>{/if}
+		{if $resource.description}<strong>Kirjeldus:</strong> {$resource.description|sanitize_rich_text|url2link|nl2br}<br/>{/if}
+		{if $resource.notes}<strong>Märkused:</strong> {$resource.notes|sanitize_rich_text|url2link|nl2br}<br/>{/if}
 		{if $resource.resourceAdministrator}<strong>Ressursi administraator:</strong> {$resource.resourceAdministrator|escape}<br/>{/if}
 
 		{if $resource.attributeRows|default:array()|count > 0}

--- a/lang/el_gr/ReservationCreated.tpl
+++ b/lang/el_gr/ReservationCreated.tpl
@@ -26,8 +26,8 @@
         <strong>Αναγνωριστικό πόρου:</strong> {$resource.id}<br/>
         {if $resource.location}<strong>Τοποθεσία:</strong> {$resource.location|escape}<br/>{/if}
         {if $resource.contact}<strong>Επικοινωνία:</strong> {$resource.contact|escape}<br/>{/if}
-        {if $resource.description}<strong>Περιγραφή:</strong> {$resource.description|escape|nl2br}<br/>{/if}
-        {if $resource.notes}<strong>Σημειώσεις:</strong> {$resource.notes|escape|nl2br}<br/>{/if}
+        {if $resource.description}<strong>Περιγραφή:</strong> {$resource.description|sanitize_rich_text|url2link|nl2br}<br/>{/if}
+        {if $resource.notes}<strong>Σημειώσεις:</strong> {$resource.notes|sanitize_rich_text|url2link|nl2br}<br/>{/if}
         {if $resource.resourceAdministrator}<strong>Διαχειριστής πόρου:</strong> {$resource.resourceAdministrator|escape}<br/>{/if}
 
         {if $resource.attributeRows|default:array()|count > 0}

--- a/lang/el_gr/ReservationCreatedAdmin.tpl
+++ b/lang/el_gr/ReservationCreatedAdmin.tpl
@@ -33,8 +33,8 @@
         <strong>Αναγνωριστικό πόρου:</strong> {$resource.id}<br/>
         {if $resource.location}<strong>Τοποθεσία:</strong> {$resource.location|escape}<br/>{/if}
         {if $resource.contact}<strong>Επικοινωνία:</strong> {$resource.contact|escape}<br/>{/if}
-        {if $resource.description}<strong>Περιγραφή:</strong> {$resource.description|escape|nl2br}<br/>{/if}
-        {if $resource.notes}<strong>Σημειώσεις:</strong> {$resource.notes|escape|nl2br}<br/>{/if}
+        {if $resource.description}<strong>Περιγραφή:</strong> {$resource.description|sanitize_rich_text|url2link|nl2br}<br/>{/if}
+        {if $resource.notes}<strong>Σημειώσεις:</strong> {$resource.notes|sanitize_rich_text|url2link|nl2br}<br/>{/if}
         {if $resource.resourceAdministrator}<strong>Διαχειριστής πόρου:</strong> {$resource.resourceAdministrator|escape}<br/>{/if}
 
         {if $resource.attributeRows|default:array()|count > 0}

--- a/lang/en_us/ReservationCreated.tpl
+++ b/lang/en_us/ReservationCreated.tpl
@@ -25,8 +25,8 @@
         <strong>Resource ID:</strong> {$resource.id}<br/>
         {if $resource.location}<strong>Location:</strong> {$resource.location|escape}<br/>{/if}
         {if $resource.contact}<strong>Contact:</strong> {$resource.contact|escape}<br/>{/if}
-        {if $resource.description}<strong>Description:</strong> {$resource.description|escape|nl2br}<br/>{/if}
-        {if $resource.notes}<strong>Notes:</strong> {$resource.notes|escape|nl2br}<br/>{/if}
+        {if $resource.description}<strong>Description:</strong> {$resource.description|sanitize_rich_text|url2link|nl2br}<br/>{/if}
+        {if $resource.notes}<strong>Notes:</strong> {$resource.notes|sanitize_rich_text|url2link|nl2br}<br/>{/if}
         {if $resource.resourceAdministrator}<strong>Resource Administrator:</strong> {$resource.resourceAdministrator|escape}<br/>{/if}
 
         {if $resource.attributeRows|default:array()|count > 0}

--- a/lang/en_us/ReservationCreatedAdmin.tpl
+++ b/lang/en_us/ReservationCreatedAdmin.tpl
@@ -32,8 +32,8 @@
         <strong>Resource ID:</strong> {$resource.id}<br/>
         {if $resource.location}<strong>Location:</strong> {$resource.location|escape}<br/>{/if}
         {if $resource.contact}<strong>Contact:</strong> {$resource.contact|escape}<br/>{/if}
-        {if $resource.description}<strong>Description:</strong> {$resource.description|escape|nl2br}<br/>{/if}
-        {if $resource.notes}<strong>Notes:</strong> {$resource.notes|escape|nl2br}<br/>{/if}
+        {if $resource.description}<strong>Description:</strong> {$resource.description|sanitize_rich_text|url2link|nl2br}<br/>{/if}
+        {if $resource.notes}<strong>Notes:</strong> {$resource.notes|sanitize_rich_text|url2link|nl2br}<br/>{/if}
         {if $resource.resourceAdministrator}<strong>Resource Administrator:</strong> {$resource.resourceAdministrator|escape}<br/>{/if}
 
         {if $resource.attributeRows|default:array()|count > 0}

--- a/lang/es/ReservationCreated.tpl
+++ b/lang/es/ReservationCreated.tpl
@@ -26,8 +26,8 @@
         <strong>ID del recurso:</strong> {$resource.id}<br/>
         {if $resource.location}<strong>Ubicación:</strong> {$resource.location|escape}<br/>{/if}
         {if $resource.contact}<strong>Contacto:</strong> {$resource.contact|escape}<br/>{/if}
-        {if $resource.description}<strong>Descripción:</strong> {$resource.description|escape|nl2br}<br/>{/if}
-        {if $resource.notes}<strong>Notas:</strong> {$resource.notes|escape|nl2br}<br/>{/if}
+        {if $resource.description}<strong>Descripción:</strong> {$resource.description|sanitize_rich_text|url2link|nl2br}<br/>{/if}
+        {if $resource.notes}<strong>Notas:</strong> {$resource.notes|sanitize_rich_text|url2link|nl2br}<br/>{/if}
         {if $resource.resourceAdministrator}<strong>Administrador del recurso:</strong> {$resource.resourceAdministrator|escape}<br/>{/if}
 
         {if $resource.attributeRows|default:array()|count > 0}

--- a/lang/es/ReservationCreatedAdmin.tpl
+++ b/lang/es/ReservationCreatedAdmin.tpl
@@ -33,8 +33,8 @@
         <strong>ID del recurso:</strong> {$resource.id}<br/>
         {if $resource.location}<strong>Ubicación:</strong> {$resource.location|escape}<br/>{/if}
         {if $resource.contact}<strong>Contacto:</strong> {$resource.contact|escape}<br/>{/if}
-        {if $resource.description}<strong>Descripción:</strong> {$resource.description|escape|nl2br}<br/>{/if}
-        {if $resource.notes}<strong>Notas:</strong> {$resource.notes|escape|nl2br}<br/>{/if}
+        {if $resource.description}<strong>Descripción:</strong> {$resource.description|sanitize_rich_text|url2link|nl2br}<br/>{/if}
+        {if $resource.notes}<strong>Notas:</strong> {$resource.notes|sanitize_rich_text|url2link|nl2br}<br/>{/if}
         {if $resource.resourceAdministrator}<strong>Administrador del recurso:</strong> {$resource.resourceAdministrator|escape}<br/>{/if}
 
         {if $resource.attributeRows|default:array()|count > 0}

--- a/lang/eu_es/ReservationCreated.tpl
+++ b/lang/eu_es/ReservationCreated.tpl
@@ -16,8 +16,8 @@
 		<strong>Baliabide IDa:</strong> {$resource.id}<br/>
 		{if $resource.location}<strong>Kokapena:</strong> {$resource.location|escape}<br/>{/if}
 		{if $resource.contact}<strong>Kontaktua:</strong> {$resource.contact|escape}<br/>{/if}
-		{if $resource.description}<strong>Deskribapena:</strong> {$resource.description|escape|nl2br}<br/>{/if}
-		{if $resource.notes}<strong>Oharrak:</strong> {$resource.notes|escape|nl2br}<br/>{/if}
+		{if $resource.description}<strong>Deskribapena:</strong> {$resource.description|sanitize_rich_text|url2link|nl2br}<br/>{/if}
+		{if $resource.notes}<strong>Oharrak:</strong> {$resource.notes|sanitize_rich_text|url2link|nl2br}<br/>{/if}
 		{if $resource.resourceAdministrator}<strong>Baliabide administratzailea:</strong> {$resource.resourceAdministrator|escape}<br/>{/if}
 
 		{if $resource.attributeRows|default:array()|count > 0}

--- a/lang/eu_es/ReservationCreatedAdmin.tpl
+++ b/lang/eu_es/ReservationCreatedAdmin.tpl
@@ -17,8 +17,8 @@
 		<strong>Baliabide IDa:</strong> {$resource.id}<br/>
 		{if $resource.location}<strong>Kokapena:</strong> {$resource.location|escape}<br/>{/if}
 		{if $resource.contact}<strong>Kontaktua:</strong> {$resource.contact|escape}<br/>{/if}
-		{if $resource.description}<strong>Deskribapena:</strong> {$resource.description|escape|nl2br}<br/>{/if}
-		{if $resource.notes}<strong>Oharrak:</strong> {$resource.notes|escape|nl2br}<br/>{/if}
+		{if $resource.description}<strong>Deskribapena:</strong> {$resource.description|sanitize_rich_text|url2link|nl2br}<br/>{/if}
+		{if $resource.notes}<strong>Oharrak:</strong> {$resource.notes|sanitize_rich_text|url2link|nl2br}<br/>{/if}
 		{if $resource.resourceAdministrator}<strong>Baliabide administratzailea:</strong> {$resource.resourceAdministrator|escape}<br/>{/if}
 
 		{if $resource.attributeRows|default:array()|count > 0}

--- a/lang/fi_fi/ReservationCreated.tpl
+++ b/lang/fi_fi/ReservationCreated.tpl
@@ -16,8 +16,8 @@
 		<strong>Resurssin tunnus:</strong> {$resource.id}<br/>
 		{if $resource.location}<strong>Sijainti:</strong> {$resource.location|escape}<br/>{/if}
 		{if $resource.contact}<strong>Yhteystieto:</strong> {$resource.contact|escape}<br/>{/if}
-		{if $resource.description}<strong>Kuvaus:</strong> {$resource.description|escape|nl2br}<br/>{/if}
-		{if $resource.notes}<strong>Huomautukset:</strong> {$resource.notes|escape|nl2br}<br/>{/if}
+		{if $resource.description}<strong>Kuvaus:</strong> {$resource.description|sanitize_rich_text|url2link|nl2br}<br/>{/if}
+		{if $resource.notes}<strong>Huomautukset:</strong> {$resource.notes|sanitize_rich_text|url2link|nl2br}<br/>{/if}
 		{if $resource.resourceAdministrator}<strong>Resurssin ylläpitäjä:</strong> {$resource.resourceAdministrator|escape}<br/>{/if}
 
 		{if $resource.attributeRows|default:array()|count > 0}

--- a/lang/fi_fi/ReservationCreatedAdmin.tpl
+++ b/lang/fi_fi/ReservationCreatedAdmin.tpl
@@ -17,8 +17,8 @@
 		<strong>Resurssin tunnus:</strong> {$resource.id}<br/>
 		{if $resource.location}<strong>Sijainti:</strong> {$resource.location|escape}<br/>{/if}
 		{if $resource.contact}<strong>Yhteystieto:</strong> {$resource.contact|escape}<br/>{/if}
-		{if $resource.description}<strong>Kuvaus:</strong> {$resource.description|escape|nl2br}<br/>{/if}
-		{if $resource.notes}<strong>Huomautukset:</strong> {$resource.notes|escape|nl2br}<br/>{/if}
+		{if $resource.description}<strong>Kuvaus:</strong> {$resource.description|sanitize_rich_text|url2link|nl2br}<br/>{/if}
+		{if $resource.notes}<strong>Huomautukset:</strong> {$resource.notes|sanitize_rich_text|url2link|nl2br}<br/>{/if}
 		{if $resource.resourceAdministrator}<strong>Resurssin ylläpitäjä:</strong> {$resource.resourceAdministrator|escape}<br/>{/if}
 
 		{if $resource.attributeRows|default:array()|count > 0}

--- a/lang/fr_fr/ReservationCreated.tpl
+++ b/lang/fr_fr/ReservationCreated.tpl
@@ -26,8 +26,8 @@
         <strong>ID de la ressource:</strong> {$resource.id}<br/>
         {if $resource.location}<strong>Emplacement:</strong> {$resource.location|escape}<br/>{/if}
         {if $resource.contact}<strong>Contact:</strong> {$resource.contact|escape}<br/>{/if}
-        {if $resource.description}<strong>Description:</strong> {$resource.description|escape|nl2br}<br/>{/if}
-        {if $resource.notes}<strong>Notes:</strong> {$resource.notes|escape|nl2br}<br/>{/if}
+        {if $resource.description}<strong>Description:</strong> {$resource.description|sanitize_rich_text|url2link|nl2br}<br/>{/if}
+        {if $resource.notes}<strong>Notes:</strong> {$resource.notes|sanitize_rich_text|url2link|nl2br}<br/>{/if}
         {if $resource.resourceAdministrator}<strong>Administrateur de la ressource:</strong> {$resource.resourceAdministrator|escape}<br/>{/if}
 
         {if $resource.attributeRows|default:array()|count > 0}

--- a/lang/fr_fr/ReservationCreatedAdmin.tpl
+++ b/lang/fr_fr/ReservationCreatedAdmin.tpl
@@ -33,8 +33,8 @@
         <strong>ID de la ressource:</strong> {$resource.id}<br/>
         {if $resource.location}<strong>Emplacement:</strong> {$resource.location|escape}<br/>{/if}
         {if $resource.contact}<strong>Contact:</strong> {$resource.contact|escape}<br/>{/if}
-        {if $resource.description}<strong>Description:</strong> {$resource.description|escape|nl2br}<br/>{/if}
-        {if $resource.notes}<strong>Notes:</strong> {$resource.notes|escape|nl2br}<br/>{/if}
+        {if $resource.description}<strong>Description:</strong> {$resource.description|sanitize_rich_text|url2link|nl2br}<br/>{/if}
+        {if $resource.notes}<strong>Notes:</strong> {$resource.notes|sanitize_rich_text|url2link|nl2br}<br/>{/if}
         {if $resource.resourceAdministrator}<strong>Administrateur de la ressource:</strong> {$resource.resourceAdministrator|escape}<br/>{/if}
 
         {if $resource.attributeRows|default:array()|count > 0}

--- a/lang/he/ReservationCreated.tpl
+++ b/lang/he/ReservationCreated.tpl
@@ -16,8 +16,8 @@
 		<strong>מזהה משאב:</strong> {$resource.id}<br/>
 		{if $resource.location}<strong>מיקום:</strong> {$resource.location|escape}<br/>{/if}
 		{if $resource.contact}<strong>איש קשר:</strong> {$resource.contact|escape}<br/>{/if}
-		{if $resource.description}<strong>תיאור:</strong> {$resource.description|escape|nl2br}<br/>{/if}
-		{if $resource.notes}<strong>הערות:</strong> {$resource.notes|escape|nl2br}<br/>{/if}
+		{if $resource.description}<strong>תיאור:</strong> {$resource.description|sanitize_rich_text|url2link|nl2br}<br/>{/if}
+		{if $resource.notes}<strong>הערות:</strong> {$resource.notes|sanitize_rich_text|url2link|nl2br}<br/>{/if}
 		{if $resource.resourceAdministrator}<strong>מנהל משאב:</strong> {$resource.resourceAdministrator|escape}<br/>{/if}
 
 		{if $resource.attributeRows|default:array()|count > 0}

--- a/lang/he/ReservationCreatedAdmin.tpl
+++ b/lang/he/ReservationCreatedAdmin.tpl
@@ -17,8 +17,8 @@
 		<strong>מזהה משאב:</strong> {$resource.id}<br/>
 		{if $resource.location}<strong>מיקום:</strong> {$resource.location|escape}<br/>{/if}
 		{if $resource.contact}<strong>איש קשר:</strong> {$resource.contact|escape}<br/>{/if}
-		{if $resource.description}<strong>תיאור:</strong> {$resource.description|escape|nl2br}<br/>{/if}
-		{if $resource.notes}<strong>הערות:</strong> {$resource.notes|escape|nl2br}<br/>{/if}
+		{if $resource.description}<strong>תיאור:</strong> {$resource.description|sanitize_rich_text|url2link|nl2br}<br/>{/if}
+		{if $resource.notes}<strong>הערות:</strong> {$resource.notes|sanitize_rich_text|url2link|nl2br}<br/>{/if}
 		{if $resource.resourceAdministrator}<strong>מנהל משאב:</strong> {$resource.resourceAdministrator|escape}<br/>{/if}
 
 		{if $resource.attributeRows|default:array()|count > 0}

--- a/lang/hr_hr/ReservationCreated.tpl
+++ b/lang/hr_hr/ReservationCreated.tpl
@@ -16,8 +16,8 @@
 		<strong>ID resursa:</strong> {$resource.id}<br/>
 		{if $resource.location}<strong>Lokacija:</strong> {$resource.location|escape}<br/>{/if}
 		{if $resource.contact}<strong>Kontakt:</strong> {$resource.contact|escape}<br/>{/if}
-		{if $resource.description}<strong>Opis:</strong> {$resource.description|escape|nl2br}<br/>{/if}
-		{if $resource.notes}<strong>Bilješke:</strong> {$resource.notes|escape|nl2br}<br/>{/if}
+		{if $resource.description}<strong>Opis:</strong> {$resource.description|sanitize_rich_text|url2link|nl2br}<br/>{/if}
+		{if $resource.notes}<strong>Bilješke:</strong> {$resource.notes|sanitize_rich_text|url2link|nl2br}<br/>{/if}
 		{if $resource.resourceAdministrator}<strong>Administrator resursa:</strong> {$resource.resourceAdministrator|escape}<br/>{/if}
 
 		{if $resource.attributeRows|default:array()|count > 0}

--- a/lang/hr_hr/ReservationCreatedAdmin.tpl
+++ b/lang/hr_hr/ReservationCreatedAdmin.tpl
@@ -17,8 +17,8 @@
 		<strong>ID resursa:</strong> {$resource.id}<br/>
 		{if $resource.location}<strong>Lokacija:</strong> {$resource.location|escape}<br/>{/if}
 		{if $resource.contact}<strong>Kontakt:</strong> {$resource.contact|escape}<br/>{/if}
-		{if $resource.description}<strong>Opis:</strong> {$resource.description|escape|nl2br}<br/>{/if}
-		{if $resource.notes}<strong>Bilješke:</strong> {$resource.notes|escape|nl2br}<br/>{/if}
+		{if $resource.description}<strong>Opis:</strong> {$resource.description|sanitize_rich_text|url2link|nl2br}<br/>{/if}
+		{if $resource.notes}<strong>Bilješke:</strong> {$resource.notes|sanitize_rich_text|url2link|nl2br}<br/>{/if}
 		{if $resource.resourceAdministrator}<strong>Administrator resursa:</strong> {$resource.resourceAdministrator|escape}<br/>{/if}
 
 		{if $resource.attributeRows|default:array()|count > 0}

--- a/lang/hu_hu/ReservationCreated.tpl
+++ b/lang/hu_hu/ReservationCreated.tpl
@@ -16,8 +16,8 @@ Befejezés: {formatdate date=$EndDate key=reservation_email}<br/>
         <strong>Erőforrás azonosító:</strong> {$resource.id}<br/>
         {if $resource.location}<strong>Helyszín:</strong> {$resource.location|escape}<br/>{/if}
         {if $resource.contact}<strong>Kapcsolat:</strong> {$resource.contact|escape}<br/>{/if}
-        {if $resource.description}<strong>Leírás:</strong> {$resource.description|escape|nl2br}<br/>{/if}
-        {if $resource.notes}<strong>Megjegyzések:</strong> {$resource.notes|escape|nl2br}<br/>{/if}
+        {if $resource.description}<strong>Leírás:</strong> {$resource.description|sanitize_rich_text|url2link|nl2br}<br/>{/if}
+        {if $resource.notes}<strong>Megjegyzések:</strong> {$resource.notes|sanitize_rich_text|url2link|nl2br}<br/>{/if}
         {if $resource.resourceAdministrator}<strong>Erőforrás rendszergazda:</strong> {$resource.resourceAdministrator|escape}<br/>{/if}
 
         {if $resource.attributeRows|default:array()|count > 0}

--- a/lang/hu_hu/ReservationCreatedAdmin.tpl
+++ b/lang/hu_hu/ReservationCreatedAdmin.tpl
@@ -22,8 +22,8 @@ Befejezés: {formatdate date=$EndDate key=reservation_email}<br/>
         <strong>Erőforrás azonosító:</strong> {$resource.id}<br/>
         {if $resource.location}<strong>Helyszín:</strong> {$resource.location|escape}<br/>{/if}
         {if $resource.contact}<strong>Kapcsolat:</strong> {$resource.contact|escape}<br/>{/if}
-        {if $resource.description}<strong>Leírás:</strong> {$resource.description|escape|nl2br}<br/>{/if}
-        {if $resource.notes}<strong>Megjegyzések:</strong> {$resource.notes|escape|nl2br}<br/>{/if}
+        {if $resource.description}<strong>Leírás:</strong> {$resource.description|sanitize_rich_text|url2link|nl2br}<br/>{/if}
+        {if $resource.notes}<strong>Megjegyzések:</strong> {$resource.notes|sanitize_rich_text|url2link|nl2br}<br/>{/if}
         {if $resource.resourceAdministrator}<strong>Erőforrás rendszergazda:</strong> {$resource.resourceAdministrator|escape}<br/>{/if}
 
         {if $resource.attributeRows|default:array()|count > 0}

--- a/lang/id_id/ReservationCreated.tpl
+++ b/lang/id_id/ReservationCreated.tpl
@@ -16,8 +16,8 @@
 		<strong>ID Sumber Daya:</strong> {$resource.id}<br/>
 		{if $resource.location}<strong>Lokasi:</strong> {$resource.location|escape}<br/>{/if}
 		{if $resource.contact}<strong>Kontak:</strong> {$resource.contact|escape}<br/>{/if}
-		{if $resource.description}<strong>Deskripsi:</strong> {$resource.description|escape|nl2br}<br/>{/if}
-		{if $resource.notes}<strong>Catatan:</strong> {$resource.notes|escape|nl2br}<br/>{/if}
+		{if $resource.description}<strong>Deskripsi:</strong> {$resource.description|sanitize_rich_text|url2link|nl2br}<br/>{/if}
+		{if $resource.notes}<strong>Catatan:</strong> {$resource.notes|sanitize_rich_text|url2link|nl2br}<br/>{/if}
 		{if $resource.resourceAdministrator}<strong>Administrator Sumber Daya:</strong> {$resource.resourceAdministrator|escape}<br/>{/if}
 
 		{if $resource.attributeRows|default:array()|count > 0}

--- a/lang/id_id/ReservationCreatedAdmin.tpl
+++ b/lang/id_id/ReservationCreatedAdmin.tpl
@@ -17,8 +17,8 @@
 		<strong>ID Sumber Daya:</strong> {$resource.id}<br/>
 		{if $resource.location}<strong>Lokasi:</strong> {$resource.location|escape}<br/>{/if}
 		{if $resource.contact}<strong>Kontak:</strong> {$resource.contact|escape}<br/>{/if}
-		{if $resource.description}<strong>Deskripsi:</strong> {$resource.description|escape|nl2br}<br/>{/if}
-		{if $resource.notes}<strong>Catatan:</strong> {$resource.notes|escape|nl2br}<br/>{/if}
+		{if $resource.description}<strong>Deskripsi:</strong> {$resource.description|sanitize_rich_text|url2link|nl2br}<br/>{/if}
+		{if $resource.notes}<strong>Catatan:</strong> {$resource.notes|sanitize_rich_text|url2link|nl2br}<br/>{/if}
 		{if $resource.resourceAdministrator}<strong>Administrator Sumber Daya:</strong> {$resource.resourceAdministrator|escape}<br/>{/if}
 
 		{if $resource.attributeRows|default:array()|count > 0}

--- a/lang/it_it/ReservationCreated.tpl
+++ b/lang/it_it/ReservationCreated.tpl
@@ -26,8 +26,8 @@
         <strong>ID risorsa:</strong> {$resource.id}<br/>
         {if $resource.location}<strong>Posizione:</strong> {$resource.location|escape}<br/>{/if}
         {if $resource.contact}<strong>Contatto:</strong> {$resource.contact|escape}<br/>{/if}
-        {if $resource.description}<strong>Descrizione:</strong> {$resource.description|escape|nl2br}<br/>{/if}
-        {if $resource.notes}<strong>Note:</strong> {$resource.notes|escape|nl2br}<br/>{/if}
+        {if $resource.description}<strong>Descrizione:</strong> {$resource.description|sanitize_rich_text|url2link|nl2br}<br/>{/if}
+        {if $resource.notes}<strong>Note:</strong> {$resource.notes|sanitize_rich_text|url2link|nl2br}<br/>{/if}
         {if $resource.resourceAdministrator}<strong>Amministratore della risorsa:</strong> {$resource.resourceAdministrator|escape}<br/>{/if}
 
         {if $resource.attributeRows|default:array()|count > 0}

--- a/lang/it_it/ReservationCreatedAdmin.tpl
+++ b/lang/it_it/ReservationCreatedAdmin.tpl
@@ -30,8 +30,8 @@
         <strong>ID risorsa:</strong> {$resource.id}<br/>
         {if $resource.location}<strong>Posizione:</strong> {$resource.location|escape}<br/>{/if}
         {if $resource.contact}<strong>Contatto:</strong> {$resource.contact|escape}<br/>{/if}
-        {if $resource.description}<strong>Descrizione:</strong> {$resource.description|escape|nl2br}<br/>{/if}
-        {if $resource.notes}<strong>Note:</strong> {$resource.notes|escape|nl2br}<br/>{/if}
+        {if $resource.description}<strong>Descrizione:</strong> {$resource.description|sanitize_rich_text|url2link|nl2br}<br/>{/if}
+        {if $resource.notes}<strong>Note:</strong> {$resource.notes|sanitize_rich_text|url2link|nl2br}<br/>{/if}
         {if $resource.resourceAdministrator}<strong>Amministratore della risorsa:</strong> {$resource.resourceAdministrator|escape}<br/>{/if}
 
         {if $resource.attributeRows|default:array()|count > 0}

--- a/lang/ja_jp/ReservationCreated.tpl
+++ b/lang/ja_jp/ReservationCreated.tpl
@@ -16,8 +16,8 @@
 		<strong>リソースID:</strong> {$resource.id}<br/>
 		{if $resource.location}<strong>場所:</strong> {$resource.location|escape}<br/>{/if}
 		{if $resource.contact}<strong>連絡先:</strong> {$resource.contact|escape}<br/>{/if}
-		{if $resource.description}<strong>説明:</strong> {$resource.description|escape|nl2br}<br/>{/if}
-		{if $resource.notes}<strong>備考:</strong> {$resource.notes|escape|nl2br}<br/>{/if}
+		{if $resource.description}<strong>説明:</strong> {$resource.description|sanitize_rich_text|url2link|nl2br}<br/>{/if}
+		{if $resource.notes}<strong>備考:</strong> {$resource.notes|sanitize_rich_text|url2link|nl2br}<br/>{/if}
 		{if $resource.resourceAdministrator}<strong>リソース管理者:</strong> {$resource.resourceAdministrator|escape}<br/>{/if}
 
 		{if $resource.attributeRows|default:array()|count > 0}

--- a/lang/ja_jp/ReservationCreatedAdmin.tpl
+++ b/lang/ja_jp/ReservationCreatedAdmin.tpl
@@ -17,8 +17,8 @@
 		<strong>リソースID:</strong> {$resource.id}<br/>
 		{if $resource.location}<strong>場所:</strong> {$resource.location|escape}<br/>{/if}
 		{if $resource.contact}<strong>連絡先:</strong> {$resource.contact|escape}<br/>{/if}
-		{if $resource.description}<strong>説明:</strong> {$resource.description|escape|nl2br}<br/>{/if}
-		{if $resource.notes}<strong>備考:</strong> {$resource.notes|escape|nl2br}<br/>{/if}
+		{if $resource.description}<strong>説明:</strong> {$resource.description|sanitize_rich_text|url2link|nl2br}<br/>{/if}
+		{if $resource.notes}<strong>備考:</strong> {$resource.notes|sanitize_rich_text|url2link|nl2br}<br/>{/if}
 		{if $resource.resourceAdministrator}<strong>リソース管理者:</strong> {$resource.resourceAdministrator|escape}<br/>{/if}
 
 		{if $resource.attributeRows|default:array()|count > 0}

--- a/lang/pl/ReservationCreated.tpl
+++ b/lang/pl/ReservationCreated.tpl
@@ -16,8 +16,8 @@
 		<strong>ID zasobu:</strong> {$resource.id}<br/>
 		{if $resource.location}<strong>Lokalizacja:</strong> {$resource.location|escape}<br/>{/if}
 		{if $resource.contact}<strong>Kontakt:</strong> {$resource.contact|escape}<br/>{/if}
-		{if $resource.description}<strong>Opis:</strong> {$resource.description|escape|nl2br}<br/>{/if}
-		{if $resource.notes}<strong>Uwagi:</strong> {$resource.notes|escape|nl2br}<br/>{/if}
+		{if $resource.description}<strong>Opis:</strong> {$resource.description|sanitize_rich_text|url2link|nl2br}<br/>{/if}
+		{if $resource.notes}<strong>Uwagi:</strong> {$resource.notes|sanitize_rich_text|url2link|nl2br}<br/>{/if}
 		{if $resource.resourceAdministrator}<strong>Administrator zasobu:</strong> {$resource.resourceAdministrator|escape}<br/>{/if}
 
 		{if $resource.attributeRows|default:array()|count > 0}

--- a/lang/pl/ReservationCreatedAdmin.tpl
+++ b/lang/pl/ReservationCreatedAdmin.tpl
@@ -17,8 +17,8 @@
 		<strong>ID zasobu:</strong> {$resource.id}<br/>
 		{if $resource.location}<strong>Lokalizacja:</strong> {$resource.location|escape}<br/>{/if}
 		{if $resource.contact}<strong>Kontakt:</strong> {$resource.contact|escape}<br/>{/if}
-		{if $resource.description}<strong>Opis:</strong> {$resource.description|escape|nl2br}<br/>{/if}
-		{if $resource.notes}<strong>Uwagi:</strong> {$resource.notes|escape|nl2br}<br/>{/if}
+		{if $resource.description}<strong>Opis:</strong> {$resource.description|sanitize_rich_text|url2link|nl2br}<br/>{/if}
+		{if $resource.notes}<strong>Uwagi:</strong> {$resource.notes|sanitize_rich_text|url2link|nl2br}<br/>{/if}
 		{if $resource.resourceAdministrator}<strong>Administrator zasobu:</strong> {$resource.resourceAdministrator|escape}<br/>{/if}
 
 		{if $resource.attributeRows|default:array()|count > 0}

--- a/lang/pt_br/ReservationCreated.tpl
+++ b/lang/pt_br/ReservationCreated.tpl
@@ -31,8 +31,8 @@
         <strong>ID do recurso:</strong> {$resource.id}<br/>
         {if $resource.location}<strong>Localização:</strong> {$resource.location|escape}<br/>{/if}
         {if $resource.contact}<strong>Contato:</strong> {$resource.contact|escape}<br/>{/if}
-        {if $resource.description}<strong>Descrição:</strong> {$resource.description|escape|nl2br}<br/>{/if}
-        {if $resource.notes}<strong>Notas:</strong> {$resource.notes|escape|nl2br}<br/>{/if}
+        {if $resource.description}<strong>Descrição:</strong> {$resource.description|sanitize_rich_text|url2link|nl2br}<br/>{/if}
+        {if $resource.notes}<strong>Notas:</strong> {$resource.notes|sanitize_rich_text|url2link|nl2br}<br/>{/if}
         {if $resource.resourceAdministrator}<strong>Administrador do recurso:</strong> {$resource.resourceAdministrator|escape}<br/>{/if}
 
         {if $resource.attributeRows|default:array()|count > 0}

--- a/lang/pt_br/ReservationCreatedAdmin.tpl
+++ b/lang/pt_br/ReservationCreatedAdmin.tpl
@@ -38,8 +38,8 @@
         <strong>ID do recurso:</strong> {$resource.id}<br/>
         {if $resource.location}<strong>Localização:</strong> {$resource.location|escape}<br/>{/if}
         {if $resource.contact}<strong>Contato:</strong> {$resource.contact|escape}<br/>{/if}
-        {if $resource.description}<strong>Descrição:</strong> {$resource.description|escape|nl2br}<br/>{/if}
-        {if $resource.notes}<strong>Notas:</strong> {$resource.notes|escape|nl2br}<br/>{/if}
+        {if $resource.description}<strong>Descrição:</strong> {$resource.description|sanitize_rich_text|url2link|nl2br}<br/>{/if}
+        {if $resource.notes}<strong>Notas:</strong> {$resource.notes|sanitize_rich_text|url2link|nl2br}<br/>{/if}
         {if $resource.resourceAdministrator}<strong>Administrador do recurso:</strong> {$resource.resourceAdministrator|escape}<br/>{/if}
 
         {if $resource.attributeRows|default:array()|count > 0}

--- a/lang/pt_pt/ReservationCreated.tpl
+++ b/lang/pt_pt/ReservationCreated.tpl
@@ -26,8 +26,8 @@
         <strong>ID do recurso:</strong> {$resource.id}<br/>
         {if $resource.location}<strong>Localização:</strong> {$resource.location|escape}<br/>{/if}
         {if $resource.contact}<strong>Contacto:</strong> {$resource.contact|escape}<br/>{/if}
-        {if $resource.description}<strong>Descrição:</strong> {$resource.description|escape|nl2br}<br/>{/if}
-        {if $resource.notes}<strong>Notas:</strong> {$resource.notes|escape|nl2br}<br/>{/if}
+        {if $resource.description}<strong>Descrição:</strong> {$resource.description|sanitize_rich_text|url2link|nl2br}<br/>{/if}
+        {if $resource.notes}<strong>Notas:</strong> {$resource.notes|sanitize_rich_text|url2link|nl2br}<br/>{/if}
         {if $resource.resourceAdministrator}<strong>Administrador do recurso:</strong> {$resource.resourceAdministrator|escape}<br/>{/if}
 
         {if $resource.attributeRows|default:array()|count > 0}

--- a/lang/pt_pt/ReservationCreatedAdmin.tpl
+++ b/lang/pt_pt/ReservationCreatedAdmin.tpl
@@ -33,8 +33,8 @@
         <strong>ID do recurso:</strong> {$resource.id}<br/>
         {if $resource.location}<strong>Localização:</strong> {$resource.location|escape}<br/>{/if}
         {if $resource.contact}<strong>Contacto:</strong> {$resource.contact|escape}<br/>{/if}
-        {if $resource.description}<strong>Descrição:</strong> {$resource.description|escape|nl2br}<br/>{/if}
-        {if $resource.notes}<strong>Notas:</strong> {$resource.notes|escape|nl2br}<br/>{/if}
+        {if $resource.description}<strong>Descrição:</strong> {$resource.description|sanitize_rich_text|url2link|nl2br}<br/>{/if}
+        {if $resource.notes}<strong>Notas:</strong> {$resource.notes|sanitize_rich_text|url2link|nl2br}<br/>{/if}
         {if $resource.resourceAdministrator}<strong>Administrador do recurso:</strong> {$resource.resourceAdministrator|escape}<br/>{/if}
 
         {if $resource.attributeRows|default:array()|count > 0}

--- a/lang/si_si/ReservationCreated.tpl
+++ b/lang/si_si/ReservationCreated.tpl
@@ -16,8 +16,8 @@
 		<strong>ID vira:</strong> {$resource.id}<br/>
 		{if $resource.location}<strong>Lokacija:</strong> {$resource.location|escape}<br/>{/if}
 		{if $resource.contact}<strong>Kontakt:</strong> {$resource.contact|escape}<br/>{/if}
-		{if $resource.description}<strong>Opis:</strong> {$resource.description|escape|nl2br}<br/>{/if}
-		{if $resource.notes}<strong>Opombe:</strong> {$resource.notes|escape|nl2br}<br/>{/if}
+		{if $resource.description}<strong>Opis:</strong> {$resource.description|sanitize_rich_text|url2link|nl2br}<br/>{/if}
+		{if $resource.notes}<strong>Opombe:</strong> {$resource.notes|sanitize_rich_text|url2link|nl2br}<br/>{/if}
 		{if $resource.resourceAdministrator}<strong>Administrator vira:</strong> {$resource.resourceAdministrator|escape}<br/>{/if}
 
 		{if $resource.attributeRows|default:array()|count > 0}

--- a/lang/si_si/ReservationCreatedAdmin.tpl
+++ b/lang/si_si/ReservationCreatedAdmin.tpl
@@ -17,8 +17,8 @@
 		<strong>ID vira:</strong> {$resource.id}<br/>
 		{if $resource.location}<strong>Lokacija:</strong> {$resource.location|escape}<br/>{/if}
 		{if $resource.contact}<strong>Kontakt:</strong> {$resource.contact|escape}<br/>{/if}
-		{if $resource.description}<strong>Opis:</strong> {$resource.description|escape|nl2br}<br/>{/if}
-		{if $resource.notes}<strong>Opombe:</strong> {$resource.notes|escape|nl2br}<br/>{/if}
+		{if $resource.description}<strong>Opis:</strong> {$resource.description|sanitize_rich_text|url2link|nl2br}<br/>{/if}
+		{if $resource.notes}<strong>Opombe:</strong> {$resource.notes|sanitize_rich_text|url2link|nl2br}<br/>{/if}
 		{if $resource.resourceAdministrator}<strong>Administrator vira:</strong> {$resource.resourceAdministrator|escape}<br/>{/if}
 
 		{if $resource.attributeRows|default:array()|count > 0}

--- a/lang/sk/ReservationCreated.tpl
+++ b/lang/sk/ReservationCreated.tpl
@@ -18,8 +18,8 @@
 		<strong>ID zdroja:</strong> {$resource.id}<br/>
 		{if $resource.location}<strong>Umiestnenie:</strong> {$resource.location|escape}<br/>{/if}
 		{if $resource.contact}<strong>Kontakt:</strong> {$resource.contact|escape}<br/>{/if}
-		{if $resource.description}<strong>Popis:</strong> {$resource.description|escape|nl2br}<br/>{/if}
-		{if $resource.notes}<strong>Poznámky:</strong> {$resource.notes|escape|nl2br}<br/>{/if}
+		{if $resource.description}<strong>Popis:</strong> {$resource.description|sanitize_rich_text|url2link|nl2br}<br/>{/if}
+		{if $resource.notes}<strong>Poznámky:</strong> {$resource.notes|sanitize_rich_text|url2link|nl2br}<br/>{/if}
 		{if $resource.resourceAdministrator}<strong>Správca zdroja:</strong> {$resource.resourceAdministrator|escape}<br/>{/if}
 
 		{if $resource.attributeRows|default:array()|count > 0}

--- a/lang/sk/ReservationCreatedAdmin.tpl
+++ b/lang/sk/ReservationCreatedAdmin.tpl
@@ -19,8 +19,8 @@
 		<strong>ID zdroja:</strong> {$resource.id}<br/>
 		{if $resource.location}<strong>Umiestnenie:</strong> {$resource.location|escape}<br/>{/if}
 		{if $resource.contact}<strong>Kontakt:</strong> {$resource.contact|escape}<br/>{/if}
-		{if $resource.description}<strong>Popis:</strong> {$resource.description|escape|nl2br}<br/>{/if}
-		{if $resource.notes}<strong>Poznámky:</strong> {$resource.notes|escape|nl2br}<br/>{/if}
+		{if $resource.description}<strong>Popis:</strong> {$resource.description|sanitize_rich_text|url2link|nl2br}<br/>{/if}
+		{if $resource.notes}<strong>Poznámky:</strong> {$resource.notes|sanitize_rich_text|url2link|nl2br}<br/>{/if}
 		{if $resource.resourceAdministrator}<strong>Správca zdroja:</strong> {$resource.resourceAdministrator|escape}<br/>{/if}
 
 		{if $resource.attributeRows|default:array()|count > 0}

--- a/lang/sr_sr/ReservationCreated.tpl
+++ b/lang/sr_sr/ReservationCreated.tpl
@@ -16,8 +16,8 @@
 		<strong>ID resursa:</strong> {$resource.id}<br/>
 		{if $resource.location}<strong>Lokacija:</strong> {$resource.location|escape}<br/>{/if}
 		{if $resource.contact}<strong>Kontakt:</strong> {$resource.contact|escape}<br/>{/if}
-		{if $resource.description}<strong>Opis:</strong> {$resource.description|escape|nl2br}<br/>{/if}
-		{if $resource.notes}<strong>Beleške:</strong> {$resource.notes|escape|nl2br}<br/>{/if}
+		{if $resource.description}<strong>Opis:</strong> {$resource.description|sanitize_rich_text|url2link|nl2br}<br/>{/if}
+		{if $resource.notes}<strong>Beleške:</strong> {$resource.notes|sanitize_rich_text|url2link|nl2br}<br/>{/if}
 		{if $resource.resourceAdministrator}<strong>Administrator resursa:</strong> {$resource.resourceAdministrator|escape}<br/>{/if}
 
 		{if $resource.attributeRows|default:array()|count > 0}

--- a/lang/sr_sr/ReservationCreatedAdmin.tpl
+++ b/lang/sr_sr/ReservationCreatedAdmin.tpl
@@ -17,8 +17,8 @@
 		<strong>ID resursa:</strong> {$resource.id}<br/>
 		{if $resource.location}<strong>Lokacija:</strong> {$resource.location|escape}<br/>{/if}
 		{if $resource.contact}<strong>Kontakt:</strong> {$resource.contact|escape}<br/>{/if}
-		{if $resource.description}<strong>Opis:</strong> {$resource.description|escape|nl2br}<br/>{/if}
-		{if $resource.notes}<strong>Beleške:</strong> {$resource.notes|escape|nl2br}<br/>{/if}
+		{if $resource.description}<strong>Opis:</strong> {$resource.description|sanitize_rich_text|url2link|nl2br}<br/>{/if}
+		{if $resource.notes}<strong>Beleške:</strong> {$resource.notes|sanitize_rich_text|url2link|nl2br}<br/>{/if}
 		{if $resource.resourceAdministrator}<strong>Administrator resursa:</strong> {$resource.resourceAdministrator|escape}<br/>{/if}
 
 		{if $resource.attributeRows|default:array()|count > 0}

--- a/lang/sv_sv/ReservationCreated.tpl
+++ b/lang/sv_sv/ReservationCreated.tpl
@@ -18,8 +18,8 @@
 		<strong>Resurs-ID:</strong> {$resource.id}<br/>
 		{if $resource.location}<strong>Plats:</strong> {$resource.location|escape}<br/>{/if}
 		{if $resource.contact}<strong>Kontakt:</strong> {$resource.contact|escape}<br/>{/if}
-		{if $resource.description}<strong>Beskrivning:</strong> {$resource.description|escape|nl2br}<br/>{/if}
-		{if $resource.notes}<strong>Anteckningar:</strong> {$resource.notes|escape|nl2br}<br/>{/if}
+		{if $resource.description}<strong>Beskrivning:</strong> {$resource.description|sanitize_rich_text|url2link|nl2br}<br/>{/if}
+		{if $resource.notes}<strong>Anteckningar:</strong> {$resource.notes|sanitize_rich_text|url2link|nl2br}<br/>{/if}
 		{if $resource.resourceAdministrator}<strong>Resursadministratör:</strong> {$resource.resourceAdministrator|escape}<br/>{/if}
 
 		{if $resource.attributeRows|default:array()|count > 0}

--- a/lang/sv_sv/ReservationCreatedAdmin.tpl
+++ b/lang/sv_sv/ReservationCreatedAdmin.tpl
@@ -17,8 +17,8 @@
 		<strong>Resurs-ID:</strong> {$resource.id}<br/>
 		{if $resource.location}<strong>Plats:</strong> {$resource.location|escape}<br/>{/if}
 		{if $resource.contact}<strong>Kontakt:</strong> {$resource.contact|escape}<br/>{/if}
-		{if $resource.description}<strong>Beskrivning:</strong> {$resource.description|escape|nl2br}<br/>{/if}
-		{if $resource.notes}<strong>Anteckningar:</strong> {$resource.notes|escape|nl2br}<br/>{/if}
+		{if $resource.description}<strong>Beskrivning:</strong> {$resource.description|sanitize_rich_text|url2link|nl2br}<br/>{/if}
+		{if $resource.notes}<strong>Anteckningar:</strong> {$resource.notes|sanitize_rich_text|url2link|nl2br}<br/>{/if}
 		{if $resource.resourceAdministrator}<strong>Resursadministratör:</strong> {$resource.resourceAdministrator|escape}<br/>{/if}
 
 		{if $resource.attributeRows|default:array()|count > 0}

--- a/lang/th_th/ReservationCreated.tpl
+++ b/lang/th_th/ReservationCreated.tpl
@@ -16,8 +16,8 @@
         <strong>รหัสทรัพยากร:</strong> {$resource.id}<br/>
         {if $resource.location}<strong>สถานที่:</strong> {$resource.location|escape}<br/>{/if}
         {if $resource.contact}<strong>ผู้ติดต่อ:</strong> {$resource.contact|escape}<br/>{/if}
-        {if $resource.description}<strong>คำอธิบาย:</strong> {$resource.description|escape|nl2br}<br/>{/if}
-        {if $resource.notes}<strong>หมายเหตุ:</strong> {$resource.notes|escape|nl2br}<br/>{/if}
+        {if $resource.description}<strong>คำอธิบาย:</strong> {$resource.description|sanitize_rich_text|url2link|nl2br}<br/>{/if}
+        {if $resource.notes}<strong>หมายเหตุ:</strong> {$resource.notes|sanitize_rich_text|url2link|nl2br}<br/>{/if}
         {if $resource.resourceAdministrator}<strong>ผู้ดูแลทรัพยากร:</strong> {$resource.resourceAdministrator|escape}<br/>{/if}
 
         {if $resource.attributeRows|default:array()|count > 0}

--- a/lang/th_th/ReservationCreatedAdmin.tpl
+++ b/lang/th_th/ReservationCreatedAdmin.tpl
@@ -22,8 +22,8 @@
         <strong>รหัสทรัพยากร:</strong> {$resource.id}<br/>
         {if $resource.location}<strong>สถานที่:</strong> {$resource.location|escape}<br/>{/if}
         {if $resource.contact}<strong>ผู้ติดต่อ:</strong> {$resource.contact|escape}<br/>{/if}
-        {if $resource.description}<strong>คำอธิบาย:</strong> {$resource.description|escape|nl2br}<br/>{/if}
-        {if $resource.notes}<strong>หมายเหตุ:</strong> {$resource.notes|escape|nl2br}<br/>{/if}
+        {if $resource.description}<strong>คำอธิบาย:</strong> {$resource.description|sanitize_rich_text|url2link|nl2br}<br/>{/if}
+        {if $resource.notes}<strong>หมายเหตุ:</strong> {$resource.notes|sanitize_rich_text|url2link|nl2br}<br/>{/if}
         {if $resource.resourceAdministrator}<strong>ผู้ดูแลทรัพยากร:</strong> {$resource.resourceAdministrator|escape}<br/>{/if}
 
         {if $resource.attributeRows|default:array()|count > 0}

--- a/lang/vn_vn/ReservationCreated.tpl
+++ b/lang/vn_vn/ReservationCreated.tpl
@@ -16,8 +16,8 @@ Ending: {formatdate date=$EndDate key=reservation_email}<br/>
 		<strong>Mã tài nguyên:</strong> {$resource.id}<br/>
 		{if $resource.location}<strong>Vị trí:</strong> {$resource.location|escape}<br/>{/if}
 		{if $resource.contact}<strong>Liên hệ:</strong> {$resource.contact|escape}<br/>{/if}
-		{if $resource.description}<strong>Mô tả:</strong> {$resource.description|escape|nl2br}<br/>{/if}
-		{if $resource.notes}<strong>Ghi chú:</strong> {$resource.notes|escape|nl2br}<br/>{/if}
+		{if $resource.description}<strong>Mô tả:</strong> {$resource.description|sanitize_rich_text|url2link|nl2br}<br/>{/if}
+		{if $resource.notes}<strong>Ghi chú:</strong> {$resource.notes|sanitize_rich_text|url2link|nl2br}<br/>{/if}
 		{if $resource.resourceAdministrator}<strong>Quản trị viên tài nguyên:</strong> {$resource.resourceAdministrator|escape}<br/>{/if}
 
 		{if $resource.attributeRows|default:array()|count > 0}

--- a/lang/vn_vn/ReservationCreatedAdmin.tpl
+++ b/lang/vn_vn/ReservationCreatedAdmin.tpl
@@ -21,8 +21,8 @@ Ending: {formatdate date=$EndDate key=reservation_email}<br/>
 		<strong>Mã tài nguyên:</strong> {$resource.id}<br/>
 		{if $resource.location}<strong>Vị trí:</strong> {$resource.location|escape}<br/>{/if}
 		{if $resource.contact}<strong>Liên hệ:</strong> {$resource.contact|escape}<br/>{/if}
-		{if $resource.description}<strong>Mô tả:</strong> {$resource.description|escape|nl2br}<br/>{/if}
-		{if $resource.notes}<strong>Ghi chú:</strong> {$resource.notes|escape|nl2br}<br/>{/if}
+		{if $resource.description}<strong>Mô tả:</strong> {$resource.description|sanitize_rich_text|url2link|nl2br}<br/>{/if}
+		{if $resource.notes}<strong>Ghi chú:</strong> {$resource.notes|sanitize_rich_text|url2link|nl2br}<br/>{/if}
 		{if $resource.resourceAdministrator}<strong>Quản trị viên tài nguyên:</strong> {$resource.resourceAdministrator|escape}<br/>{/if}
 
 		{if $resource.attributeRows|default:array()|count > 0}

--- a/lang/zh_cn/ReservationCreated.tpl
+++ b/lang/zh_cn/ReservationCreated.tpl
@@ -16,8 +16,8 @@
         <strong>资源 ID:</strong> {$resource.id}<br/>
         {if $resource.location}<strong>位置:</strong> {$resource.location|escape}<br/>{/if}
         {if $resource.contact}<strong>联系人:</strong> {$resource.contact|escape}<br/>{/if}
-        {if $resource.description}<strong>说明:</strong> {$resource.description|escape|nl2br}<br/>{/if}
-        {if $resource.notes}<strong>备注:</strong> {$resource.notes|escape|nl2br}<br/>{/if}
+        {if $resource.description}<strong>说明:</strong> {$resource.description|sanitize_rich_text|url2link|nl2br}<br/>{/if}
+        {if $resource.notes}<strong>备注:</strong> {$resource.notes|sanitize_rich_text|url2link|nl2br}<br/>{/if}
         {if $resource.resourceAdministrator}<strong>资源管理员:</strong> {$resource.resourceAdministrator|escape}<br/>{/if}
 
         {if $resource.attributeRows|default:array()|count > 0}

--- a/lang/zh_cn/ReservationCreatedAdmin.tpl
+++ b/lang/zh_cn/ReservationCreatedAdmin.tpl
@@ -22,8 +22,8 @@
         <strong>资源 ID:</strong> {$resource.id}<br/>
         {if $resource.location}<strong>位置:</strong> {$resource.location|escape}<br/>{/if}
         {if $resource.contact}<strong>联系人:</strong> {$resource.contact|escape}<br/>{/if}
-        {if $resource.description}<strong>说明:</strong> {$resource.description|escape|nl2br}<br/>{/if}
-        {if $resource.notes}<strong>备注:</strong> {$resource.notes|escape|nl2br}<br/>{/if}
+        {if $resource.description}<strong>说明:</strong> {$resource.description|sanitize_rich_text|url2link|nl2br}<br/>{/if}
+        {if $resource.notes}<strong>备注:</strong> {$resource.notes|sanitize_rich_text|url2link|nl2br}<br/>{/if}
         {if $resource.resourceAdministrator}<strong>资源管理员:</strong> {$resource.resourceAdministrator|escape}<br/>{/if}
 
         {if $resource.attributeRows|default:array()|count > 0}


### PR DESCRIPTION
…ation email

Resource description and notes fields support HTML when edited, but the reservation confirmation email was rendering them through |escape, which escaped that formatting.

Switch to |sanitize_rich_text|url2link so the email output matches what was actually entered, consistent with how these fields are rendered elsewhere in the app. sanitize_rich_text still strips unsafe markup, so this isn't reintroducing an XSS risk.