### PR TITLE
fix(auth): preserve redirect target through Google, Keyclaok and OAuth2 login

### DIFF
--- a/Presenters/LoginPresenter.php
+++ b/Presenters/LoginPresenter.php
@@ -137,7 +137,7 @@ class LoginPresenter
         $keycloakEnabled  = Configuration::Instance()->GetKey(ConfigKeys::AUTHENTICATION_KEYCLOAK_LOGIN_ENABLED, new BooleanConverter());
         $oauth2Enabled    = Configuration::Instance()->GetKey(ConfigKeys::AUTHENTICATION_OAUTH2_LOGIN_ENABLED, new BooleanConverter());
 
-        $this->_page->SetGoogleUrl($googleEnabled ? $this->GetGoogleUrl() : null);
+        $this->_page->SetGoogleUrl($googleEnabled ? $this->GetGoogleUrl($this->_page->GetResumeUrl()) : null);
         $this->_page->SetMicrosoftUrl($microsoftEnabled ? $this->GetMicrosoftUrl($this->_page->GetResumeUrl()) : null);
         $this->_page->SetFacebookUrl($facebookEnabled ? $this->GetFacebookUrl() : null);
         $this->_page->SetKeycloakUrl($keycloakEnabled ? $this->GetKeycloakUrl() : null);
@@ -291,7 +291,7 @@ class LoginPresenter
      * Checks in the config files if google authentication is active creating a new client if true and setting it's config keys.
      * Returns the created google url for the authentication
      */
