### PR TITLE
fix(admin): validate user reservation colors

### DIFF
--- a/Presenters/Admin/ManageUsersPresenter.php
+++ b/Presenters/Admin/ManageUsersPresenter.php
@@ -531,6 +531,10 @@ class ManageUsersPresenter extends ActionPresenter implements IManageUsersPresen
         Log::Debug('Changing reservation color for userId: %s', $userId);
 
         $color = $this->page->GetReservationColor();
+        if (!$this->IsValidReservationColor($color)) {
+            Log::Error('ChangeColor denied. Invalid reservation color. UserId=%s, Target UserId=%s', $userSession->UserId, $this->page->GetUserId());
+            return;
+        }
 
         $user = $this->userRepository->LoadById($userId);
         $user->ChangePreference(UserPreferences::RESERVATION_COLOR, $color);
@@ -707,7 +711,11 @@ class ManageUsersPresenter extends ActionPresenter implements IManageUsersPresen
                     }
 
                     if ($row->color != null) {
-                        $user->ChangePreference(UserPreferences::RESERVATION_COLOR, $row->color);
+                        if ($this->IsValidReservationColor($row->color)) {
+                            $user->ChangePreference(UserPreferences::RESERVATION_COLOR, $row->color);
+                        } else {
+                            Log::Error('Ignoring invalid reservation color during user import. Username=%s', $row->username);
+                        }
                     }
 
                     foreach ($row->attributes as $label => $value) {
@@ -778,6 +786,11 @@ class ManageUsersPresenter extends ActionPresenter implements IManageUsersPresen
         }
 
         return AccountStatus::ACTIVE;
+    }
+
+    private function IsValidReservationColor($color): bool
+    {
+        return is_string($color) && ($color === '' || preg_match('/^#[0-9a-fA-F]{6}\z/', $color) === 1);
     }
 
     public function ShowUpdate()

--- a/tests/Presenters/Admin/ManageUsersPresenterTest.php
+++ b/tests/Presenters/Admin/ManageUsersPresenterTest.php
@@ -290,6 +290,23 @@ class ManageUsersPresenterTest extends TestBase
         $this->assertSame($user, $this->userRepo->_UpdatedUser);
     }
 
+    public function testChangeColorRejectsInvalidColor()
+    {
+        $this->fakeUser->IsAdmin = true;
+        $this->fakeConfig->SetKey(ConfigKeys::SCHEDULE_USE_PER_USER_COLORS, 'true');
+        $userId = 809;
+        $user = new FakeUser($userId);
+
+        $this->page->_UserId = $userId;
+        $this->page->_ReservationColor = '#123456\" onmouseover=\"alert(1)';
+        $this->userRepo->_User = $user;
+
+        $this->presenter->ChangeColor();
+
+        $this->assertNull($user->GetPreferences()->Get(UserPreferences::RESERVATION_COLOR));
+        $this->assertNull($this->userRepo->_UpdatedUser);
+    }
+
     public function testChangeCreditsIsDeniedWhenNotApplicationAdmin()
     {
         $this->fakeUser->IsAdmin = false;


### PR DESCRIPTION
Reject malformed reservation colors submitted through the manage users action before updating user preferences. Apply the same validation to CSV imports, ignoring invalid colors while allowing the rest of the row to be imported.

Accept only empty values or six-digit hexadecimal colors in #RRGGBB format. Add presenter coverage confirming that crafted color values are not persisted.

Assisted-by: Codex:gpt-5