### PR TITLE
fix(admin): restrict user and group CSV export to application admins

### DIFF
--- a/Pages/Admin/GroupAdminManageGroupsPage.php
+++ b/Pages/Admin/GroupAdminManageGroupsPage.php
@@ -11,6 +11,7 @@ class GroupAdminManageGroupsPage extends ManageGroupsPage
 
         $this->CanChangeRoles = false;
         $this->CanImportGroups = false;
+        $this->CanExportGroups = false;
         $this->presenter = new ManageGroupsPresenter(
             $this,
             new GroupAdminGroupRepository(new UserRepository(), ServiceLocator::GetServer()->GetUserSession()),

--- a/Pages/Admin/ManageGroupsPage.php
+++ b/Pages/Admin/ManageGroupsPage.php
@@ -137,6 +137,7 @@ class ManageGroupsPage extends ActionPage implements IManageGroupsPage
 {
     protected $CanChangeRoles = true;
     protected $CanImportGroups = true;
+    protected $CanExportGroups = true;
     /**
      * @var ManageGroupsPresenter
      */
@@ -171,6 +172,7 @@ class ManageGroupsPage extends ActionPage implements IManageGroupsPage
         $this->Set('chooseText', Resources::GetInstance()->GetString('Choose') . '...');
         $this->Set('CanChangeRoles', $this->CanChangeRoles);
         $this->Set('CanImportGroups', $this->CanImportGroups);
+        $this->Set('CanExportGroups', $this->CanExportGroups);
         $this->Display('Admin/Groups/manage_groups.tpl');
     }
 

--- a/Pages/Admin/ManageUsersPage.php
+++ b/Pages/Admin/ManageUsersPage.php
@@ -225,6 +225,7 @@ class ManageUsersPage extends ActionPage implements IManageUsersPage
         $this->Set('CanChangePasswords', $isApplicationAdmin);
         $this->Set('CanEditUsers', $isApplicationAdmin);
         $this->Set('CanCreateUsers', $isApplicationAdmin);
+        $this->Set('CanExportUsers', $isApplicationAdmin);
         $url = $this->server->GetUrl();
         $exportUrl = BookedStringHelper::Contains($url, '?') ? $url . '&dr=export' : $this->server->GetRequestUri() . '?dr=export';
         $this->Set('ExportUrl', $exportUrl);

--- a/Presenters/Admin/ManageGroupsPresenter.php
+++ b/Presenters/Admin/ManageGroupsPresenter.php
@@ -491,6 +491,13 @@ class ManageGroupsPresenter extends ActionPresenter
 
     public function Export()
     {
+        $userSession = ServiceLocator::GetServer()->GetUserSession();
+        if (!$userSession->IsAdmin) {
+            // only application administrators may export groups
+            Log::Error('Export denied. UserId=%s is not an application administrator', $userSession->UserId);
+            return;
+        }
+
         /** @var GroupItemView[] $groups */
         $groups = $this->groupRepository->GetList()->Results();
         /** @var UserItemView[] $userGroups */

--- a/Presenters/Admin/ManageUsersPresenter.php
+++ b/Presenters/Admin/ManageUsersPresenter.php
@@ -350,6 +350,13 @@ class ManageUsersPresenter extends ActionPresenter implements IManageUsersPresen
 
     public function ExportUsers()
     {
+        $userSession = ServiceLocator::GetServer()->GetUserSession();
+        if (!$userSession->IsAdmin) {
+            // only application administrators may export users
+            Log::Error('ExportUsers denied. UserId=%s is not an application administrator', $userSession->UserId);
+            return;
+        }
+
         $this->PageLoad();
         $this->page->ShowExportCsv();
     }

--- a/docs/source/ADMINISTRATION.rst
+++ b/docs/source/ADMINISTRATION.rst
@@ -379,8 +379,8 @@ Roles
 
 Roles give a group of users the authorization to perform certain actions.
 Only Application Administrators can assign roles to a group, change which
-groups, resources, and schedules a group administers, or import groups from
-a CSV file.
+groups, resources, and schedules a group administers, or import and export
+users and groups as CSV files.
 
 Application Administrator: Users that belong to a group that is given the
 Application Administrator role are open to full administrative privileges.

--- a/tests/Pages/Admin/GroupAdminManageGroupsPageTest.php
+++ b/tests/Pages/Admin/GroupAdminManageGroupsPageTest.php
@@ -13,9 +13,11 @@ class GroupAdminManageGroupsPageTest extends TestBase
 
         $canChangeRoles = new ReflectionProperty(ManageGroupsPage::class, 'CanChangeRoles');
         $canImportGroups = new ReflectionProperty(ManageGroupsPage::class, 'CanImportGroups');
+        $canExportGroups = new ReflectionProperty(ManageGroupsPage::class, 'CanExportGroups');
 
         $this->assertFalse($canChangeRoles->getValue($page));
         $this->assertFalse($canImportGroups->getValue($page));
+        $this->assertFalse($canExportGroups->getValue($page));
     }
 
     public function testEnablesRoleAndImportControlsForApplicationAdmins(): void
@@ -24,8 +26,10 @@ class GroupAdminManageGroupsPageTest extends TestBase
 
         $canChangeRoles = new ReflectionProperty(ManageGroupsPage::class, 'CanChangeRoles');
         $canImportGroups = new ReflectionProperty(ManageGroupsPage::class, 'CanImportGroups');
+        $canExportGroups = new ReflectionProperty(ManageGroupsPage::class, 'CanExportGroups');
 
         $this->assertTrue($canChangeRoles->getValue($page));
         $this->assertTrue($canImportGroups->getValue($page));
+        $this->assertTrue($canExportGroups->getValue($page));
     }
 }

