### PR TITLE
fix(config): warn all users when script.url is empty

### DIFF
--- a/lang/en_us.php
+++ b/lang/en_us.php
@@ -135,6 +135,7 @@ class en_us extends Language
         $strings['NextWeek'] = 'Next Week';
         $strings['SignOut'] = 'Sign Out';
         $strings['JavascriptRequired'] = 'This application requires JavaScript to function properly. Please enable JavaScript in your browser settings.';
+        $strings['ScriptUrlNotConfigured'] = 'LibreBooking is not configured correctly. The <code>script.url</code> setting is empty, so some application features will not work. Please contact the administrator.';
         $strings['LayoutDescription'] = 'Starts on %s, showing %s days at a time';
         $strings['AllResources'] = 'All Resources';
         $strings['TakeOffline'] = 'Take Offline';

--- a/tests/Infrastructure/Common/SmartyPageTest.php
+++ b/tests/Infrastructure/Common/SmartyPageTest.php
@@ -6,6 +6,28 @@ require_once(ROOT_DIR . 'lib/Common/namespace.php');
 
 class SmartyPageTest extends TestBase
 {
+    public function testGlobalHeaderDisplaysWarningWhenScriptUrlIsEmpty(): void
+    {
+        $page = new SmartyPage();
+        $page->assign('ScriptUrl', '');
+
+        $output = $page->fetch('globalheader.tpl');
+
+        $this->assertStringContainsString('id="script-url-warning"', $output);
+        $this->assertStringContainsString('ScriptUrlNotConfigured', $output);
+    }
+
+    public function testGlobalHeaderDoesNotDisplayWarningWhenScriptUrlIsConfigured(): void
+    {
+        $page = new SmartyPage();
+        $page->assign('ScriptUrl', 'https://librebooking.example/Web');
+
+        $output = $page->fetch('globalheader.tpl');
+
+        $this->assertStringNotContainsString('id="script-url-warning"', $output);
+        $this->assertStringNotContainsString('ScriptUrlNotConfigured', $output);
+    }
+
     public function testCreateUrlLinkifiesHttpAndHttpsUrls(): void
     {
         $page = new SmartyPage();

--- a/tpl/globalheader.tpl
+++ b/tpl/globalheader.tpl
@@ -117,6 +117,13 @@
         </div>
     </noscript>
 
+    {* Alert everyone if `script.url` is unset as it will cause issues. *}
+    {if !isset($ScriptUrl) || $ScriptUrl eq ''}
+        <div id="script-url-warning" class="alert alert-danger text-center m-2" role="alert">
+            {translate key="ScriptUrlNotConfigured"}
+        </div>
+    {/if}
+
     {if !isset($HideNavBar) || $HideNavBar == false}
         <div class="d-flex align-items-center gap-2 m-2">
             <a class="navbar-brand" href="{$HomeUrl}">


### PR DESCRIPTION
Display a persistent error banner in the shared page header when script.url is not configured. Show the warning to authenticated and anonymous users so the configuration problem cannot go unnoticed.

Add localized warning text and tests covering empty and configured script URL values.

Closes: #1554
Assisted-by: Codex:gpt-5