### PR TITLE
fix(auth): preserve redirect target through Microsoft OAuth login

### DIFF
--- a/Presenters/LoginPresenter.php
+++ b/Presenters/LoginPresenter.php
@@ -138,7 +138,7 @@ class LoginPresenter
         $oauth2Enabled    = Configuration::Instance()->GetKey(ConfigKeys::AUTHENTICATION_OAUTH2_LOGIN_ENABLED, new BooleanConverter());
 
         $this->_page->SetGoogleUrl($googleEnabled ? $this->GetGoogleUrl() : null);
-        $this->_page->SetMicrosoftUrl($microsoftEnabled ? $this->GetMicrosoftUrl() : null);
+        $this->_page->SetMicrosoftUrl($microsoftEnabled ? $this->GetMicrosoftUrl($this->_page->GetResumeUrl()) : null);
         $this->_page->SetFacebookUrl($facebookEnabled ? $this->GetFacebookUrl() : null);
         $this->_page->SetKeycloakUrl($keycloakEnabled ? $this->GetKeycloakUrl() : null);
         $this->_page->SetOauth2Url($oauth2Enabled ? $this->GetOauth2Url() : null);
@@ -309,7 +309,7 @@ class LoginPresenter
      * Checks in the config files if microsoft authentication is active creating the url if true with the respective keys
      * Returns the created microsoft url for the authentication
      */
-    public function GetMicrosoftUrl()
+    public function GetMicrosoftUrl(?string $state = null)
     {
 
         $tenantId = Configuration::Instance()->GetKey(ConfigKeys::AUTHENTICATION_MICROSOFT_TENANT_ID);
@@ -325,8 +325,12 @@ class LoginPresenter
             'prompt' => 'select_account'
         ];
 
