### PR TITLE
fix(admin): restrict user deletion to application administrators

### DIFF
--- a/Pages/Admin/ManageUsersPage.php
+++ b/Pages/Admin/ManageUsersPage.php
@@ -220,6 +220,7 @@ class ManageUsersPage extends ActionPage implements IManageUsersPage
         $this->Set('FilterStatusId', $this->GetFilterStatusId());
         $this->Set('PerUserColors', $config->GetKey(ConfigKeys::SCHEDULE_USE_PER_USER_COLORS, new BooleanConverter()));
         $this->Set('CreditsEnabled', $config->GetKey(ConfigKeys::CREDITS_ENABLED, new BooleanConverter()));
+        $this->Set('CanDeleteUsers', $this->server->GetUserSession()->IsAdmin);
         $url = $this->server->GetUrl();
         $exportUrl = BookedStringHelper::Contains($url, '?') ? $url . '&dr=export' : $this->server->GetRequestUri() . '?dr=export';
         $this->Set('ExportUrl', $exportUrl);

--- a/docs/source/ADMINISTRATION.rst
+++ b/docs/source/ADMINISTRATION.rst
@@ -386,9 +386,10 @@ can manage all aspects of the application.
 
 Group Administrator: Users that belong to a group that is given the Group
 Administrator role are able to manage their groups and reserve on behalf of
-and manage users within that group. A group administrator must first be
-assigned the Group Administrator role. This group will then be available in
-the Group Administrators list.
+and manage users within that group. Group Administrators cannot delete user
+accounts; only Application Administrators can delete users. A group
+administrator must first be assigned the Group Administrator role. This
+group will then be available in the Group Administrators list.
 
 Resource Administrator: Users that belong to a group that is given the
 Resource Administrators role have the same capabilities as Application

