### PR TITLE
docs(config): document required script URL setting

### DIFF
--- a/docs/source/BASIC-CONFIGURATION.rst
+++ b/docs/source/BASIC-CONFIGURATION.rst
@@ -291,13 +291,21 @@ Frontend Settings
 
 .. code-block:: php
 
-   'script.url' => '',
+   'script.url' => 'https://example.com/librebooking/Web',
    'css.theme' => 'default',
    'cache.templates' => true,
    'default.homepage' => 1,
 
 **script.url**
-  Public URL to the Web directory of this instance.
+  Public URL to the ``Web`` directory of this instance. For example, if
+  LibreBooking is accessed at ``https://example.com/librebooking/Web/``, set
+  this value to ``https://example.com/librebooking/Web``. The equivalent
+  environment variable is ``LB_SCRIPT_URL``.
+
+  This setting must not be empty. When it is empty, LibreBooking displays a
+  persistent configuration warning to authenticated and anonymous users
+  because application links and other features may not work correctly. Set
+  ``script.url`` (or ``LB_SCRIPT_URL``) to dismiss the warning.
 
 **css.theme**
   Theme to use for the application. Options: default, dimgray, dark_red,

--- a/docs/source/INSTALLATION.rst
+++ b/docs/source/INSTALLATION.rst
@@ -89,6 +89,18 @@ minimal default settings which should be enough for the application to work.
 Copy ``/config/config.dist.php`` to ``/config/config.php`` and adjust
 the settings for your environment.
 
+Set ``script.url`` to the public URL of LibreBooking's ``Web`` directory. For
+example:
+
+.. code-block:: php
+
+    'script.url' => 'https://example.com/librebooking/Web',
+
+If ``script.url`` is empty, LibreBooking displays a persistent configuration
+warning to all users because some application features will not work
+correctly. Docker and other environment-based deployments can set the same
+value with ``LB_SCRIPT_URL``.
+
 For detailed information on all configuration options, see :doc:`BASIC-CONFIGURATION`
 for essential settings or :doc:`ADVANCED-CONFIGURATION` for comprehensive options.
 


### PR DESCRIPTION
Add script.url configuration examples to the installation and basic configuration guides. Document the LB_SCRIPT_URL environment variable and explain the persistent warning shown when the setting is empty.

Assisted-by: Codex:gpt-5