### PR TITLE
fix(admin): restrict user editing to application administrators

### DIFF
--- a/Pages/Admin/ManageUsersPage.php
+++ b/Pages/Admin/ManageUsersPage.php
@@ -223,6 +223,7 @@ class ManageUsersPage extends ActionPage implements IManageUsersPage
         $isApplicationAdmin = $this->server->GetUserSession()->IsAdmin;
         $this->Set('CanDeleteUsers', $isApplicationAdmin);
         $this->Set('CanChangePasswords', $isApplicationAdmin);
+        $this->Set('CanEditUsers', $isApplicationAdmin);
         $url = $this->server->GetUrl();
         $exportUrl = BookedStringHelper::Contains($url, '?') ? $url . '&dr=export' : $this->server->GetRequestUri() . '?dr=export';
         $this->Set('ExportUrl', $exportUrl);

--- a/docs/source/ADMINISTRATION.rst
+++ b/docs/source/ADMINISTRATION.rst
@@ -385,11 +385,11 @@ This role has nearly zero restrictions on what resources can be booked. It
 can manage all aspects of the application.
 
 Group Administrator: Users that belong to a group that is given the Group
-Administrator role are able to manage their groups and reserve on behalf of
-and manage users within that group. Group Administrators cannot delete user
-accounts or change user passwords; only Application Administrators can. A group
-administrator must first be assigned the Group Administrator role. This
-group will then be available in the Group Administrators list.
+Administrator role are able to manage their groups and reserve on behalf of and
+manage users within that group. Group Administrators cannot edit user details,
+delete user accounts, or change user passwords; only Application Administrators
+can. A group administrator must first be assigned the Group Administrator role.
+This group will then be available in the Group Administrators list.
 
 Resource Administrator: Users that belong to a group that is given the
 Resource Administrators role have the same capabilities as Application

--- a/lib/Application/User/ManageUsersService.php
+++ b/lib/Application/User/ManageUsersService.php
@@ -199,6 +199,13 @@ class ManageUsersService implements IManageUsersService
 
     public function UpdateUser($userId, $username, $email, $firstName, $lastName, $timezone, $extraAttributes, $customAttributes)
     {
+        $currentUser = ServiceLocator::GetServer()->GetUserSession();
+        if (!$currentUser->IsAdmin) {
+            // only application administrators may update accounts
+            Log::Error('UpdateUser denied. UserId=%s is not an application administrator. Target UserId=%s', $currentUser->UserId, $userId);
+            return null;
+        }
+
         $attributes = new UserAttribute($extraAttributes);
         $user = $this->userRepository->LoadById($userId);
         $user->ChangeName($firstName, $lastName);
@@ -221,7 +228,7 @@ class ManageUsersService implements IManageUsersService
 
     public function ChangeGroups($user, $groupIds)
     {
-        if (is_null($groupIds)) {
+        if (is_null($user) || is_null($groupIds)) {
             return;
         }
 

--- a/tests/Application/User/ManageUsersServiceTest.php
+++ b/tests/Application/User/ManageUsersServiceTest.php
@@ -161,6 +161,8 @@ class ManageUsersServiceTest extends TestBase
 
     public function testUpdatesUser()
     {
+        $this->fakeUser->IsAdmin = true;
+
         $user = new User();
         $userId = 1029380;
         $fname = 'f';
@@ -195,6 +197,31 @@ class ManageUsersServiceTest extends TestBase
         $this->assertEquals($position, $user->GetAttribute(UserAttribute::Position));
         $this->assertEquals('value', $user->GetAttributeValue(1));
         $this->assertEquals($user, $this->userRepo->_UpdatedUser);
+    }
+
+    public function testChangeGroupsIgnoresNullUser()
+    {
+        $this->groupRepo->expects($this->never())
+                        ->method('LoadById');
+
+        $this->service->ChangeGroups(null, [1, 2]);
+    }
+
+    public function testUpdateUserIsDeniedWhenNotApplicationAdmin()
+    {
+        $this->fakeUser->IsAdmin = false;
+        $this->fakeUser->IsGroupAdmin = true;
+
+        $user = new User();
+        $user->ChangeEmailAddress('original@email.com');
+
+        $this->userRepo->_User = $user;
+
+        $updatedUser = $this->service->UpdateUser(1029380, 'un', 'attacker@email.com', 'f', 'l', 'America/Chicago', [], []);
+
+        $this->assertNull($updatedUser);
+        $this->assertNull($this->userRepo->_UpdatedUser);
+        $this->assertEquals('original@email.com', $user->EmailAddress());
     }
 
     public function testAddsAndRemovesUserFromGroups()

--- a/tpl/Admin/Users/manage_users.tpl
+++ b/tpl/Admin/Users/manage_users.tpl
@@ -147,17 +147,21 @@
 
                                 <td width="100">
                                     <div class="btn-group btn-group-sm">
-                                        <button type="button" class="btn btn-primary update edit">
-                                            <span class="visually-hidden">{translate key=Update}</span>
-                                            <i class="bi bi-pencil-square"></i></button>
+                                        {if $CanEditUsers}
+                                            <button type="button" class="btn btn-primary update edit">
+                                                <span class="visually-hidden">{translate key=Update}</span>
+                                                <i class="bi bi-pencil-square"></i></button>
+                                        {/if}
                                         <button type="button" class="btn btn-primary dropdown-toggle"
                                             data-bs-toggle="dropdown">
                                             <span class="visually-hidden">{translate key=More}</span>
                                         </button>
                                         <ul class="dropdown-menu" role="menu">
-                                            <li role="presentation"><a role="menuitem" href="#"
-                                                    class="dropdown-item update edit">{translate key="Edit"}</a>
-                                            </li>
+                                            {if $CanEditUsers}
+                                                <li role="presentation"><a role="menuitem" href="#"
+                                                        class="dropdown-item update edit">{translate key="Edit"}</a>
+                                                </li>
+                                            {/if}
                                             <li role="presentation"><a role="menuitem" href="#"
                                                     class="dropdown-item update changePermissions">{translate key="Permissions"}</a>
                                             </li>
@@ -512,6 +516,7 @@
         </form>
     </div>
 
+    {if $CanEditUsers}
     <div id="userDialog" class="modal fade" tabindex="-1" role="dialog" aria-labelledby="userModalLabel"
         aria-hidden="true">
         <form id="userForm" method="post" ajaxAction="{ManageUsersActions::UpdateUser}">
@@ -533,6 +538,7 @@
             </div>
         </form>
     </div>
+    {/if}
 
     {if $CanDeleteUsers}
     <div id="deleteDialog" class="modal fade" tabindex="-1" role="dialog" aria-labelledby="deleteModalLabel"


### PR DESCRIPTION
The group admin user management page reuses ManageUsersPresenter, whose updateUser action flows through the unscoped ManageUsersService. A group administrator could modify any user's username, email, name, and attributes.

Deny ManageUsersService::UpdateUser() unless the session belongs to an application administrator, matching the existing DeleteUser and UpdatePassword guards. The REST API update endpoint was already restricted via AddAdminPost. Hide the edit button, edit menu item, and edit dialog for non-application administrators with a new CanEditUsers template flag, and note the restriction in the administration guide.

Assisted-by: Claude:claude-fable-5