### PR TITLE
fix(admin): restrict user creation to application administrators

### DIFF
--- a/Pages/Admin/ManageUsersPage.php
+++ b/Pages/Admin/ManageUsersPage.php
@@ -224,6 +224,7 @@ class ManageUsersPage extends ActionPage implements IManageUsersPage
         $this->Set('CanDeleteUsers', $isApplicationAdmin);
         $this->Set('CanChangePasswords', $isApplicationAdmin);
         $this->Set('CanEditUsers', $isApplicationAdmin);
+        $this->Set('CanCreateUsers', $isApplicationAdmin);
         $url = $this->server->GetUrl();
         $exportUrl = BookedStringHelper::Contains($url, '?') ? $url . '&dr=export' : $this->server->GetRequestUri() . '?dr=export';
         $this->Set('ExportUrl', $exportUrl);

--- a/Presenters/Admin/ManageUsersPresenter.php
+++ b/Presenters/Admin/ManageUsersPresenter.php
@@ -257,6 +257,10 @@ class ManageUsersPresenter extends ActionPresenter implements IManageUsersPresen
             $this->GetAttributeValues()
         );
 
+        if ($user == null) {
+            return;
+        }
+
         $userId = $user->Id();
         $groupId = $this->page->GetUserGroup();
 
@@ -532,6 +536,12 @@ class ManageUsersPresenter extends ActionPresenter implements IManageUsersPresen
 
     public function ImportUsers()
     {
+        $userSession = ServiceLocator::GetServer()->GetUserSession();
+        if (!$userSession->IsAdmin) {
+            $this->page->SetImportResult(new CsvImportResult(0, [], 'User is not an admin'));
+            return;
+        }
+
         ini_set('max_execution_time', 600);
 
         $attributes = $this->attributeService->GetByCategory(CustomAttributeCategory::USER);
@@ -684,6 +694,13 @@ class ManageUsersPresenter extends ActionPresenter implements IManageUsersPresen
 
     public function InviteUsers()
     {
+        $userSession = ServiceLocator::GetServer()->GetUserSession();
+        if (!$userSession->IsAdmin) {
+            // only application administrators may invite new accounts
+            Log::Error('InviteUsers denied. UserId=%s is not an application administrator', $userSession->UserId);
+            return;
+        }
+
         $emailList = $this->page->GetInvitedEmails();
         $emails = preg_split('/[,;\s\n]+/', $emailList);
         foreach ($emails as $email) {

--- a/WebServices/Controllers/UserSaveController.php
+++ b/WebServices/Controllers/UserSaveController.php
@@ -79,6 +79,10 @@ class UserSaveController implements IUserSaveController
             $customAttributes
         );
 
+        if ($user == null) {
+            return new UserControllerResult(null, ['Only application administrators may create users']);
+        }
+
         $userService->ChangeGroups($user, $request->groups);
 
         return new UserControllerResult($user->Id());
@@ -110,6 +114,10 @@ class UserSaveController implements IUserSaveController
             $extraAttributes,
             $customAttributes
         );
+
+        if ($user == null) {
+            return new UserControllerResult(null, ['Only application administrators may update users']);
+        }
 
         //		$userService->ChangeAttributes($userId, $customAttributes);
 

--- a/docs/source/ADMINISTRATION.rst
+++ b/docs/source/ADMINISTRATION.rst
@@ -386,7 +386,8 @@ can manage all aspects of the application.
 
 Group Administrator: Users that belong to a group that is given the Group
 Administrator role are able to manage their groups and reserve on behalf of and
-manage users within that group. Group Administrators cannot edit user details,
+manage users within that group. Group Administrators cannot create user
+accounts (individually, by invitation, or by CSV import), edit user details,
 delete user accounts, or change user passwords; only Application Administrators
 can. A group administrator must first be assigned the Group Administrator role.
 This group will then be available in the Group Administrators list.

--- a/lib/Application/User/ManageUsersService.php
+++ b/lib/Application/User/ManageUsersService.php
@@ -17,7 +17,7 @@ interface IManageUsersService
      * @param $homePageId int
      * @param $extraAttributes array|string[]
      * @param $customAttributes array|AttributeValue[]
-     * @return User
+     * @return User|null null when the current session is not an application administrator
      */
     public function AddUser(
         $username,
@@ -41,7 +41,7 @@ interface IManageUsersService
      * @param $timezone string
      * @param $extraAttributes string[]|array
      * @param $customAttributes AttributeValue[]
-     * @return User
+     * @return User|null null when the current session is not an application administrator
      */
     public function UpdateUser($userId, $username, $email, $firstName, $lastName, $timezone, $extraAttributes, $customAttributes);
 
@@ -134,6 +134,13 @@ class ManageUsersService implements IManageUsersService
         $extraAttributes,
         $customAttributes
     ) {
+        $currentUser = ServiceLocator::GetServer()->GetUserSession();
+        if (!$currentUser->IsAdmin) {
+            // only application administrators may create accounts
+            Log::Error('AddUser denied. UserId=%s is not an application administrator', $currentUser->UserId);
+            return null;
+        }
+
         $user = $this->registration->Register(
             $username,
             $email,

--- a/tests/Application/User/ManageUsersServiceTest.php
+++ b/tests/Application/User/ManageUsersServiceTest.php
@@ -48,6 +48,8 @@ class ManageUsersServiceTest extends TestBase
 
     public function testAddsUser()
     {
+        $this->fakeUser->IsAdmin = true;
+
         $fname = 'f';
         $lname = 'l';
         $username = 'un';
@@ -197,6 +199,19 @@ class ManageUsersServiceTest extends TestBase
         $this->assertEquals($position, $user->GetAttribute(UserAttribute::Position));
         $this->assertEquals('value', $user->GetAttributeValue(1));
         $this->assertEquals($user, $this->userRepo->_UpdatedUser);
+    }
+
+    public function testAddUserIsDeniedWhenNotApplicationAdmin()
+    {
+        $this->fakeUser->IsAdmin = false;
+        $this->fakeUser->IsGroupAdmin = true;
+
+        $this->registration->expects($this->never())
+                           ->method('Register');
+
+        $actualUser = $this->service->AddUser('un', 'e@mail.com', 'f', 'l', 'pw', 'America/Chicago', 'en_us', 1, [], []);
+
+        $this->assertNull($actualUser);
     }
 
     public function testChangeGroupsIgnoresNullUser()

--- a/tests/Presenters/Admin/ManageUsersPresenterTest.php
+++ b/tests/Presenters/Admin/ManageUsersPresenterTest.php
@@ -202,6 +202,33 @@ class ManageUsersPresenterTest extends TestBase
         $this->assertEquals($this->userRepo->_UpdatedUser, $user);
     }
 
+    public function testImportUsersIsDeniedWhenNotApplicationAdmin()
+    {
+        $this->fakeUser->IsAdmin = false;
+        $this->fakeUser->IsGroupAdmin = true;
+
+        $this->manageUsersService->expects($this->never())
+                                 ->method('AddUser');
+        $this->manageUsersService->expects($this->never())
+                                 ->method('LoadUser');
+
+        $this->presenter->ImportUsers();
+
+        $this->assertEquals(0, $this->page->_ImportResult->importCount);
+        $this->assertEquals(['User is not an admin'], $this->page->_ImportResult->messages);
+    }
+
+    public function testInviteUsersIsDeniedWhenNotApplicationAdmin()
+    {
+        $this->fakeUser->IsAdmin = false;
+        $this->fakeUser->IsGroupAdmin = true;
+        $this->page->_InvitedEmails = 'invitee@email.com';
+
+        $this->presenter->InviteUsers();
+
+        $this->assertEquals(0, count($this->fakeEmailService->_Messages));
+    }
+
     public function testResetPasswordDelegatesToService()
     {
         $password = 'password';
@@ -477,6 +504,14 @@ class ManageUsersPresenterTest extends TestBase
 class FakeManageUsersPage extends FakeActionPageBase implements IManageUsersPage
 {
     /**
+     * @var CsvImportResult
+     */
+    public $_ImportResult;
+    /**
+     * @var string
+     */
+    public $_InvitedEmails = '';
+    /**
      * @var int
      */
     public $_UserId;
@@ -726,12 +761,12 @@ class FakeManageUsersPage extends FakeActionPageBase implements IManageUsersPage
 
     public function SetImportResult($importResult)
     {
-        // TODO: Implement SetImportResult() method.
+        $this->_ImportResult = $importResult;
     }
 
     public function GetInvitedEmails()
     {
-        return '';
+        return $this->_InvitedEmails;
     }
 
     public function ShowExportCsv()

--- a/tpl/Admin/Users/manage_users.tpl
+++ b/tpl/Admin/Users/manage_users.tpl
@@ -5,10 +5,12 @@
     <div class="border-bottom mb-3 clearfix">
         <div class="dropdown admin-header-more float-end">
             <div class="btn-group btn-group-sm">
-                <a href="#" id="add-user" class="add-link add-user add-group btn btn-primary">
-                    <i class="bi bi-plus-circle-fill me-1"></i>
-                    {translate key="AddUser"}
-                </a>
+                {if $CanCreateUsers}
+                    <a href="#" id="add-user" class="add-link add-user add-group btn btn-primary">
+                        <i class="bi bi-plus-circle-fill me-1"></i>
+                        {translate key="AddUser"}
+                    </a>
+                {/if}
 
                 <button class="btn btn-primary btn-sm dropdown-toggle" type="button" id="moreUserActions"
                     data-bs-toggle="dropdown" aria-expanded="false" aria-label="{translate key='More'}">
@@ -16,18 +18,20 @@
                 </button>
 
                 <ul class="dropdown-menu" aria-labelledby="moreUserActions">
-                    <li>
-                        <a href="#" id="invite-users" class="dropdown-item">
-                            <i class="bi bi-send me-1"></i>
-                            {translate key="InviteUsers"}
-                        </a>
-                    </li>
-                    <li>
-                        <a href="#" id="import-users" class="dropdown-item">
-                            <i class="bi bi-download me-1"></i>
-                            {translate key="Import"}
-                        </a>
-                    </li>
+                    {if $CanCreateUsers}
+                        <li>
+                            <a href="#" id="invite-users" class="dropdown-item">
+                                <i class="bi bi-send me-1"></i>
+                                {translate key="InviteUsers"}
+                            </a>
+                        </li>
+                        <li>
+                            <a href="#" id="import-users" class="dropdown-item">
+                                <i class="bi bi-download me-1"></i>
+                                {translate key="Import"}
+                            </a>
+                        </li>
+                    {/if}
                     <li>
                         <a href="{$ExportUrl}" download id="export-users" class="dropdown-item" target="_blank">
                             <i class="bi bi-upload me-1"></i>
@@ -216,6 +220,7 @@
         </div>
     </div>
 
+    {if $CanCreateUsers}
     <div id="addUserDialog" class="modal" tabindex="-1" role="dialog" aria-labelledby="addUserModalLabel"
         aria-hidden="true">
         <form id="addUserForm" class="form" role="form" method="post" ajaxAction="{ManageUsersActions::AddUser}">
@@ -408,6 +413,7 @@
             </div>
         </form>
     </div>
+    {/if}
 
     <input type="hidden" id="activeId" />
 
@@ -489,6 +495,7 @@
     </div>
     {/if}
 
+    {if $CanCreateUsers}
     <div id="invitationDialog" class="modal fade" tabindex="-1" role="dialog" aria-labelledby="invitationModalLabel"
         aria-hidden="true">
         <form id="invitationForm" method="post" ajaxAction="{ManageUsersActions::InviteUsers}">
@@ -515,6 +522,7 @@
             </div>
         </form>
     </div>
+    {/if}
 
     {if $CanEditUsers}
     <div id="userDialog" class="modal fade" tabindex="-1" role="dialog" aria-labelledby="userModalLabel"


### PR DESCRIPTION
The group admin user management page exposed the addUser, importUsers, and inviteUsers actions. A group administrator could create accounts with passwords they chose and the CSV import path could additionally update existing users.

Deny ManageUsersService::AddUser() unless the session belongs to an application administrator, and guard the ImportUsers and InviteUsers presenter actions, following the existing ImportReservations pattern. The presenter's AddUser action tolerates the service's null denial return. Hide the add, invite, and import controls and dialogs for non-application administrators with a new CanCreateUsers template flag, and note the restriction in the administration guide.

Assisted-by: Claude:claude-fable-5