### PR TITLE
fix(admin): restrict user password changes to application administrators

### DIFF
--- a/Pages/Admin/ManageUsersPage.php
+++ b/Pages/Admin/ManageUsersPage.php
@@ -220,7 +220,9 @@ class ManageUsersPage extends ActionPage implements IManageUsersPage
         $this->Set('FilterStatusId', $this->GetFilterStatusId());
         $this->Set('PerUserColors', $config->GetKey(ConfigKeys::SCHEDULE_USE_PER_USER_COLORS, new BooleanConverter()));
         $this->Set('CreditsEnabled', $config->GetKey(ConfigKeys::CREDITS_ENABLED, new BooleanConverter()));
-        $this->Set('CanDeleteUsers', $this->server->GetUserSession()->IsAdmin);
+        $isApplicationAdmin = $this->server->GetUserSession()->IsAdmin;
+        $this->Set('CanDeleteUsers', $isApplicationAdmin);
+        $this->Set('CanChangePasswords', $isApplicationAdmin);
         $url = $this->server->GetUrl();
         $exportUrl = BookedStringHelper::Contains($url, '?') ? $url . '&dr=export' : $this->server->GetRequestUri() . '?dr=export';
         $this->Set('ExportUrl', $exportUrl);

--- a/Presenters/Admin/ManageUsersPresenter.php
+++ b/Presenters/Admin/ManageUsersPresenter.php
@@ -336,12 +336,7 @@ class ManageUsersPresenter extends ActionPresenter implements IManageUsersPresen
 
     public function ResetPassword()
     {
-        $salt = $this->passwordEncryption->Salt();
-        $encryptedPassword = $this->passwordEncryption->Encrypt($this->page->GetPassword(), $salt);
-
-        $user = $this->userRepository->LoadById($this->page->GetUserId());
-        $user->ChangePassword($encryptedPassword, $salt);
-        $this->userRepository->Update($user);
+        $this->manageUsersService->UpdatePassword($this->page->GetUserId(), $this->page->GetPassword());
     }
 
     public function ChangeAttribute()

--- a/docs/source/ADMINISTRATION.rst
+++ b/docs/source/ADMINISTRATION.rst
@@ -387,7 +387,7 @@ can manage all aspects of the application.
 Group Administrator: Users that belong to a group that is given the Group
 Administrator role are able to manage their groups and reserve on behalf of
 and manage users within that group. Group Administrators cannot delete user
-accounts; only Application Administrators can delete users. A group
+accounts or change user passwords; only Application Administrators can. A group
 administrator must first be assigned the Group Administrator role. This
 group will then be available in the Group Administrators list.
 

--- a/lib/Application/User/ManageUsersService.php
+++ b/lib/Application/User/ManageUsersService.php
@@ -251,6 +251,13 @@ class ManageUsersService implements IManageUsersService
 
     public function UpdatePassword($userId, $password)
     {
+        $currentUser = ServiceLocator::GetServer()->GetUserSession();
+        if (!$currentUser->IsAdmin) {
+            // only application administrators may change passwords
+            Log::Error('UpdatePassword denied. UserId=%s is not an application administrator. Target UserId=%s', $currentUser->UserId, $userId);
+            return;
+        }
+
         $user = $this->userRepository->LoadById($userId);
 
         $encrypted = $this->passwordEncryption->EncryptPassword($password);

--- a/tests/Application/User/ManageUsersServiceTest.php
+++ b/tests/Application/User/ManageUsersServiceTest.php
@@ -228,6 +228,8 @@ class ManageUsersServiceTest extends TestBase
 
     public function testEncryptsAndSavesPassword()
     {
+        $this->fakeUser->IsAdmin = true;
+
         $userId = 1;
         $password = 'password';
         $user = new FakeUser($userId);
@@ -239,5 +241,20 @@ class ManageUsersServiceTest extends TestBase
         $this->assertEquals($this->passwordEncryption->_Encrypted, $user->_Password);
         $this->assertEquals($this->passwordEncryption->_Salt, $user->_Salt);
         $this->assertEquals($user, $this->userRepo->_UpdatedUser);
+    }
+
+    public function testUpdatePasswordIsDeniedWhenNotApplicationAdmin()
+    {
+        $this->fakeUser->IsAdmin = false;
+        $this->fakeUser->IsGroupAdmin = true;
+
+        $userId = 1;
+        $user = new FakeUser($userId);
+
+        $this->userRepo->_User = $user;
+
+        $this->service->UpdatePassword($userId, 'password');
+
+        $this->assertNull($this->userRepo->_UpdatedUser);
     }
 }