--- a/lib/Application/User/ManageUsersService.php
+++ b/lib/Application/User/ManageUsersService.php
@@ -169,6 +169,12 @@ class ManageUsersService implements IManageUsersService
     public function DeleteUser($userId, $notify = true)
     {
         $currentUser = ServiceLocator::GetServer()->GetUserSession();
+        if (!$currentUser->IsAdmin) {
+            // only application administrators may delete accounts
+            Log::Error('DeleteUser denied. UserId=%s is not an application administrator. Target UserId=%s', $currentUser->UserId, $userId);
+            return;
+        }
+
         if ($currentUser->UserId == $userId) {
             // don't delete own account
             return;

--- a/tests/Application/User/ManageUsersServiceTest.php
+++ b/tests/Application/User/ManageUsersServiceTest.php
@@ -120,6 +120,7 @@ class ManageUsersServiceTest extends TestBase
     public function testDeleteDelegatesToRepositoryAndSendsEmails()
     {
         $this->fakeConfig->SetKey(ConfigKeys::REGISTRATION_NOTIFY_ADMIN, 'true');
+        $this->fakeUser->IsAdmin = true;
 
         $userId = 809;
         $user = new FakeUser($userId);
@@ -142,6 +143,20 @@ class ManageUsersServiceTest extends TestBase
 
         $this->assertEquals(2, count($this->fakeEmailService->_Messages));
         $this->assertEquals($userId, $this->userRepo->_DeletedUserId);
+    }
+
+    public function testDeleteIsDeniedWhenNotApplicationAdmin()
+    {
+        $this->fakeConfig->SetKey(ConfigKeys::REGISTRATION_NOTIFY_ADMIN, 'true');
+        $this->fakeUser->IsAdmin = false;
+        $this->fakeUser->IsGroupAdmin = true;
+
+        $userId = 809;
+
+        $this->service->DeleteUser($userId);
+
+        $this->assertNull($this->userRepo->_DeletedUserId);
+        $this->assertEquals(0, count($this->fakeEmailService->_Messages));
     }
 
     public function testUpdatesUser()

--- a/tpl/Admin/Users/manage_users.tpl
+++ b/tpl/Admin/Users/manage_users.tpl
@@ -82,16 +82,18 @@
                                 <th class="action">{translate key='Color'}</th>
                             {/if}
                             <th>{translate key='Actions'}</th>
-                            <th class="action-delete">
-                                <div class="form-check checkbox-single">
-                                    <input class="form-check-input" type="checkbox" id="delete-all"
-                                        aria-label="{translate key=All}" title="{translate key=All}" />
-                                </div>
-                                <a href="#" id="delete-selected" class="d-none" title="{translate key=Delete}">
-                                    <span class="visually-hidden">{translate key=Delete}</span>
-                                    <span class="bi bi-trash3-fill text-danger icon remove"></span>
-                                </a>
-                            </th>
+                            {if $CanDeleteUsers}
+                                <th class="action-delete">
+                                    <div class="form-check checkbox-single">
+                                        <input class="form-check-input" type="checkbox" id="delete-all"
+                                            aria-label="{translate key=All}" title="{translate key=All}" />
+                                    </div>
+                                    <a href="#" id="delete-selected" class="d-none" title="{translate key=Delete}">
+                                        <span class="visually-hidden">{translate key=Delete}</span>
+                                        <span class="bi bi-trash3-fill text-danger icon remove"></span>
+                                    </a>
+                                </th>
+                            {/if}
                             {assign var=attributes value=$AttributeList}
                             {if $attributes|default:array()|count > 0}
                                 <th>{translate key='More'}
@@ -171,21 +173,25 @@
 
                                         </ul>
                                     </div>
-                                    |
-                                    <span class="inline">
-                                        <a href="#" class="update delete">
-                                            <span class="visually-hidden">{translate key=Delete}</span>
-                                            <span class="bi bi-trash3-fill text-danger icon remove"></span>
-                                        </a>
-                                    </span>
+                                    {if $CanDeleteUsers}
+                                        |
+                                        <span class="inline">
+                                            <a href="#" class="update delete">
+                                                <span class="visually-hidden">{translate key=Delete}</span>
+                                                <span class="bi bi-trash3-fill text-danger icon remove"></span>
+                                            </a>
+                                        </span>
+                                    {/if}
                                 </td>
-                                <td class="action-delete">
-                                    <div class="form-check checkbox-single">
-                                        <input {formname key=USER_ID multi=true} class="delete-multiple form-check-input"
-                                            type="checkbox" id="delete{$id}" value="{$id}"
-                                            aria-label="{translate key=Delete}" title="{translate key=Delete}" />
-                                    </div>
-                                </td>
+                                {if $CanDeleteUsers}
+                                    <td class="action-delete">
+                                        <div class="form-check checkbox-single">
+                                            <input {formname key=USER_ID multi=true} class="delete-multiple form-check-input"
+                                                type="checkbox" id="delete{$id}" value="{$id}"
+                                                aria-label="{translate key=Delete}" title="{translate key=Delete}" />
+                                        </div>
+                                    </td>
+                                {/if}
 
                                 {if $attributes|default:array()|count > 0}
                                     <td class="customAttributes" userId="{$id}">
@@ -524,6 +530,7 @@
         </form>
     </div>
 
+    {if $CanDeleteUsers}
     <div id="deleteDialog" class="modal fade" tabindex="-1" role="dialog" aria-labelledby="deleteModalLabel"
         aria-hidden="true">
         <form id="deleteUserForm" method="post" ajaxAction="{ManageUsersActions::DeleteUser}">
@@ -579,6 +586,7 @@
             </div>
         </form>
     </div>
+    {/if}
 
     <div id="groupsDialog" class="modal fade" tabindex="-1" role="dialog" aria-labelledby="groupsModalLabel"
         aria-hidden="true">


### PR DESCRIPTION
The group admin user management page (manage_group_users.php) reuses ManageUsersPage and its presenter, so the deleteUser and deleteMultipleUsers actions were exposed to group administrators, and ManageUsersService::DeleteUser() performed no role check beyond preventing self-deletion. A group administrator could therefore delete any user account, including users outside the groups they administer.

Deny deletion in ManageUsersService::DeleteUser() unless the current session belongs to an application administrator, and log denied attempts. The REST API delete endpoint was already restricted to application administrators via AddAdminDelete and is unaffected.

Hide the delete controls (per-row delete link, multi-select checkbox column, and both confirmation dialogs) in the manage users template for non-application administrators via a new CanDeleteUsers template flag. The page JavaScript uses event delegation, and the DataTable configuration has no fixed column indexes, so the conditional column is safe to omit.

Also state in the administration guide that Group Administrators cannot delete user accounts.

Assisted-by: Claude:claude-fable-5