--- a/tests/Presenters/Admin/ManageGroupsPresenterTest.php
+++ b/tests/Presenters/Admin/ManageGroupsPresenterTest.php
@@ -219,6 +219,19 @@ class ManageGroupsPresenterTest extends TestBase
         $this->presenter->ChangeScheduleGroups();
     }
 
+    public function testExportIsDeniedWhenNotApplicationAdmin()
+    {
+        $this->fakeUser->IsAdmin = false;
+        $this->fakeUser->IsGroupAdmin = true;
+
+        $this->groupRepository->expects($this->never())->method('GetList');
+        $this->groupRepository->expects($this->never())->method('GetPermissionList');
+
+        $this->presenter->Export();
+
+        $this->assertFalse($this->page->_Exported);
+    }
+
     public function testImportIsDeniedWhenNotApplicationAdmin()
     {
         $this->fakeUser->IsAdmin = false;
@@ -242,6 +255,11 @@ class FakeManageGroupsPage extends FakeActionPageBase implements IManageGroupsPa
      * @var CsvImportResult
      */
     public $_ImportResult;
+
+    /**
+     * @var bool
+     */
+    public $_Exported = false;
     /** @var string[]|null */
     public ?array $_AllowedResourceIds = null;
 
@@ -340,6 +358,7 @@ class FakeManageGroupsPage extends FakeActionPageBase implements IManageGroupsPa
 
     public function Export($groups, $users, $permissionsWrite, $permissionsRead)
     {
+        $this->_Exported = true;
     }
 
     public function GetImportFile()

--- a/tests/Presenters/Admin/ManageUsersPresenterTest.php
+++ b/tests/Presenters/Admin/ManageUsersPresenterTest.php
@@ -202,6 +202,16 @@ class ManageUsersPresenterTest extends TestBase
         $this->assertEquals($this->userRepo->_UpdatedUser, $user);
     }
 