-        $MicrosoftUrl = $baseUrl . '?' . http_build_query($params, '', '&', PHP_QUERY_RFC3986);
-        return $MicrosoftUrl;
+        if (!empty($state)) {
+            $params['state'] = $state;
+        }
+
+        return $baseUrl . '?' . http_build_query($params, '', '&', PHP_QUERY_RFC3986);
+
     }
 
     /**

--- a/lib/Application/Authentication/MicrosoftOAuthCallback.php
+++ b/lib/Application/Authentication/MicrosoftOAuthCallback.php
@@ -89,11 +89,12 @@ class MicrosoftOAuthCallback
     {
         $error = $params['error'] ?? null;
         $code = $params['code'] ?? null;
+        $state = $params['state'] ?? null;
 
         // A non-string value for a recognized parameter (e.g. ?error[]=x) is
         // not a shape Azure sends; treat the whole request as malformed
         // instead of interpreting the remaining parameters.
-        if (($error !== null && !is_string($error)) || ($code !== null && !is_string($code))) {
+        if (($error !== null && !is_string($error)) || ($code !== null && !is_string($code)) || ($state !== null && !is_string($state))) {
             return MicrosoftOAuthCallbackResult::malformedRequest($failureRedirectURL);
         }
 
@@ -108,6 +109,9 @@ class MicrosoftOAuthCallback
 
         if (is_string($code) && $code !== '') {
             $url = $externalAuthUrl . '?type=microsoft&code=' . urlencode($code);
+            if (is_string($state) && $state !== '') {
+                $url .= '&redirect=' . urlencode($state);
+            }
             return MicrosoftOAuthCallbackResult::success($url);
         }
 

--- a/tests/Application/Authentication/MicrosoftOAuthCallbackTest.php
+++ b/tests/Application/Authentication/MicrosoftOAuthCallbackTest.php
@@ -19,7 +19,7 @@ class MicrosoftOAuthCallbackTest extends TestBase
     public function testSuccessRedirectsToExternalAuthWithCode(): void
     {
         $result = $this->msAuthHandler->handle(
-            ['code' => 'abc123', 'state' => 'xyz'],
+            ['code' => 'abc123'],
             $this->externalAuthUrl,
             $this->failureRedirectURL,
         );
@@ -30,6 +30,50 @@ class MicrosoftOAuthCallbackTest extends TestBase
             'http://localhost/external-auth.php?type=microsoft&code=abc123',
             $result->redirectURL,
         );
+    }
+
+    public function testSuccessWithStateAppendsRedirectParam(): void
+    {
+        $result = $this->msAuthHandler->handle(
+            ['code' => 'abc123', 'state' => '/Web/reservation.php?rn=123'],
+            $this->externalAuthUrl,
+            $this->failureRedirectURL,
+        );
+
+        $this->assertFalse($result->hasOAuthErrorResponse());
+        $this->assertFalse($result->isMalformedRequest());
+        $this->assertEquals(
+            'http://localhost/external-auth.php?type=microsoft&code=abc123'
+                . '&redirect=' . urlencode('/Web/reservation.php?rn=123'),
+            $result->redirectURL,
+        );
+    }
+
+    public function testSuccessWithEmptyStateOmitsRedirectParam(): void
+    {
+        $result = $this->msAuthHandler->handle(
+            ['code' => 'abc123', 'state' => ''],
+            $this->externalAuthUrl,
+            $this->failureRedirectURL,
+        );
+
+        $this->assertEquals(
+            'http://localhost/external-auth.php?type=microsoft&code=abc123',
+            $result->redirectURL,
+        );
+    }
+
+    public function testNonStringStateIsMalformedRequest(): void
+    {
+        $result = $this->msAuthHandler->handle(
+            ['code' => 'abc123', 'state' => ['x']],
+            $this->externalAuthUrl,
+            $this->failureRedirectURL,
+        );
+
+        $this->assertTrue($result->isMalformedRequest());
+        $this->assertFalse($result->hasOAuthErrorResponse());
+        $this->assertEquals($this->failureRedirectURL, $result->redirectURL);
     }
 
     public function testSuccessUrlEncodesCode(): void

--- a/tests/Presenters/LoginPresenterTest.php
+++ b/tests/Presenters/LoginPresenterTest.php
@@ -141,6 +141,47 @@ class LoginPresenterTest extends TestBase
         $this->assertEquals(Pages::UrlFromId(Pages::DEFAULT_HOMEPAGE_ID), $this->page->_LastRedirect);
     }
 
+    public function testMicrosoftUrlIncludesResumeUrlAsState()
+    {
+        $this->fakeConfig->SetKey(ConfigKeys::AUTHENTICATION_MICROSOFT_LOGIN_ENABLED, 'true');
+        $this->fakeConfig->SetKey(ConfigKeys::AUTHENTICATION_MICROSOFT_TENANT_ID, 'tenant');
+        $this->fakeConfig->SetKey(ConfigKeys::AUTHENTICATION_MICROSOFT_CLIENT_ID, 'client');
+        $this->fakeConfig->SetKey(ConfigKeys::AUTHENTICATION_MICROSOFT_REDIRECT_URI, 'https://booked.example/Web/external-auth.php');
+
+        $this->page->_ResumeUrl = '/Web/reservation.php?rn=123';
+
+        $this->presenter->PageLoad();
+
+        $this->assertStringContainsString(
+            'state=' . rawurlencode('/Web/reservation.php?rn=123'),
+            $this->page->_MicrosoftUrl
+        );
+    }
+
+    public function testMicrosoftUrlOmitsStateWhenNoResumeUrl()
+    {
+        $this->fakeConfig->SetKey(ConfigKeys::AUTHENTICATION_MICROSOFT_LOGIN_ENABLED, 'true');
+        $this->fakeConfig->SetKey(ConfigKeys::AUTHENTICATION_MICROSOFT_TENANT_ID, 'tenant');
+        $this->fakeConfig->SetKey(ConfigKeys::AUTHENTICATION_MICROSOFT_CLIENT_ID, 'client');
+        $this->fakeConfig->SetKey(ConfigKeys::AUTHENTICATION_MICROSOFT_REDIRECT_URI, 'https://booked.example/Web/external-auth.php');
+
+        $this->page->_ResumeUrl = '';
+
+        $this->presenter->PageLoad();
+
+        $this->assertStringNotContainsString('state=', $this->page->_MicrosoftUrl);
+    }
+
+    public function testMicrosoftUrlNotSetWhenMicrosoftLoginDisabled()
+    {
+        $this->fakeConfig->SetKey(ConfigKeys::AUTHENTICATION_MICROSOFT_LOGIN_ENABLED, 'false');
+        $this->page->_ResumeUrl = '/Web/reservation.php?rn=123';
+
+        $this->presenter->PageLoad();
+
+        $this->assertNull($this->page->_MicrosoftUrl);
+    }
+
     public function testPageLoadSetsVariablesCorrectly()
     {
         $this->fakeConfig->SetKey(ConfigKeys::REGISTRATION_ALLOW_SELF, 'true');
@@ -307,6 +348,7 @@ class FakeLoginPage extends FakePageBase implements ILoginPage
     public $_Languages = [];
     public $_UseLogonName = false;
     public $_ResumeUrl = '';
+    public $_MicrosoftUrl;
     public $_ShowLoginError = false;
     public $_LoginErrorMessage = null;
     public $_requestedLanguage;
@@ -325,6 +367,7 @@ class FakeLoginPage extends FakePageBase implements ILoginPage
 
     public function SetMicrosoftUrl($URL)
     {
+        $this->_MicrosoftUrl = $URL;
     }
 
     public function SetFacebookUrl($URL)


### PR DESCRIPTION
The "Sign in with Microsoft" link never carried the original ?redirect= query param through the OAuth round trip, so users who followed a deep link into a protected page (e.g.
index.php?redirect=/Web/reservation.php?rn=...) were sent to their default homepage after authenticating with Microsoft instead of the page they originally requested.

- LoginPresenter::GetMicrosoftUrl() now accepts an optional $state parameter and includes it as the OAuth `state` param on the Microsoft authorize URL. PageLoad() passes the page's resume URL into it via GetResumeUrl().
- MicrosoftOAuthCallback::handle() now reads `state` back from Microsoft's callback params (validated as a string, consistent with the existing code/error handling) and forwards it to external-auth.php as redirect=, which ExternalAuthLoginPage::GetResumeUrl() already reads via QueryStringKeys::REDIRECT.

The forwarded value still passes through
RedirectUrlSanitizer::Sanitize() in LoginRedirector::Redirect() before use, same as the plain-login ?redirect= flow, so open-redirect protection is unchanged.

Refs: #1559
Assisted-by: Claude:claude-sonnet-4-6