### PR TITLE
fix(admin): restrict remaining user management actions to application…

### DIFF
--- a/Pages/Admin/ManageUsersPage.php
+++ b/Pages/Admin/ManageUsersPage.php
@@ -226,6 +226,11 @@ class ManageUsersPage extends ActionPage implements IManageUsersPage
         $this->Set('CanEditUsers', $isApplicationAdmin);
         $this->Set('CanCreateUsers', $isApplicationAdmin);
         $this->Set('CanExportUsers', $isApplicationAdmin);
+        $this->Set('CanChangeUserStatus', $isApplicationAdmin);
+        $this->Set('CanChangeCredits', $isApplicationAdmin);
+        $this->Set('CanChangeColors', $isApplicationAdmin);
+        $this->Set('CanChangePermissions', $isApplicationAdmin);
+        $this->Set('CanChangeAttributes', $isApplicationAdmin);
         $url = $this->server->GetUrl();
         $exportUrl = BookedStringHelper::Contains($url, '?') ? $url . '&dr=export' : $this->server->GetRequestUri() . '?dr=export';
         $this->Set('ExportUrl', $exportUrl);

--- a/Presenters/Admin/ManageUsersPresenter.php
+++ b/Presenters/Admin/ManageUsersPresenter.php
@@ -218,6 +218,13 @@ class ManageUsersPresenter extends ActionPresenter implements IManageUsersPresen
 
     public function Deactivate()
     {
+        $userSession = ServiceLocator::GetServer()->GetUserSession();
+        if (!$userSession->IsAdmin) {
+            // only application administrators may deactivate accounts
+            Log::Error('Deactivate denied. UserId=%s is not an application administrator. Target UserId=%s', $userSession->UserId, $this->page->GetUserId());
+            return;
+        }
+
         if ($this->page->GetUserId() != ServiceLocator::GetServer()->GetUserSession()->UserId) {
             $user = $this->userRepository->LoadById($this->page->GetUserId());
             $user->Deactivate();
@@ -230,6 +237,13 @@ class ManageUsersPresenter extends ActionPresenter implements IManageUsersPresen
 
     public function Activate()
     {
+        $userSession = ServiceLocator::GetServer()->GetUserSession();
+        if (!$userSession->IsAdmin) {
+            // only application administrators may activate accounts
+            Log::Error('Activate denied. UserId=%s is not an application administrator. Target UserId=%s', $userSession->UserId, $this->page->GetUserId());
+            return;
+        }
+
         $user = $this->userRepository->LoadById($this->page->GetUserId());
         $user->Activate();
         $this->userRepository->Update($user);
@@ -310,6 +324,13 @@ class ManageUsersPresenter extends ActionPresenter implements IManageUsersPresen
 
     public function ChangePermissions()
     {
+        $userSession = ServiceLocator::GetServer()->GetUserSession();
+        if (!$userSession->IsAdmin) {
+            // only application administrators may change resource permissions
+            Log::Error('ChangePermissions denied. UserId=%s is not an application administrator. Target UserId=%s', $userSession->UserId, $this->page->GetUserId());
+            return;
+        }
+
         $currentUser = $this->userRepository->LoadById(ServiceLocator::GetServer()->GetUserSession()->UserId);
         $managedResourceIds = $this->resourcePermissionService->GetResourceIdsThatUserCanAdminister($currentUser);
 
@@ -499,6 +520,13 @@ class ManageUsersPresenter extends ActionPresenter implements IManageUsersPresen
 
     public function ChangeColor()
     {
+        $userSession = ServiceLocator::GetServer()->GetUserSession();
+        if (!$userSession->IsAdmin) {
+            // only application administrators may change reservation colors
+            Log::Error('ChangeColor denied. UserId=%s is not an application administrator. Target UserId=%s', $userSession->UserId, $this->page->GetUserId());
+            return;
+        }
+
         $userId = $this->page->GetUserId();
         Log::Debug('Changing reservation color for userId: %s', $userId);
 
@@ -512,6 +540,13 @@ class ManageUsersPresenter extends ActionPresenter implements IManageUsersPresen
 
     public function ChangeCredits()
     {
+        $userSession = ServiceLocator::GetServer()->GetUserSession();
+        if (!$userSession->IsAdmin) {
+            // only application administrators may change credits
+            Log::Error('ChangeCredits denied. UserId=%s is not an application administrator. Target UserId=%s', $userSession->UserId, $this->page->GetUserId());
+            return;
+        }
+
         $userId = $this->page->GetUserId();
         $creditCount = $this->page->GetValue();
 

--- a/docs/source/ADMINISTRATION.rst
+++ b/docs/source/ADMINISTRATION.rst
@@ -390,9 +390,11 @@ can manage all aspects of the application.
 Group Administrator: Users that belong to a group that is given the Group
 Administrator role are able to manage their groups and reserve on behalf of and
 manage users within that group. Group Administrators cannot create user
-accounts (individually, by invitation, or by CSV import), edit user details,
-delete user accounts, or change user passwords; only Application Administrators
-can. A group administrator must first be assigned the Group Administrator role.
+accounts (individually, by invitation, or by CSV import), edit user details or
+custom attributes, delete user accounts, change user passwords, activate or
+deactivate accounts, or change a user's resource permissions, credits, or
+reservation color; only Application Administrators can. A group administrator
+must first be assigned the Group Administrator role.
 This group will then be available in the Group Administrators list.
 
 Resource Administrator: Users that belong to a group that is given the

--- a/lib/Application/User/ManageUsersService.php
+++ b/lib/Application/User/ManageUsersService.php
@@ -159,6 +159,13 @@ class ManageUsersService implements IManageUsersService
 
     public function ChangeAttribute($userId, $attributeValue)
     {
+        $currentUser = ServiceLocator::GetServer()->GetUserSession();
+        if (!$currentUser->IsAdmin) {
+            // only application administrators may change user attributes
+            Log::Error('ChangeAttribute denied. UserId=%s is not an application administrator. Target UserId=%s', $currentUser->UserId, $userId);
+            return;
+        }
+
         $user = $this->userRepository->LoadById($userId);
         $user->ChangeCustomAttribute($attributeValue);
         $this->userRepository->Update($user);
@@ -166,6 +173,13 @@ class ManageUsersService implements IManageUsersService
 
     public function ChangeAttributes($userId, $attributes)
     {
+        $currentUser = ServiceLocator::GetServer()->GetUserSession();
+        if (!$currentUser->IsAdmin) {
+            // only application administrators may change user attributes
+            Log::Error('ChangeAttributes denied. UserId=%s is not an application administrator. Target UserId=%s', $currentUser->UserId, $userId);
+            return;
+        }
+
         $user = $this->userRepository->LoadById($userId);
         foreach ($attributes as $attribute) {
             $user->ChangeCustomAttribute($attribute);

--- a/tests/Application/User/ManageUsersServiceTest.php
+++ b/tests/Application/User/ManageUsersServiceTest.php
@@ -102,8 +102,29 @@ class ManageUsersServiceTest extends TestBase
         $this->assertEquals($userId, $actualUser->Id());
     }
 
+    public function testUpdatesAttribute()
+    {
+        $this->fakeUser->IsAdmin = true;
+
+        $attributeId = 1;
+        $attributeValue = 'value';
+        $userId = 111;
+        $attribute = new AttributeValue($attributeId, $attributeValue);
+
+        $user = new FakeUser($userId);
+
+        $this->userRepo->_User = $user;
+        $this->service->ChangeAttribute($userId, $attribute);
+
+        $this->assertCount(1, $user->GetAddedAttributes());
+        $this->assertEquals($attributeValue, $user->GetAttributeValue($attributeId));
+        $this->assertSame($user, $this->userRepo->_UpdatedUser);
+    }
+
     public function testUpdatesAttributes()
     {
+        $this->fakeUser->IsAdmin = true;
+
         $attributeId = 1;
         $attributeValue = 'value';
         $userId = 111;
@@ -199,6 +220,32 @@ class ManageUsersServiceTest extends TestBase
         $this->assertEquals($position, $user->GetAttribute(UserAttribute::Position));
         $this->assertEquals('value', $user->GetAttributeValue(1));
         $this->assertEquals($user, $this->userRepo->_UpdatedUser);
+    }
+
+    public function testChangeAttributeIsDeniedWhenNotApplicationAdmin()
+    {
+        $this->fakeUser->IsAdmin = false;
+        $this->fakeUser->IsGroupAdmin = true;
+
+        $user = new FakeUser(111);
+        $this->userRepo->_User = $user;
+
+        $this->service->ChangeAttribute(111, new AttributeValue(1, 'value'));
+
+        $this->assertNull($this->userRepo->_UpdatedUser);
+    }
+
+    public function testChangeAttributesIsDeniedWhenNotApplicationAdmin()
+    {
+        $this->fakeUser->IsAdmin = false;
+        $this->fakeUser->IsGroupAdmin = true;
+
+        $user = new FakeUser(111);
+        $this->userRepo->_User = $user;
+
+        $this->service->ChangeAttributes(111, [new AttributeValue(1, 'value')]);
+
+        $this->assertNull($this->userRepo->_UpdatedUser);
     }
 
     public function testAddUserIsDeniedWhenNotApplicationAdmin()

--- a/tests/Presenters/Admin/ManageUsersPresenterTest.php
+++ b/tests/Presenters/Admin/ManageUsersPresenterTest.php
@@ -116,6 +116,8 @@ class ManageUsersPresenterTest extends TestBase
 
     public function testGetsSelectedResourcesFromPageAndAssignsPermission()
     {
+        $this->fakeUser->IsAdmin = true;
+
         $resourcesThatShouldRemainUnchanged = [5, 10];
         $adminManageableIds = [1, 2, 4, 20, 30];
         $submittedResourceIds = ['1_0', '4_0'];
@@ -159,6 +161,8 @@ class ManageUsersPresenterTest extends TestBase
 
     public function testViewPermissionsPreservedSeparatelyFromFullPermissions()
     {
+        $this->fakeUser->IsAdmin = true;
+
         // Admin can manage resources [1, 2, 3]
         // User has full=[1, 5], view=[2, 6]
         // Admin submits full=[1], view=[3]
@@ -200,6 +204,129 @@ class ManageUsersPresenterTest extends TestBase
         $this->assertEquals([1, 5], $actualFull);
         $this->assertEquals([3, 6], $actualView);
         $this->assertEquals($this->userRepo->_UpdatedUser, $user);
+    }
+
+    public function testActivateIsDeniedWhenNotApplicationAdmin()
+    {
+        $this->fakeUser->IsAdmin = false;
+        $this->fakeUser->IsGroupAdmin = true;
+        $this->page->_UserId = 809;
+
+        $this->presenter->Activate();
+
+        $this->assertNull($this->userRepo->_UpdatedUser);
+    }
+
+    public function testActivatesUserWhenApplicationAdmin()
+    {
+        $this->fakeUser->IsAdmin = true;
+        $userId = 809;
+        $user = new FakeUser($userId);
+        $user->SetStatus(AccountStatus::INACTIVE);
+
+        $this->page->_UserId = $userId;
+        $this->userRepo->_User = $user;
+
+        $this->presenter->Activate();
+
+        $this->assertEquals(AccountStatus::ACTIVE, $user->StatusId());
+        $this->assertSame($user, $this->userRepo->_UpdatedUser);
+        $this->assertEquals(Resources::GetInstance()->GetString('Active'), $this->page->_JsonResponse);
+    }
+
+    public function testDeactivateIsDeniedWhenNotApplicationAdmin()
+    {
+        $this->fakeUser->IsAdmin = false;
+        $this->fakeUser->IsGroupAdmin = true;
+        $this->page->_UserId = 809;
+
+        $this->presenter->Deactivate();
+
+        $this->assertNull($this->userRepo->_UpdatedUser);
+    }
+
+    public function testDeactivatesUserWhenApplicationAdmin()
+    {
+        $this->fakeUser->IsAdmin = true;
+        $userId = 809;
+        $user = new FakeUser($userId);
+
+        $this->page->_UserId = $userId;
+        $this->userRepo->_User = $user;
+
+        $this->presenter->Deactivate();
+
+        $this->assertEquals(AccountStatus::INACTIVE, $user->StatusId());
+        $this->assertSame($user, $this->userRepo->_UpdatedUser);
+        $this->assertEquals(Resources::GetInstance()->GetString('Inactive'), $this->page->_JsonResponse);
+    }
+
+    public function testChangeColorIsDeniedWhenNotApplicationAdmin()
+    {
+        $this->fakeUser->IsAdmin = false;
+        $this->fakeUser->IsGroupAdmin = true;
+        $this->page->_UserId = 809;
+
+        $this->presenter->ChangeColor();
+
+        $this->assertNull($this->userRepo->_UpdatedUser);
+    }
+
+    public function testChangesColorWhenApplicationAdmin()
+    {
+        $this->fakeUser->IsAdmin = true;
+        $this->fakeConfig->SetKey(ConfigKeys::SCHEDULE_USE_PER_USER_COLORS, 'true');
+        $userId = 809;
+        $color = '#123456';
+        $user = new FakeUser($userId);
+
+        $this->page->_UserId = $userId;
+        $this->page->_ReservationColor = $color;
+        $this->userRepo->_User = $user;
+
+        $this->presenter->ChangeColor();
+
+        $this->assertEquals($color, $user->GetPreferences()->Get(UserPreferences::RESERVATION_COLOR));
+        $this->assertSame($user, $this->userRepo->_UpdatedUser);
+    }
+
+    public function testChangeCreditsIsDeniedWhenNotApplicationAdmin()
+    {
+        $this->fakeUser->IsAdmin = false;
+        $this->fakeUser->IsGroupAdmin = true;
+        $this->page->_UserId = 809;
+
+        $this->presenter->ChangeCredits();
+
+        $this->assertNull($this->userRepo->_UpdatedUser);
+    }
+
+    public function testChangesCreditsWhenApplicationAdmin()
+    {
+        $this->fakeUser->IsAdmin = true;
+        $userId = 809;
+        $creditCount = 25;
+        $user = new FakeUser($userId);
+
+        $this->page->_UserId = $userId;
+        $this->page->_Value = $creditCount;
+        $this->userRepo->_User = $user;
+
+        $this->presenter->ChangeCredits();
+
+        $this->assertEquals($creditCount, $user->GetCurrentCredits());
+        $this->assertSame($user, $this->userRepo->_UpdatedUser);
+    }
+
+    public function testChangePermissionsIsDeniedWhenNotApplicationAdmin()
+    {
+        $this->fakeUser->IsAdmin = false;
+        $this->fakeUser->IsGroupAdmin = true;
+        $this->page->_UserId = 809;
+
+        $this->presenter->ChangePermissions();
+
+        $this->assertNull($this->userRepo->_UpdatedUser);
     }
 
     public function testExportUsersIsDeniedWhenNotApplicationAdmin()
@@ -615,6 +742,8 @@ class FakeManageUsersPage extends FakeActionPageBase implements IManageUsersPage
      */
     public $_UserGroup;
     public $_JsonResponse;
+    public $_ReservationColor = '';
+    public $_Value = '';
     /**
      * @var User
      */
@@ -744,12 +873,12 @@ class FakeManageUsersPage extends FakeActionPageBase implements IManageUsersPage
 
     public function GetReservationColor()
     {
-        return '';
+        return $this->_ReservationColor;
     }
 
     public function GetValue()
     {
-        return '';
+        return $this->_Value;
     }
 
     public function GetName()

--- a/tpl/Admin/Users/manage_users.tpl
+++ b/tpl/Admin/Users/manage_users.tpl
@@ -126,15 +126,24 @@
                                     {format_date date=$user->DateCreated key=short_datetime timezone=$Timezone}</td>
                                 <td data-order="{format_date date=$user->LastLogin format='Y-m-d H:i' timezone=$Timezone}">
                                     {format_date date=$user->LastLogin key=short_datetime timezone=$Timezone}</td>
-                                <td class="action"><a href="#"
-                                        class="update changeStatus link-primary">{$statusDescriptions[$user->StatusId]}</a>
-                                    {indicator id="userStatusIndicator"}
+                                <td class="action">
+                                    {if $CanChangeUserStatus}
+                                        <a href="#"
+                                            class="update changeStatus link-primary">{$statusDescriptions[$user->StatusId]}</a>
+                                        {indicator id="userStatusIndicator"}
+                                    {else}
+                                        {$statusDescriptions[$user->StatusId]}
+                                    {/if}
                                 </td>
                                 {if $CreditsEnabled}
                                     <td class="text-end">
-                                        <span class="propertyValue inlineUpdate changeCredits fw-bold text-decoration-underline"
-                                            data-type="number" data-pk="{$id}" data-value="{$user->CurrentCreditCount}"
-                                            data-name="{FormKeys::CREDITS}">{$user->CurrentCreditCount}</span>
+                                        {if $CanChangeCredits}
+                                            <span class="propertyValue inlineUpdate changeCredits fw-bold text-decoration-underline"
+                                                data-type="number" data-pk="{$id}" data-value="{$user->CurrentCreditCount}"
+                                                data-name="{FormKeys::CREDITS}">{$user->CurrentCreditCount}</span>
+                                        {else}
+                                            <span class="fw-bold">{$user->CurrentCreditCount}</span>
+                                        {/if}
                                         <a href="credit_log.php?{QueryStringKeys::USER_ID}={$id}"
                                             title="{translate key=CreditHistory}" class="link-primary">
                                             <span class="no-color">{translate key=CreditHistory}</span>
@@ -144,12 +153,21 @@
                                 {/if}
                                 {if $PerUserColors}
                                     <td class="action">
-                                        <a href="#" class="update changeColor link-primary">{translate key='Edit'}</a>
-                                        {if !empty($user->ReservationColor)}
-                                            <div class="user-color update changeColor rounded"
-                                                style="background-color:{$user->ReservationColor}">
-                                                &nbsp;
-                                            </div>
+                                        {if $CanChangeColors}
+                                            <a href="#" class="update changeColor link-primary">{translate key='Edit'}</a>
+                                            {if !empty($user->ReservationColor)}
+                                                <div class="user-color update changeColor rounded"
+                                                    style="background-color:{$user->ReservationColor|escape:'html'}">
+                                                    &nbsp;
+                                                </div>
+                                            {/if}
+                                        {else}
+                                            {if !empty($user->ReservationColor)}
+                                                <div class="user-color rounded"
+                                                    style="background-color:{$user->ReservationColor|escape:'html'}">
+                                                    &nbsp;
+                                                </div>
+                                            {/if}
                                         {/if}
                                     </td>
                                 {/if}
@@ -171,9 +189,11 @@
                                                         class="dropdown-item update edit">{translate key="Edit"}</a>
                                                 </li>
                                             {/if}
-                                            <li role="presentation"><a role="menuitem" href="#"
-                                                    class="dropdown-item update changePermissions">{translate key="Permissions"}</a>
-                                            </li>
+                                            {if $CanChangePermissions}
+                                                <li role="presentation"><a role="menuitem" href="#"
+                                                        class="dropdown-item update changePermissions">{translate key="Permissions"}</a>
+                                                </li>
+                                            {/if}
                                             <li role="presentation"><a role="menuitem" href="#"
                                                     class="dropdown-item update changeGroups">{translate key="Groups"}</a>
                                             </li>
@@ -213,7 +233,14 @@
                                         {assign var=changeAttributeAction value=ManageUsersActions::ChangeAttribute}
                                         {assign var=attributeUrl value="`$smarty.server.SCRIPT_NAME`?action=`$changeAttributeAction`"}
                                         {foreach from=$AttributeList item=attribute}
-                                            {include file='Admin/InlineAttributeEdit.tpl' url=$attributeUrl id=$id attribute=$attribute value=$user->GetAttributeValue($attribute->Id())}
+                                            {if $CanChangeAttributes}
+                                                {include file='Admin/InlineAttributeEdit.tpl' url=$attributeUrl id=$id attribute=$attribute value=$user->GetAttributeValue($attribute->Id())}
+                                            {elseif $attribute->AppliesToEntity($id)}
+                                                <div class="mb-0 d-inline-block">
+                                                    <label class="inline fw-bold">{$attribute->Label()}</label>
+                                                    {$user->GetAttributeValue($attribute->Id())|escape}
+                                                </div>
+                                            {/if}
                                         {/foreach}
                                     </td>
                                 {/if}
@@ -422,6 +449,7 @@
 
     <input type="hidden" id="activeId" />
 
+    {if $CanChangePermissions}
     <div id="permissionsDialog" class="modal fade" tabindex="-1" role="dialog" aria-labelledby="permissionsModalLabel"
         aria-hidden="true">
         <div class="modal-dialog modal-dialog-scrollable">
@@ -472,6 +500,7 @@
             </div>
         </div>
     </div>
+    {/if}
 
     {if $CanChangePasswords}
     <div id="passwordDialog" class="modal fade" tabindex="-1" role="dialog" aria-labelledby="passwordModalLabel"


### PR DESCRIPTION
… admins

Make the activate, deactivate, permissions, changeCredits, changeColor, and changeAttribute actions on the manage users page enforce on the server side that the current session belongs to an application administrator, completing the delegated administration model for user management: group administrators manage group membership and reservations on behalf of members, while account state and properties are application administrator responsibilities. Self-registration and email verification activation flows are unaffected; the guards apply only to the administrative page actions.

Hide or render read-only the corresponding controls for group administrators: status toggle, credits inline edit, reservation color editor, permissions menu item and dialog, and inline custom attribute editing. Update the administration guide to enumerate the restrictions.

Assisted-by: Claude:claude-fable-5