+    public function testExportUsersIsDeniedWhenNotApplicationAdmin()
+    {
+        $this->fakeUser->IsAdmin = false;
+        $this->fakeUser->IsGroupAdmin = true;
+
+        $this->presenter->ExportUsers();
+
+        $this->assertFalse($this->page->_ShowedExportCsv);
+    }
+
     public function testImportUsersIsDeniedWhenNotApplicationAdmin()
     {
         $this->fakeUser->IsAdmin = false;
@@ -508,6 +518,10 @@ class FakeManageUsersPage extends FakeActionPageBase implements IManageUsersPage
      */
     public $_ImportResult;
     /**
+     * @var bool
+     */
+    public $_ShowedExportCsv = false;
+    /**
      * @var string
      */
     public $_InvitedEmails = '';
@@ -771,7 +785,7 @@ class FakeManageUsersPage extends FakeActionPageBase implements IManageUsersPage
 
     public function ShowExportCsv()
     {
-        // TODO: Implement ShowExportCsv() method.
+        $this->_ShowedExportCsv = true;
     }
 
     public function BindStatusDescriptions()

--- a/tpl/Admin/Groups/manage_groups.tpl
+++ b/tpl/Admin/Groups/manage_groups.tpl
@@ -8,6 +8,7 @@
                     <i class="bi bi-plus-circle-fill me-1"></i>
                     {translate key="AddGroup"}
                 </a>
+                {if $CanImportGroups or $CanExportGroups}
                 <button class="btn btn-primary dropdown-toggle" type="button" id="moreResourceActions"
                     data-bs-toggle="dropdown" aria-expanded="false" aria-label="{translate key='More'}">
                     <i class="bi bi-three-dots"></i>
@@ -21,13 +22,16 @@
                             </a>
                         </li>
                     {/if}
-                    <li>
-                        <a href="{$smarty.server.SCRIPT_NAME}?dr=export" download class="export-groups dropdown-item"
-                            id="export-groups" target="_blank">
-                            <i class="bi bi-upload me-1"></i>{translate key="Export"}
-                        </a>
-                    </li>
+                    {if $CanExportGroups}
+                        <li>
+                            <a href="{$smarty.server.SCRIPT_NAME}?dr=export" download class="export-groups dropdown-item"
+                                id="export-groups" target="_blank" rel="noopener noreferrer">
+                                <i class="bi bi-upload me-1"></i>{translate key="Export"}
+                            </a>
+                        </li>
+                    {/if}
                 </ul>
+                {/if}
             </div>
         </div>
 

--- a/tpl/Admin/Users/manage_users.tpl
+++ b/tpl/Admin/Users/manage_users.tpl
@@ -12,6 +12,7 @@
                     </a>
                 {/if}
 
+                {if $CanCreateUsers or $CanExportUsers}
                 <button class="btn btn-primary btn-sm dropdown-toggle" type="button" id="moreUserActions"
                     data-bs-toggle="dropdown" aria-expanded="false" aria-label="{translate key='More'}">
                     <i class="bi bi-three-dots"></i>
@@ -32,13 +33,17 @@
                             </a>
                         </li>
                     {/if}
-                    <li>
-                        <a href="{$ExportUrl}" download id="export-users" class="dropdown-item" target="_blank">
-                            <i class="bi bi-upload me-1"></i>
-                            {translate key="Export"}
-                        </a>
-                    </li>
+                    {if $CanExportUsers}
+                        <li>
+                            <a href="{$ExportUrl}" download id="export-users" class="dropdown-item" target="_blank"
+                                rel="noopener noreferrer">
+                                <i class="bi bi-upload me-1"></i>
+                                {translate key="Export"}
+                            </a>
+                        </li>
+                    {/if}
                 </ul>
+                {/if}
             </div>
         </div>
         <h1 class="float-start">{translate key=ManageUsers}</h1>


### PR DESCRIPTION
Make the dr=export data requests on the manage users and manage groups pages enforce on the server side that the current session belongs to an application administrator, following the guard pattern used in the recent delegated administration changes. The group export includes the full group permission list, which is application administrator material under the delegated administration model.

Hide the Export menu items with new CanExportUsers and CanExportGroups flags, and hide the header dropdown toggles entirely when no items in them are available. Document the restriction in the administration guide.

Assisted-by: Claude:claude-fable-5