--- a/tests/Presenters/Admin/ManageUsersPresenterTest.php
+++ b/tests/Presenters/Admin/ManageUsersPresenterTest.php
@@ -202,35 +202,19 @@ class ManageUsersPresenterTest extends TestBase
         $this->assertEquals($this->userRepo->_UpdatedUser, $user);
     }
 
-    public function testResetPasswordEncryptsAndUpdates()
+    public function testResetPasswordDelegatesToService()
     {
         $password = 'password';
-        $salt = 'salt';
-        $encrypted = 'encrypted';
         $userId = 123;
 
         $this->page->_UserId = $userId;
-
         $this->page->_Password = $password;
 
-        $this->encryption->expects($this->once())
-                         ->method('Salt')
-                         ->willReturn($salt);
-
-        $this->encryption->expects($this->once())
-                         ->method('Encrypt')
-                         ->with($this->equalTo($password), $this->equalTo($salt))
-                         ->willReturn($encrypted);
-
-        $user = new User();
-
-        $this->userRepo->_User = $user;
+        $this->manageUsersService->expects($this->once())
+                                 ->method('UpdatePassword')
+                                 ->with($this->equalTo($userId), $this->equalTo($password));
 
         $this->presenter->ResetPassword();
-
-        $this->assertEquals($encrypted, $user->encryptedPassword);
-        $this->assertEquals($salt, $user->passwordSalt);
-        $this->assertEquals($this->userRepo->_UpdatedUser, $user);
     }
 
     public function testCanUpdateUser()

--- a/tpl/Admin/Users/manage_users.tpl
+++ b/tpl/Admin/Users/manage_users.tpl
@@ -167,9 +167,11 @@
                                             <li role="presentation"><a role="menuitem" href="#"
                                                     class="dropdown-item update viewReservations">{translate key="Reservations"}</a>
                                             </li>
-                                            <li role="presentation"><a role="menuitem" href="#"
-                                                    class="dropdown-item update resetPassword">{translate key="ChangePassword"}</a>
-                                            </li>
+                                            {if $CanChangePasswords}
+                                                <li role="presentation"><a role="menuitem" href="#"
+                                                        class="dropdown-item update resetPassword">{translate key="ChangePassword"}</a>
+                                                </li>
+                                            {/if}
 
                                         </ul>
                                     </div>
@@ -456,6 +458,7 @@
         </div>
     </div>
 
+    {if $CanChangePasswords}
     <div id="passwordDialog" class="modal fade" tabindex="-1" role="dialog" aria-labelledby="passwordModalLabel"
         aria-hidden="true">
         <form id="passwordForm" method="post" ajaxAction="{ManageUsersActions::Password}" class="was-validated">
@@ -480,6 +483,7 @@
             </div>
         </form>
     </div>
+    {/if}
 
     <div id="invitationDialog" class="modal fade" tabindex="-1" role="dialog" aria-labelledby="invitationModalLabel"
         aria-hidden="true">


### PR DESCRIPTION
The manage users page allowed group administrators to set any user's password directly. The presenter's ResetPassword action encrypted and saved the password itself through the user repository, bypassing ManageUsersService entirely.

Delegate the presenter action to ManageUsersService::UpdatePassword() and deny the change there unless the session belongs to an application administrator, matching the DeleteUser guard. The REST API password endpoint already went through the service and was already restricted via AddAdminPost. Hide the change password menu item and dialog for non-application administrators with a new CanChangePasswords flag.

Assisted-by: Claude:claude-fable-5