### PR TITLE
docs: group the documentation table of contents by audience

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -10,22 +10,47 @@ LibreBooking documentation
 ==========================
 
 .. toctree::
-   :maxdepth: 2
-   :caption: Table of Contents:
+   :maxdepth: 1
+   :titlesonly:
+   :caption: Getting Started:
 
    INSTALLATION
    CONFIGURATION
    BASIC-CONFIGURATION
    ADVANCED-CONFIGURATION
-   ADMINISTRATION
-   FAQ
-   DEVELOPER-README
-   CUSTOM-PLUGINS
-   API
+
+.. toctree::
+   :maxdepth: 1
+   :titlesonly:
+   :caption: Authentication:
+
    LDAP-Authentication
    ActiveDirectory-Authentication
    Oauth2-Configuration
    SAML-Configuration
+
+.. toctree::
+   :maxdepth: 1
+   :titlesonly:
+   :caption: Using LibreBooking:
+
+   ADMINISTRATION
+   FAQ
+
+.. toctree::
+   :maxdepth: 1
+   :titlesonly:
+   :caption: Developer:
+
+   DEVELOPER-README
+   CUSTOM-PLUGINS
+   API
+
+.. toctree::
+   :maxdepth: 1
+   :titlesonly:
+   :caption: Project:
+
    changelog
    HISTORY
    LICENSE


### PR DESCRIPTION
Split the single flat toctree in index.rst into five captioned groups: Getting Started, Authentication, Using LibreBooking, Developer, and Project. Use maxdepth 1 and titlesonly so each document contributes a single line to the table of contents instead of expanding its full section outline, which had grown unwieldy after the administration guide was added.

No documents are renamed or moved, so published URLs are unchanged.

Assisted-by: Claude:claude-fable-5