### PR TITLE
refactor(config): build suggested script URLs with URI library

### DIFF
--- a/lib/Common/ScriptUrlSuggestion.php
+++ b/lib/Common/ScriptUrlSuggestion.php
@@ -2,11 +2,10 @@
 
 declare(strict_types=1);
 
+use League\Uri\Http;
+
 class ScriptUrlSuggestion
 {
-    private const DEFAULT_HTTP_PORT = '80';
-    private const DEFAULT_HTTPS_PORT = '443';
-
     public static function Get(string $scriptUrl, Server $server): ?string
     {
         $currentUrl = $server->GetUrl();
@@ -18,15 +17,15 @@ class ScriptUrlSuggestion
         }
 
         $isHttps = $server->GetIsHttps();
-        $port = $server->GetHeader('SERVER_PORT');
-        $defaultPort = $isHttps ? self::DEFAULT_HTTPS_PORT : self::DEFAULT_HTTP_PORT;
-        $portSuffix = $port === '' || $port === $defaultPort ? '' : ':' . $port;
+        $portHeader = $server->GetHeader('SERVER_PORT');
+        $port = $portHeader === '' ? null : (int) $portHeader;
         $basePath = explode('/Web', $currentUrl, 2)[0];
 
-        return ($isHttps ? 'https://' : 'http://')
-            . $server->GetHeader('SERVER_NAME')
-            . $portSuffix
-            . $basePath
-            . '/Web';
+        return (string) Http::fromComponents([
+            'scheme' => $isHttps ? 'https' : 'http',
+            'host' => $server->GetHeader('SERVER_NAME'),
+            'port' => $port,
+            'path' => $basePath . '/Web',
+        ]);
     }
 }


### PR DESCRIPTION
Use League URI to assemble suggested script URLs from their scheme, host, port, and path components. This removes manual URL concatenation and delegates port separators, default-port normalization, validation, and encoding to the URI builder.

Assisted-by: Codex:GPT-5