### PR TITLE
fix(config): correct suggested script URL ports

### DIFF
--- a/Presenters/Admin/ManageConfigurationPresenter.php
+++ b/Presenters/Admin/ManageConfigurationPresenter.php
@@ -358,18 +358,9 @@ class ManageConfigurationPresenter extends ActionPresenter
     private function CheckIfScriptUrlMayBeWrong()
     {
         $scriptUrl = Configuration::Instance()->GetScriptUrl();
-        $server = ServiceLocator::GetServer();
-        $currentUrl = $server->GetUrl();
+        $suggestedUrl = ScriptUrlSuggestion::Get($scriptUrl, ServiceLocator::GetServer());
 
-        $maybeWrong = !BookedStringHelper::Contains($scriptUrl, '/Web') && BookedStringHelper::Contains($currentUrl, '/Web');
-        if ($maybeWrong) {
-            $parts = explode('/Web', $currentUrl);
-            $port = $server->GetHeader('SERVER_PORT');
-            $suggestedUrl = ($server->GetIsHttps() ? 'https://' : 'http://')
-                . $server->GetHeader('SERVER_NAME')
-                . ($port == '80' ? '' : $port)
-                . $parts[0]
-                . '/Web';
+        if ($suggestedUrl !== null) {
             $this->page->ShowScriptUrlWarning($scriptUrl, $suggestedUrl);
         }
     }

--- a/Presenters/Install/InstallPresenter.php
+++ b/Presenters/Install/InstallPresenter.php
@@ -145,18 +145,9 @@ class InstallPresenter
     private function CheckIfScriptUrlMayBeWrong()
     {
         $scriptUrl = Configuration::Instance()->GetScriptUrl();
-        $server = ServiceLocator::GetServer();
-        $currentUrl = $server->GetUrl();
+        $suggestedUrl = ScriptUrlSuggestion::Get($scriptUrl, ServiceLocator::GetServer());
 
-        $maybeWrong = !BookedStringHelper::Contains($scriptUrl, '/Web') && BookedStringHelper::Contains($currentUrl, '/Web') ;
-        if ($maybeWrong) {
-            $parts = explode('/Web', $currentUrl);
-            $port = $server->GetHeader('SERVER_PORT');
-            $suggestedUrl = ($server->GetIsHttps() ? 'https://' : 'http://')
-                . $server->GetHeader('SERVER_NAME')
-                . ($port == '80' ? '' : $port)
-                . $parts[0]
-                . '/Web';
+        if ($suggestedUrl !== null) {
             $this->page->ShowScriptUrlWarning($scriptUrl, $suggestedUrl);
         }
     }

--- a/lib/Common/ScriptUrlSuggestion.php
+++ b/lib/Common/ScriptUrlSuggestion.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+class ScriptUrlSuggestion
+{
+    private const DEFAULT_HTTP_PORT = '80';
+    private const DEFAULT_HTTPS_PORT = '443';
+
+    public static function Get(string $scriptUrl, Server $server): ?string
+    {
+        $currentUrl = $server->GetUrl();
+        $shouldSuggest = !BookedStringHelper::Contains($scriptUrl, '/Web')
+            && BookedStringHelper::Contains($currentUrl, '/Web');
+
+        if (!$shouldSuggest) {
+            return null;
+        }
+
+        $isHttps = $server->GetIsHttps();
+        $port = $server->GetHeader('SERVER_PORT');
+        $defaultPort = $isHttps ? self::DEFAULT_HTTPS_PORT : self::DEFAULT_HTTP_PORT;
+        $portSuffix = $port === '' || $port === $defaultPort ? '' : ':' . $port;
+        $basePath = explode('/Web', $currentUrl, 2)[0];
+
+        return ($isHttps ? 'https://' : 'http://')
+            . $server->GetHeader('SERVER_NAME')
+            . $portSuffix
+            . $basePath
+            . '/Web';
+    }
+}

--- a/lib/Common/namespace.php
+++ b/lib/Common/namespace.php
@@ -18,3 +18,4 @@ require_once(ROOT_DIR . 'lib/Common/ContrastingColor.php');
 require_once(ROOT_DIR . 'lib/Common/Security/RichTextHtmlSanitizer.php');
 require_once(ROOT_DIR . 'lib/Common/RedirectUrlSanitizer.php');
 require_once(ROOT_DIR . 'lib/Common/VersionDisplayResolver.php');
+require_once(ROOT_DIR . 'lib/Common/ScriptUrlSuggestion.php');

--- a/tests/Infrastructure/Common/ScriptUrlSuggestionTest.php
+++ b/tests/Infrastructure/Common/ScriptUrlSuggestionTest.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+require_once(ROOT_DIR . 'lib/Common/namespace.php');
+
+class ScriptUrlSuggestionTest extends TestBase
+{
+    #[\PHPUnit\Framework\Attributes\DataProvider('portProvider')]
+    public function testBuildsSuggestedUrlWithExpectedPort(
+        bool $isHttps,
+        string $port,
+        string $expectedUrl
+    ): void {
+        $server = $this->createServer('/Web/admin/manage_configuration.php', $isHttps, $port);
+
+        $suggestedUrl = ScriptUrlSuggestion::Get('', $server);
+
+        $this->assertSame($expectedUrl, $suggestedUrl);
+    }
+
+    public static function portProvider(): array
+    {
+        return [
+            'default HTTP port' => [false, '80', 'http://localhost/Web'],
+            'non-default HTTP port' => [false, '8080', 'http://localhost:8080/Web'],
+            'default HTTPS port' => [true, '443', 'https://localhost/Web'],
+            'non-default HTTPS port' => [true, '8443', 'https://localhost:8443/Web'],
+            'missing port' => [false, '', 'http://localhost/Web'],
+        ];
+    }
+
+    public function testIncludesApplicationPathBeforeWebDirectory(): void
+    {
+        $server = $this->createServer('/librebooking/Web/install.php', false, '8080');
+
+        $suggestedUrl = ScriptUrlSuggestion::Get('', $server);
+
+        $this->assertSame('http://localhost:8080/librebooking/Web', $suggestedUrl);
+    }
+
+    public function testDoesNotSuggestUrlWhenConfiguredUrlContainsWebDirectory(): void
+    {
+        $server = $this->createServer('/Web/admin/manage_configuration.php', false, '8080');
+
+        $suggestedUrl = ScriptUrlSuggestion::Get('http://localhost:8080/Web', $server);
+
+        $this->assertNull($suggestedUrl);
+    }
+
+    public function testDoesNotSuggestUrlWhenCurrentUrlDoesNotContainWebDirectory(): void
+    {
+        $server = $this->createServer('/admin/manage_configuration.php', false, '8080');
+
+        $suggestedUrl = ScriptUrlSuggestion::Get('', $server);
+
+        $this->assertNull($suggestedUrl);
+    }
+
+    private function createServer(string $currentUrl, bool $isHttps, string $port): Server
+    {
+        $server = $this->createMock(Server::class);
+        $server->method('GetUrl')->willReturn($currentUrl);
+        $server->method('GetIsHttps')->willReturn($isHttps);
+        $server->method('GetHeader')->willReturnMap([
+            ['SERVER_NAME', 'localhost'],
+            ['SERVER_PORT', $port],
+        ]);
+
+        return $server;
+    }
+}


### PR DESCRIPTION
Centralize script URL suggestion generation for the install and configuration pages. Prefix non-default ports with a colon and omit the default HTTP and HTTPS ports.

Add coverage for default and non-default ports, application subpaths, and conditions where no suggestion should be shown.

Closes: #1555
Assisted-by: Codex:GPT-5