### PR TITLE
fix(admin): restrict group role assignment to application administrators

### DIFF
--- a/Pages/Admin/GroupAdminManageGroupsPage.php
+++ b/Pages/Admin/GroupAdminManageGroupsPage.php
@@ -10,6 +10,7 @@ class GroupAdminManageGroupsPage extends ManageGroupsPage
         parent::__construct();
 
         $this->CanChangeRoles = false;
+        $this->CanImportGroups = false;
         $this->presenter = new ManageGroupsPresenter(
             $this,
             new GroupAdminGroupRepository(new UserRepository(), ServiceLocator::GetServer()->GetUserSession()),

--- a/Pages/Admin/ManageGroupsPage.php
+++ b/Pages/Admin/ManageGroupsPage.php
@@ -136,6 +136,7 @@ interface IManageGroupsPage extends IActionPage
 class ManageGroupsPage extends ActionPage implements IManageGroupsPage
 {
     protected $CanChangeRoles = true;
+    protected $CanImportGroups = true;
     /**
      * @var ManageGroupsPresenter
      */
@@ -169,6 +170,7 @@ class ManageGroupsPage extends ActionPage implements IManageGroupsPage
         $this->presenter->PageLoad();
         $this->Set('chooseText', Resources::GetInstance()->GetString('Choose') . '...');
         $this->Set('CanChangeRoles', $this->CanChangeRoles);
+        $this->Set('CanImportGroups', $this->CanImportGroups);
         $this->Display('Admin/Groups/manage_groups.tpl');
     }
 

--- a/Presenters/Admin/ManageGroupsPresenter.php
+++ b/Presenters/Admin/ManageGroupsPresenter.php
@@ -162,6 +162,13 @@ class ManageGroupsPresenter extends ActionPresenter
 
     public function ChangeRoles()
     {
+        $userSession = ServiceLocator::GetServer()->GetUserSession();
+        if (!$userSession->IsAdmin) {
+            // only application administrators may change group roles
+            Log::Error('ChangeRoles denied. UserId=%s is not an application administrator', $userSession->UserId);
+            return;
+        }
+
         $groupId = $this->page->GetGroupId();
         Log::Debug('Changing roles for groupId: %s', $groupId);
 
@@ -291,6 +298,13 @@ class ManageGroupsPresenter extends ActionPresenter
 
     public function ChangeGroupAdmin()
     {
+        $userSession = ServiceLocator::GetServer()->GetUserSession();
+        if (!$userSession->IsAdmin) {
+            // only application administrators may change group administrators
+            Log::Error('ChangeGroupAdmin denied. UserId=%s is not an application administrator', $userSession->UserId);
+            return;
+        }
+
         $groupId = $this->page->GetGroupId();
         $adminGroupId = $this->page->GetAdminGroupId();
 
@@ -387,6 +401,13 @@ class ManageGroupsPresenter extends ActionPresenter
 
     public function ChangeAdminGroups()
     {
+        $userSession = ServiceLocator::GetServer()->GetUserSession();
+        if (!$userSession->IsAdmin) {
+            // only application administrators may change administered groups
+            Log::Error('ChangeAdminGroups denied. UserId=%s is not an application administrator', $userSession->UserId);
+            return;
+        }
+
         $groupId = $this->page->GetGroupId();
         $groupIds = $this->page->GetGroupAdminIds();
         if (empty($groupIds)) {
@@ -410,6 +431,13 @@ class ManageGroupsPresenter extends ActionPresenter
 
     public function ChangeResourceGroups()
     {
+        $userSession = ServiceLocator::GetServer()->GetUserSession();
+        if (!$userSession->IsAdmin) {
+            // only application administrators may change administered resources
+            Log::Error('ChangeResourceGroups denied. UserId=%s is not an application administrator', $userSession->UserId);
+            return;
+        }
+
         $groupId = $this->page->GetGroupId();
         $resourceIds = $this->page->GetResourceAdminIds();
         if (empty($resourceIds)) {
@@ -433,6 +461,13 @@ class ManageGroupsPresenter extends ActionPresenter
 
     public function ChangeScheduleGroups()
     {
+        $userSession = ServiceLocator::GetServer()->GetUserSession();
+        if (!$userSession->IsAdmin) {
+            // only application administrators may change administered schedules
+            Log::Error('ChangeScheduleGroups denied. UserId=%s is not an application administrator', $userSession->UserId);
+            return;
+        }
+
         $groupId = $this->page->GetGroupId();
         $scheduleIds = $this->page->GetScheduleAdminIds();
         if (empty($scheduleIds)) {
@@ -491,6 +526,12 @@ class ManageGroupsPresenter extends ActionPresenter
 
     public function Import()
     {
+        $userSession = ServiceLocator::GetServer()->GetUserSession();
+        if (!$userSession->IsAdmin) {
+            $this->page->SetImportResult(new CsvImportResult(0, [], 'User is not an admin'));
+            return;
+        }
+
         Log::Debug('Importing groups');
 
         ini_set('max_execution_time', 600);

--- a/docs/source/ADMINISTRATION.rst
+++ b/docs/source/ADMINISTRATION.rst
@@ -378,6 +378,9 @@ Roles
 -----
 
 Roles give a group of users the authorization to perform certain actions.
+Only Application Administrators can assign roles to a group, change which
+groups, resources, and schedules a group administers, or import groups from
+a CSV file.
 
 Application Administrator: Users that belong to a group that is given the
 Application Administrator role are open to full administrative privileges.

--- a/tests/Pages/Admin/GroupAdminManageGroupsPageTest.php
+++ b/tests/Pages/Admin/GroupAdminManageGroupsPageTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+require_once(ROOT_DIR . 'Pages/Admin/GroupAdminManageGroupsPage.php');
+require_once(ROOT_DIR . 'lib/Application/Admin/namespace.php');
+
+class GroupAdminManageGroupsPageTest extends TestBase
+{
+    public function testDisablesRoleAndImportControlsForGroupAdmins(): void
+    {
+        $page = new GroupAdminManageGroupsPage();
+
+        $canChangeRoles = new ReflectionProperty(ManageGroupsPage::class, 'CanChangeRoles');
+        $canImportGroups = new ReflectionProperty(ManageGroupsPage::class, 'CanImportGroups');
+
+        $this->assertFalse($canChangeRoles->getValue($page));
+        $this->assertFalse($canImportGroups->getValue($page));
+    }
+
+    public function testEnablesRoleAndImportControlsForApplicationAdmins(): void
+    {
+        $page = new ManageGroupsPage();
+
+        $canChangeRoles = new ReflectionProperty(ManageGroupsPage::class, 'CanChangeRoles');
+        $canImportGroups = new ReflectionProperty(ManageGroupsPage::class, 'CanImportGroups');
+
+        $this->assertTrue($canChangeRoles->getValue($page));
+        $this->assertTrue($canImportGroups->getValue($page));
+    }
+}

--- a/tests/Presenters/Admin/ManageGroupsPresenterTest.php
+++ b/tests/Presenters/Admin/ManageGroupsPresenterTest.php
@@ -136,11 +136,112 @@ class ManageGroupsPresenterTest extends TestBase
         $this->assertEquals([], $group->AllowedResourceIds());
         $this->assertEquals([], $group->AllowedViewResourceIds());
     }
+
+    public function testChangeRolesUpdatesGroupWhenApplicationAdmin()
+    {
+        $this->fakeUser->IsAdmin = true;
+
+        $groupId = 100;
+        $group = new Group(0, 'test group');
+        $group->WithId($groupId);
+
+        $this->page->_GroupId = $groupId;
+
+        $this->groupRepository
+            ->expects($this->once())
+            ->method('LoadById')
+            ->with($groupId)
+            ->willReturn($group);
+
+        $this->groupRepository
+            ->expects($this->once())
+            ->method('Update')
+            ->with($group);
+
+        $this->presenter->ChangeRoles();
+    }
+
+    public function testChangeRolesIsDeniedWhenNotApplicationAdmin()
+    {
+        $this->fakeUser->IsAdmin = false;
+        $this->fakeUser->IsGroupAdmin = true;
+        $this->page->_GroupId = 100;
+
+        $this->groupRepository->expects($this->never())->method('LoadById');
+        $this->groupRepository->expects($this->never())->method('Update');
+
+        $this->presenter->ChangeRoles();
+    }
+
+    public function testChangeGroupAdminIsDeniedWhenNotApplicationAdmin()
+    {
+        $this->fakeUser->IsAdmin = false;
+        $this->fakeUser->IsGroupAdmin = true;
+        $this->page->_GroupId = 100;
+
+        $this->groupRepository->expects($this->never())->method('LoadById');
+        $this->groupRepository->expects($this->never())->method('Update');
+
+        $this->presenter->ChangeGroupAdmin();
+    }
+
+    public function testChangeAdminGroupsIsDeniedWhenNotApplicationAdmin()
+    {
+        $this->fakeUser->IsAdmin = false;
+        $this->fakeUser->IsGroupAdmin = true;
+        $this->page->_GroupId = 100;
+
+        $this->groupRepository->expects($this->never())->method('LoadById');
+        $this->groupRepository->expects($this->never())->method('Update');
+
+        $this->presenter->ChangeAdminGroups();
+    }
+
+    public function testChangeResourceGroupsIsDeniedWhenNotApplicationAdmin()
+    {
+        $this->fakeUser->IsAdmin = false;
+        $this->fakeUser->IsGroupAdmin = true;
+        $this->page->_GroupId = 100;
+
+        $this->presenter->ChangeResourceGroups();
+
+        $this->assertNull($this->resourceRepo->_UpdatedResource);
+    }
+
+    public function testChangeScheduleGroupsIsDeniedWhenNotApplicationAdmin()
+    {
+        $this->fakeUser->IsAdmin = false;
+        $this->fakeUser->IsGroupAdmin = true;
+        $this->page->_GroupId = 100;
+
+        $this->scheduleRepository->expects($this->never())->method('Update');
+
+        $this->presenter->ChangeScheduleGroups();
+    }
+
+    public function testImportIsDeniedWhenNotApplicationAdmin()
+    {
+        $this->fakeUser->IsAdmin = false;
+        $this->fakeUser->IsGroupAdmin = true;
+
+        $this->groupRepository->expects($this->never())->method('Add');
+        $this->groupRepository->expects($this->never())->method('Update');
+
+        $this->presenter->Import();
+
+        $this->assertEquals(0, $this->page->_ImportResult->importCount);
+        $this->assertEquals(['User is not an admin'], $this->page->_ImportResult->messages);
+    }
 }
 
 class FakeManageGroupsPage extends FakeActionPageBase implements IManageGroupsPage
 {
     public ?int $_GroupId = null;
+
+    /**
+     * @var CsvImportResult
+     */
+    public $_ImportResult;
     /** @var string[]|null */
     public ?array $_AllowedResourceIds = null;
 
@@ -252,6 +353,7 @@ class FakeManageGroupsPage extends FakeActionPageBase implements IManageGroupsPa
 
     public function SetImportResult($importResult)
     {
+        $this->_ImportResult = $importResult;
     }
 
     public function GetUpdateOnImport()

--- a/tpl/Admin/Groups/manage_groups.tpl
+++ b/tpl/Admin/Groups/manage_groups.tpl
@@ -13,12 +13,14 @@
                     <i class="bi bi-three-dots"></i>
                 </button>
                 <ul class="dropdown-menu" aria-labelledby="moreResourceActions">
-                    <li>
-                        <a href="#" class="import-groups dropdown-item" id="import-groups" data-bs-toggle="modal"
-                            data-bs-target="#importGroupsDialog">
-                            <i class="bi bi-download me-1"></i>{translate key="Import"}
-                        </a>
-                    </li>
+                    {if $CanImportGroups}
+                        <li>
+                            <a href="#" class="import-groups dropdown-item" id="import-groups" data-bs-toggle="modal"
+                                data-bs-target="#importGroupsDialog">
+                                <i class="bi bi-download me-1"></i>{translate key="Import"}
+                            </a>
+                        </li>
+                    {/if}
                     <li>
                         <a href="{$smarty.server.SCRIPT_NAME}?dr=export" download class="export-groups dropdown-item"
                             id="export-groups" target="_blank">
@@ -103,8 +105,12 @@
                                     {/if}
                                 </td>
                             {/if}
-                            <td><a href="#"
-                                    class="update groupAdmin link-primary">{$group->AdminGroupName|default:$chooseText}</a>
+                            <td>{if $CanChangeRoles}
+                                    <a href="#"
+                                        class="update groupAdmin link-primary">{$group->AdminGroupName|default:$chooseText}</a>
+                                {else}
+                                    {$group->AdminGroupName|default:$chooseText}
+                                {/if}
                             </td>
                             <td>{if $group->IsDefault}
                                     <i class="bi bi-check-circle text-success"></i>
@@ -451,6 +457,7 @@
     </div>
     {/if}
 
+    {if $CanChangeRoles}
     <div class="modal fade" id="groupAdminDialog" tabindex="-1" role="dialog" aria-labelledby="groupAdminDialogLabel"
         aria-hidden="true">
         <div class="modal-dialog">
@@ -481,7 +488,9 @@
             </form>
         </div>
     </div>
+    {/if}
 
+    {if $CanImportGroups}
     <div id="importGroupsDialog" class="modal" tabindex="-1" role="dialog" aria-labelledby="importGroupsModalLabel"
         aria-hidden="true">
         <form id="importGroupsForm" class="form" role="form" method="post" enctype="multipart/form-data"
@@ -535,6 +544,7 @@
             </div>
         </form>
     </div>
+    {/if}
 
     {csrf_token}
 


### PR DESCRIPTION
Make the roles, groupAdmin, adminGroups, resourceGroups, scheduleGroups, and import actions in ManageGroupsPresenter enforce on the server side that the current session belongs to an application administrator, following the same guard pattern used for the recent user management changes. Previously only the page templates controlled which of these actions were presented.

Group role assignment and administered group, resource, and schedule associations are application administrator responsibilities under the delegated administration model, as is the group CSV import, which can also assign roles and create groups.

Hide the group import menu item and dialog on the group admin page with a new CanImportGroups flag, matching the existing CanChangeRoles handling, and document the restriction in the administration guide.

Assisted-by: Claude:claude-fable-5