### PR TITLE
Adding PSR-4 support

### DIFF
--- a/Web/microsoft-auth.php
+++ b/Web/microsoft-auth.php
@@ -5,7 +5,7 @@ define('ROOT_DIR', '../');
 require_once(ROOT_DIR . 'vendor/autoload.php');
 require_once(ROOT_DIR . 'lib/Common/Logging/Log.php');
 
-use Lib\Application\Authentication\MicrosoftOAuthCallback;
+use lib\Application\Authentication\MicrosoftOAuthCallback;
 
 $result = (new MicrosoftOAuthCallback())->handle(
     params: $_GET,

--- a/Web/microsoft-auth.php
+++ b/Web/microsoft-auth.php
@@ -2,8 +2,10 @@
 
 define('ROOT_DIR', '../');
 
-require_once(ROOT_DIR . 'lib/Common/namespace.php');
-require_once(ROOT_DIR . 'lib/Application/Authentication/MicrosoftOAuthCallback.php');
+require_once(ROOT_DIR . 'vendor/autoload.php');
+require_once(ROOT_DIR . 'lib/Common/Logging/Log.php');
+
+use Lib\Application\Authentication\MicrosoftOAuthCallback;
 
 $result = (new MicrosoftOAuthCallback())->handle(
     params: $_GET,

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "license": "GPL-3.0-only",
     "autoload": {
         "psr-4": {
-            "Lib\\": "lib/"
+            "lib\\": "lib/"
         }
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,11 @@
     "name": "librebooking/librebooking",
     "description": "LibreBooking",
     "license": "GPL-3.0-only",
-    "autoload": {},
+    "autoload": {
+        "psr-4": {
+            "Lib\\": "lib/"
+        }
+    },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.95",
         "squizlabs/php_codesniffer": "^3.7.1",

--- a/lib/Application/Authentication/MicrosoftOAuthCallback.php
+++ b/lib/Application/Authentication/MicrosoftOAuthCallback.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+namespace lib\Application\Authentication;
+
 /**
  * Classification of a Microsoft OAuth callback request.
  */
@@ -11,6 +13,7 @@ enum MicrosoftOAuthCallbackOutcome
     case OAUTH_ERROR;
     case MALFORMED_REQUEST;
 }
+
 
 /**
  * Microsoft's OAuth callback outcome — either a redirect to external-auth or a redirect to home on error.

--- a/tests/Application/Authentication/MicrosoftOAuthCallbackTest.php
+++ b/tests/Application/Authentication/MicrosoftOAuthCallbackTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-require_once(ROOT_DIR . 'lib/Application/Authentication/MicrosoftOAuthCallback.php');
+use lib\Application\Authentication\MicrosoftOAuthCallback;
 
 class MicrosoftOAuthCallbackTest extends TestBase
 {

--- a/tests/Application/Authentication/MicrosoftOAuthCallbackTest.php
+++ b/tests/Application/Authentication/MicrosoftOAuthCallbackTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-use lib\Application\Authentication\MicrosoftOAuthCallback;
+use Lib\Application\Authentication\MicrosoftOAuthCallback;
 
 class MicrosoftOAuthCallbackTest extends TestBase
 {

--- a/tests/Application/Authentication/MicrosoftOAuthCallbackTest.php
+++ b/tests/Application/Authentication/MicrosoftOAuthCallbackTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-use Lib\Application\Authentication\MicrosoftOAuthCallback;
+use lib\Application\Authentication\MicrosoftOAuthCallback;
 
 class MicrosoftOAuthCallbackTest extends TestBase
 {


### PR DESCRIPTION
Addressing #1501 , this PR adds PSR-4 to the project. I've went in greater depth with regards to the necessity of PSR-4 in the issue. But in general, PSR-4 gives us the following:

1. Sane imports. even the strict require_once still silently executes files, introducing many code smells like polluting the global namespace
2. Better performance as imports are explicit. Even with smart compiler tree shaking, using barel files such as namespace.php with dozen of files fires off unecessary system calls in the file lookups.
3. Stricter allows us to reveal expensive runtime errors in compile time using static analysis.

