### PR TITLE
docs: replace dead GitHub wiki links with ReadTheDocs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -708,6 +708,11 @@ Output: `docs/build/html/`
 8. **Email template files** - Validate template filenames before using them in
    filesystem paths; follow the existing `ManageEmailTemplatesPresenter`
    validation pattern
+9. **External links opening in a new tab** - Any `target="_blank"` link to an
+   external, third-party-controlled origin must include
+   `rel="noopener noreferrer"` to prevent tabnabbing (the opened page gaining
+   access to `window.opener`). Internal/same-origin links (downloads,
+   exports, self-hosted URLs) don't need it.
 
 ## Performance Considerations
 
@@ -741,7 +746,7 @@ Plugins extend LibreBooking functionality:
 - **Main Repository**: <https://github.com/LibreBooking/librebooking>
 - **Live Demo**: <https://librebooking-demo.fly.dev/>
 - **Discord Community**: <https://discord.gg/4TGThPtmX8>
-- **Wiki**: <https://github.com/LibreBooking/librebooking/wiki>
+- **Documentation**: <https://librebooking.readthedocs.io/en/latest/>
 - **Docker Image**: <https://github.com/LibreBooking/docker>
 - **Issue Tracker**: <https://github.com/LibreBooking/librebooking/issues>
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 [![Docker pulls](https://img.shields.io/docker/pulls/librebooking/librebooking)](https://github.com/LibreBooking/docker)
 
 [![Discord](https://img.shields.io/badge/Discord-5865F2?style=flat&logo=discord&logoColor=white)](https://discord.gg/4TGThPtmX8)
-[![Wiki](https://img.shields.io/badge/Wiki-Available-lightgrey?logo=read-the-docs)](https://github.com/LibreBooking/librebooking/wiki)
+[![Docs](https://img.shields.io/badge/Docs-Available-lightgrey?logo=read-the-docs)](https://librebooking.readthedocs.io/en/latest/)
 
 ⭐ Star us on GitHub — it motivates us a lot!
 
@@ -151,7 +151,7 @@ As of 09-Mar-2023, ReCaptcha integration updated to v3. Generate new keys for yo
 ## 💬 Community & Support
 
 - [Discord](https://discord.gg/4TGThPtmX8)
-- [Wiki](https://github.com/LibreBooking/librebooking/wiki)
+- [Docs](https://librebooking.readthedocs.io/en/latest/)
 - [Issues](https://github.com/LibreBooking/librebooking/issues)
 - [Discussions](https://github.com/LibreBooking/librebooking/discussions)
 

--- a/tpl/Admin/Configuration/manage_configuration.tpl
+++ b/tpl/Admin/Configuration/manage_configuration.tpl
@@ -113,7 +113,7 @@
     {if $IsPageEnabled && $IsConfigFileWritable}
         <div class="card shadow">
             <div class="card-body">
-                {assign var=HelpUrl value="https://github.com/LibreBooking/librebooking/wiki/Administration"}
+                {assign var=HelpUrl value="https://librebooking.readthedocs.io/en/latest/ADMINISTRATION.html"}
                 <h2 class="text-center border-bottom mb-3">{translate key=ConfigurationUpdateHelp args=$HelpUrl}</h2>
                 <div id="updatedMessage" class="alert alert-success" style="display:none;">
                     {translate key=ConfigurationUpdated}

--- a/tpl/ResourceDisplay/resource-display-instructions.tpl
+++ b/tpl/ResourceDisplay/resource-display-instructions.tpl
@@ -1,7 +1,8 @@
 {include file='globalheader.tpl' HideNavBar=true}
 <div class="alert alert-danger mt-4">
 	{translate key=ResourceDisplayInstructions}
-	<a href="https://github.com/LibreBooking/librebooking/wiki/Administration" target="_blank" class="alert-link"><i
+	<a href="https://librebooking.readthedocs.io/en/latest/ADMINISTRATION.html" target="_blank"
+		rel="noopener noreferrer" class="alert-link"><i
 			class="bi bi-question-circle-fill mx-1"></i>{translate key=Help}</a>
 </div>
 {include file='globalfooter.tpl'}

--- a/tpl/globalheader.tpl
+++ b/tpl/globalheader.tpl
@@ -416,11 +416,11 @@
                                 data-bs-toggle="dropdown">{translate key="Help"}</a>
                             <ul class="dropdown-menu  dropdown-menu-end">
                                 <li id="navHelp"><a class="dropdown-item"
-                                        href="https://github.com/LibreBooking/librebooking/wiki">{translate key=Help}</a>
+                                        href="https://librebooking.readthedocs.io/en/latest/">{translate key=Help}</a>
                                 </li>
                                 {if isset($CanViewAdmin) && $CanViewAdmin}
                                     <li id="navHelpAdmin"><a class="dropdown-item"
-                                            href="https://github.com/LibreBooking/librebooking/wiki/Administration">{translate key=Administration}</a>
+                                            href="https://librebooking.readthedocs.io/en/latest/ADMINISTRATION.html">{translate key=Administration}</a>
                                     </li>
                                 {/if}
                                 <li id="navAbout"><a class="dropdown-item"

--- a/tpl/support-and-credits.tpl
+++ b/tpl/support-and-credits.tpl
@@ -6,6 +6,11 @@
             <div class="card-body">
                 <h1 class="text-center border-bottom">About LibreBooking</h1>
 
+                <h2>Documentation</h2>
+
+                <p><a class="link-primary" href="https://librebooking.readthedocs.io/en/latest/">LibreBooking
+                        Documentation</a></p>
+
                 <h2>Support</h2>
 
                 <p><a class="link-primary" href="https://github.com/LibreBooking/librebooking">LibreBooking Support</a></p>


### PR DESCRIPTION
The GitHub wiki has been retired, so every in-app and repo-doc link pointing at it was dead. Repoint the Help menu, the Administration help links (config page and resource display instructions), the README badge and support list, and AGENTS.md/CLAUDE.md at https://librebooking.readthedocs.io/en/latest/ (or its ADMINISTRATION.html page where the link was administration-specific). Also add a Documentation section with a ReadTheDocs link to the About LibreBooking page, which previously had no link to the docs site at all.

Assisted-by: Claude:claude-sonnet-5