-    public function GetGoogleUrl()
+    public function GetGoogleUrl(?string $state = null)
     {
         $client = new Google\Client();
         $client->setClientId(Configuration::Instance()->GetKey(ConfigKeys::AUTHENTICATION_GOOGLE_CLIENT_ID));
@@ -300,9 +300,11 @@ class LoginPresenter
         $client->addScope('email');
         $client->addScope('profile');
         $client->setPrompt('select_account');
-        $GoogleUrl = $client->createAuthUrl();
+        if (!empty($state)) {
+            $client->setState($state);
+        }
 
-        return $GoogleUrl;
+        return $client->createAuthUrl();
     }
 
     /**

--- a/Presenters/LoginPresenter.php
+++ b/Presenters/LoginPresenter.php
@@ -140,8 +140,8 @@ class LoginPresenter
         $this->_page->SetGoogleUrl($googleEnabled ? $this->GetGoogleUrl($this->_page->GetResumeUrl()) : null);
         $this->_page->SetMicrosoftUrl($microsoftEnabled ? $this->GetMicrosoftUrl($this->_page->GetResumeUrl()) : null);
         $this->_page->SetFacebookUrl($facebookEnabled ? $this->GetFacebookUrl() : null);
-        $this->_page->SetKeycloakUrl($keycloakEnabled ? $this->GetKeycloakUrl() : null);
-        $this->_page->SetOauth2Url($oauth2Enabled ? $this->GetOauth2Url() : null);
+        $this->_page->SetKeycloakUrl($keycloakEnabled ? $this->GetKeycloakUrl($this->_page->GetResumeUrl()) : null);
+        $this->_page->SetOauth2Url($oauth2Enabled ? $this->GetOauth2Url($this->_page->GetResumeUrl()) : null);
         $this->_page->SetOauth2Name($oauth2Enabled ? Configuration::Instance()->GetKey(ConfigKeys::AUTHENTICATION_OAUTH2_NAME) : null);
     }
 
@@ -368,7 +368,7 @@ class LoginPresenter
         return $FacebookUrl;
     }
 
-    public function GetKeycloakUrl()
+    public function GetKeycloakUrl(?string $state = null)
     {
         // Retrieve Keycloak configuration values
         $baseUrl    = rtrim(Configuration::Instance()->GetKey(ConfigKeys::AUTHENTICATION_KEYCLOAK_URL), '/');
@@ -385,10 +385,15 @@ class LoginPresenter
             'response_type' => 'code'
         ];
 
+        if (!empty($state)) {
+            $params['state'] = $state;
+        }
+
         return $authorizeEndpoint . '?' . http_build_query($params, '', '&', PHP_QUERY_RFC3986);
+
     }
 
-    public function GetOauth2Url()
+    public function GetOauth2Url(?string $state = null)
     {
         // Retrieve Oauth2 configuration values
         $removeTrailingSlash = Configuration::Instance()->GetKey(ConfigKeys::AUTHENTICATION_OAUTH2_STRIP_TRAILING_SLASH);
@@ -406,8 +411,12 @@ class LoginPresenter
             'response_type' => 'code'
         ];
 
-        $Oauth2Url = $baseUrl . '?' . http_build_query($params, '', '&', PHP_QUERY_RFC3986);
-        return $Oauth2Url;
+        if (!empty($state)) {
+            $params['state'] = $state;
+        }
+
+        return $baseUrl . '?' . http_build_query($params, '', '&', PHP_QUERY_RFC3986);
+
     }
 
 }

--- a/Web/google-auth.php
+++ b/Web/google-auth.php
@@ -12,7 +12,7 @@ if (is_string($code) && $code !== '') {
 
     $state = filter_input(INPUT_GET, 'state', FILTER_UNSAFE_RAW);
     if (is_string($state) && $state !== '') {
-        $params['state'] = $state;
+        $params['redirect'] = $state;
     }
 
     header('Location: ' . ROOT_DIR . 'Web/external-auth.php?' . http_build_query($params, '', '&', PHP_QUERY_RFC3986));

--- a/Web/google-auth.php
+++ b/Web/google-auth.php
@@ -5,18 +5,19 @@ define('ROOT_DIR', '../');
 require_once(ROOT_DIR . 'lib/Common/namespace.php');
 
 //Checks if the user was authenticated by google and redirects to external authentication page
-if (isset($_GET['code'])) {
-    $code = filter_input(INPUT_GET, 'code');
-    $url = ROOT_DIR . 'Web/external-auth.php?type=google&code=' . urlencode($code);
+$code = filter_input(INPUT_GET, 'code', FILTER_UNSAFE_RAW);
 
-    $state = filter_input(INPUT_GET, 'state');
-    if (!empty($state)) {
-        $url .= '&redirect=' . urlencode($state);
+if (is_string($code) && $code !== '') {
+    $params = ['type' => 'google', 'code' => $code];
+
+    $state = filter_input(INPUT_GET, 'state', FILTER_UNSAFE_RAW);
+    if (is_string($state) && $state !== '') {
+        $params['state'] = $state;
     }
 
-    header('Location: ' . $url);
+    header('Location: ' . ROOT_DIR . 'Web/external-auth.php?' . http_build_query($params, '', '&', PHP_QUERY_RFC3986));
     exit;
-} else {
-    header('Location:' . ROOT_DIR . 'Web');
-    exit();
 }
+
+header('Location:' . ROOT_DIR . 'Web');
+exit();

--- a/Web/google-auth.php
+++ b/Web/google-auth.php
@@ -7,9 +7,16 @@ require_once(ROOT_DIR . 'lib/Common/namespace.php');
 //Checks if the user was authenticated by google and redirects to external authentication page
 if (isset($_GET['code'])) {
     $code = filter_input(INPUT_GET, 'code');
-    header('Location: '.ROOT_DIR.'Web/external-auth.php?type=google&code='.$code);
+    $url = ROOT_DIR . 'Web/external-auth.php?type=google&code=' . urlencode($code);
+
+    $state = filter_input(INPUT_GET, 'state');
+    if (!empty($state)) {
+        $url .= '&redirect=' . urlencode($state);
+    }
+
+    header('Location: ' . $url);
     exit;
 } else {
-    header('Location:'.ROOT_DIR.'Web');
+    header('Location:' . ROOT_DIR . 'Web');
     exit();
 }

--- a/Web/keycloak-auth.php
+++ b/Web/keycloak-auth.php
@@ -12,7 +12,7 @@ if (is_string($code) && $code !== '') {
 
     $state = filter_input(INPUT_GET, 'state', FILTER_UNSAFE_RAW);
     if (is_string($state) && $state !== '') {
-        $params['state'] = $state;
+        $params['redirect'] = $state;
     }
 
     header('Location: ' . ROOT_DIR . 'Web/external-auth.php?' . http_build_query($params, '', '&', PHP_QUERY_RFC3986));

--- a/Web/keycloak-auth.php
+++ b/Web/keycloak-auth.php
@@ -7,7 +7,14 @@ require_once(ROOT_DIR . 'lib/Common/namespace.php');
 //Checks if the user was authenticated by keycloak and redirects to external authentication page
 if (isset($_GET['code'])) {
     $code = filter_input(INPUT_GET, 'code');
-    header('Location: ' . ROOT_DIR . 'Web/external-auth.php?type=keycloak&code=' . $code);
+    $url = ROOT_DIR . 'Web/external-auth.php?type=keycloak&code=' . urlencode($code);
+
+    $state = filter_input(INPUT_GET, 'state');
+    if (!empty($state)) {
+        $url .= '&redirect=' . urlencode($state);
+    }
+
+    header('Location: ' . $url);
     exit;
 } else {
     header('Location:' . ROOT_DIR . 'Web');

--- a/Web/keycloak-auth.php
+++ b/Web/keycloak-auth.php
@@ -5,18 +5,19 @@ define('ROOT_DIR', '../');
 require_once(ROOT_DIR . 'lib/Common/namespace.php');
 
 //Checks if the user was authenticated by keycloak and redirects to external authentication page
-if (isset($_GET['code'])) {
-    $code = filter_input(INPUT_GET, 'code');
-    $url = ROOT_DIR . 'Web/external-auth.php?type=keycloak&code=' . urlencode($code);
+$code = filter_input(INPUT_GET, 'code', FILTER_UNSAFE_RAW);
 
-    $state = filter_input(INPUT_GET, 'state');
-    if (!empty($state)) {
-        $url .= '&redirect=' . urlencode($state);
+if (is_string($code) && $code !== '') {
+    $params = ['type' => 'keycloak', 'code' => $code];
+
+    $state = filter_input(INPUT_GET, 'state', FILTER_UNSAFE_RAW);
+    if (is_string($state) && $state !== '') {
+        $params['state'] = $state;
     }
 
-    header('Location: ' . $url);
+    header('Location: ' . ROOT_DIR . 'Web/external-auth.php?' . http_build_query($params, '', '&', PHP_QUERY_RFC3986));
     exit;
-} else {
-    header('Location:' . ROOT_DIR . 'Web');
-    exit();
 }
+
+header('Location:' . ROOT_DIR . 'Web');
+exit();

--- a/Web/oauth2-auth.php
+++ b/Web/oauth2-auth.php
@@ -12,7 +12,7 @@ if (is_string($code) && $code !== '') {
 
     $state = filter_input(INPUT_GET, 'state', FILTER_UNSAFE_RAW);
     if (is_string($state) && $state !== '') {
-        $params['state'] = $state;
+        $params['redirect'] = $state;
     }
 
     header('Location: ' . ROOT_DIR . 'Web/external-auth.php?' . http_build_query($params, '', '&', PHP_QUERY_RFC3986));

--- a/Web/oauth2-auth.php
+++ b/Web/oauth2-auth.php
@@ -5,18 +5,19 @@ define('ROOT_DIR', '../');
 require_once(ROOT_DIR . 'lib/Common/namespace.php');
 
 //Checks if the user was authenticated by oauth2 and redirects to external authentication page
-if (isset($_GET['code'])) {
-    $code = filter_input(INPUT_GET, 'code');
-    $url = ROOT_DIR . 'Web/external-auth.php?type=oauth2&code=' . urlencode($code);
+$code = filter_input(INPUT_GET, 'code', FILTER_UNSAFE_RAW);
 
-    $state = filter_input(INPUT_GET, 'state');
-    if (!empty($state)) {
-        $url .= '&redirect=' . urlencode($state);
+if (is_string($code) && $code !== '') {
+    $params = ['type' => 'oauth2', 'code' => $code];
+
+    $state = filter_input(INPUT_GET, 'state', FILTER_UNSAFE_RAW);
+    if (is_string($state) && $state !== '') {
+        $params['state'] = $state;
     }
 
-    header('Location: ' . $url);
+    header('Location: ' . ROOT_DIR . 'Web/external-auth.php?' . http_build_query($params, '', '&', PHP_QUERY_RFC3986));
     exit;
-} else {
-    header('Location:' . ROOT_DIR . 'Web');
-    exit();
 }
+
+header('Location:' . ROOT_DIR . 'Web');
+exit();

--- a/Web/oauth2-auth.php
+++ b/Web/oauth2-auth.php
@@ -7,7 +7,14 @@ require_once(ROOT_DIR . 'lib/Common/namespace.php');
 //Checks if the user was authenticated by oauth2 and redirects to external authentication page
 if (isset($_GET['code'])) {
     $code = filter_input(INPUT_GET, 'code');
-    header('Location: ' . ROOT_DIR . 'Web/external-auth.php?type=oauth2&code=' . $code);
+    $url = ROOT_DIR . 'Web/external-auth.php?type=oauth2&code=' . urlencode($code);
+
+    $state = filter_input(INPUT_GET, 'state');
+    if (!empty($state)) {
+        $url .= '&redirect=' . urlencode($state);
+    }
+
+    header('Location: ' . $url);
     exit;
 } else {
     header('Location:' . ROOT_DIR . 'Web');


### PR DESCRIPTION
fix(auth): preserve redirect target through Google, Keycloak and OAuth2 login

Same issue as the Microsoft fix: the "Sign in
with ...  links never carried
the original ?redirect= query param through the OAuth round trip,
so users who followed a deep link into a protected page were sent
to their default homepage after authenticating instead of the page
they originally requested.

- LoginPresenter now accept an
  optional $state parameter and include it as the OAuth `state`
  param on their respective authorize URLs. PageLoad() passes the
  page's resume URL into both via GetResumeUrl().
- Web/xxx-auth.php files now read `state`
  back from their callback params and forward it to
  external-auth.php as redirect=, which
  ExternalAuthLoginPage::GetResumeUrl() already reads via
  QueryStringKeys::REDIRECT.

The forwarded value still passes through
RedirectUrlSanitizer::Sanitize() in LoginRedirector::Redirect()
before use, same as the plain-login ?redirect= flow, so open-redirect
protection is unchanged.

Refs: #1559
Assisted-by: Claude:claude-sonnet-4-6