### PR TITLE
feat(config): warn when script.url is missing the required /Web suffix

### DIFF
--- a/Pages/Page.php
+++ b/Pages/Page.php
@@ -65,7 +65,9 @@ abstract class Page implements IPage
         $this->smarty->assign('Version', Configuration::VERSION);
         $this->smarty->assign('DisplayVersion', $this->GetDisplayVersion());
         $this->smarty->assign('Path', $this->path);
-        $this->smarty->assign('ScriptUrl', Configuration::Instance()->GetScriptUrl());
+        $scriptUrl = Configuration::Instance()->GetScriptUrl();
+        $this->smarty->assign('ScriptUrl', $scriptUrl);
+        $this->smarty->assign('ScriptUrlMissingWebSuffix', $scriptUrl !== '' && !str_ends_with(rtrim($scriptUrl, '/'), '/Web'));
         $this->smarty->assign('UserName', !is_null($userSession) ? $userSession->FirstName : '');
         $this->smarty->assign('DisplayWelcome', $this->DisplayWelcome());
         $this->smarty->assign('UserId', $userSession->UserId);

--- a/docs/source/BASIC-CONFIGURATION.rst
+++ b/docs/source/BASIC-CONFIGURATION.rst
@@ -307,6 +307,13 @@ Frontend Settings
   because application links and other features may not work correctly. Set
   ``script.url`` (or ``LB_SCRIPT_URL``) to dismiss the warning.
 
+  ``script.url`` must always end with ``/Web``. The webserver document root
+  must not be set directly to the ``Web`` directory with ``/Web`` omitted
+  from the URL — that configuration is not supported and breaks navigation
+  links and login/SSO redirects. LibreBooking can still be installed in a
+  subdirectory/subsite under the document root, as long as ``/Web`` remains
+  the final path segment (e.g. ``https://example.com/librebooking/Web``).
+
 **css.theme**
   Theme to use for the application. Options: default, dimgray, dark_red,
   dark_green, french_blue, cake_blue, orange.

--- a/docs/source/FAQ.rst
+++ b/docs/source/FAQ.rst
@@ -261,3 +261,25 @@ Related threads:
 
 - `<https://github.com/LibreBooking/librebooking/discussions/752>`__
 - `<https://github.com/LibreBooking/librebooking/issues/13>`__
+
+Can I set the document root directly to the ``Web`` directory and drop ``/Web`` from the URL?
+------------------------------------------------------------------------------------------------
+
+No. LibreBooking can be installed at the document root or in a
+subdirectory/subsite underneath it, but the public URL must always include
+``/Web/`` (e.g. ``https://example.com/Web/`` or
+``https://example.com/librebooking/Web/``), and ``script.url`` must be set
+accordingly.
+
+Pointing the document root directly at the ``Web`` directory so that URLs
+omit ``/Web`` (e.g. ``https://example.com/schedule.php``) is not supported.
+Several parts of the application assume ``/Web`` is present in the request
+path, including navigation-link validation and login/SSO redirect
+construction, so omitting it breaks Schedule/Calendar navigation and can
+break external authentication redirects.
+
+See :doc:`INSTALLATION` and :doc:`BASIC-CONFIGURATION`.
+
+Related threads:
+
+- `<https://github.com/LibreBooking/librebooking/issues/1590>`__

--- a/docs/source/INSTALLATION.rst
+++ b/docs/source/INSTALLATION.rst
@@ -50,6 +50,16 @@ Alternatively, you can clone the application directly from the official GitHub r
 
     git clone https://github.com/LibreBooking/librebooking.git
 
+.. important::
+   The document root (or subsite) must point at the LibreBooking project
+   directory itself, **not** at its ``Web`` subdirectory. LibreBooking can be
+   installed directly at the document root or in a subdirectory/subsite
+   underneath it (e.g. ``https://example.com/librebooking/``), but the public
+   URL must always include ``/Web/`` (e.g. ``https://example.com/Web/`` or
+   ``https://example.com/librebooking/Web/``). Pointing the document root
+   directly at ``Web`` and omitting ``/Web/`` from the URL is not supported —
+   it breaks navigation links and login/SSO redirects.
+
 After copying or cloning the application to your web server:
 
 Install PHP dependencies using Composer:

--- a/lang/en_us.php
+++ b/lang/en_us.php
@@ -136,6 +136,7 @@ class en_us extends Language
         $strings['SignOut'] = 'Sign Out';
         $strings['JavascriptRequired'] = 'This application requires JavaScript to function properly. Please enable JavaScript in your browser settings.';
         $strings['ScriptUrlNotConfigured'] = 'LibreBooking is not configured correctly. The <code>script.url</code> setting is empty, so some application features will not work. Please contact the administrator.';
+        $strings['ScriptUrlMissingWebSuffix'] = 'LibreBooking is not configured correctly. The <code>script.url</code> setting must end with <code>/Web</code>, or navigation links and login redirects will not work correctly. Please contact the administrator.';
         $strings['LayoutDescription'] = 'Starts on %s, showing %s days at a time';
         $strings['AllResources'] = 'All Resources';
         $strings['TakeOffline'] = 'Take Offline';

--- a/tests/Infrastructure/Common/SmartyPageTest.php
+++ b/tests/Infrastructure/Common/SmartyPageTest.php
@@ -21,11 +21,38 @@ class SmartyPageTest extends TestBase
     {
         $page = new SmartyPage();
         $page->assign('ScriptUrl', 'https://librebooking.example/Web');
+        $page->assign('ScriptUrlMissingWebSuffix', false);
 
         $output = $page->fetch('globalheader.tpl');
 
         $this->assertStringNotContainsString('id="script-url-warning"', $output);
         $this->assertStringNotContainsString('ScriptUrlNotConfigured', $output);
+        $this->assertStringNotContainsString('id="script-url-web-suffix-warning"', $output);
+        $this->assertStringNotContainsString('ScriptUrlMissingWebSuffix', $output);
+    }
+
+    public function testGlobalHeaderDisplaysWarningWhenScriptUrlIsMissingWebSuffix(): void
+    {
+        $page = new SmartyPage();
+        $page->assign('ScriptUrl', 'https://librebooking.example');
+        $page->assign('ScriptUrlMissingWebSuffix', true);
+
+        $output = $page->fetch('globalheader.tpl');
+
+        $this->assertStringContainsString('id="script-url-web-suffix-warning"', $output);
+        $this->assertStringContainsString('ScriptUrlMissingWebSuffix', $output);
+    }
+
+    public function testGlobalHeaderPrefersEmptyWarningOverWebSuffixWarning(): void
+    {
+        $page = new SmartyPage();
+        $page->assign('ScriptUrl', '');
+        $page->assign('ScriptUrlMissingWebSuffix', true);
+
+        $output = $page->fetch('globalheader.tpl');
+
+        $this->assertStringContainsString('id="script-url-warning"', $output);
+        $this->assertStringNotContainsString('id="script-url-web-suffix-warning"', $output);
     }
 
     public function testCreateUrlLinkifiesHttpAndHttpsUrls(): void

--- a/tpl/globalheader.tpl
+++ b/tpl/globalheader.tpl
@@ -117,10 +117,14 @@
         </div>
     </noscript>
 
-    {* Alert everyone if `script.url` is unset as it will cause issues. *}
+    {* Alert everyone if `script.url` is unset or missing the required `/Web` suffix, as either will cause issues. *}
     {if !isset($ScriptUrl) || $ScriptUrl eq ''}
         <div id="script-url-warning" class="alert alert-danger text-center m-2" role="alert">
             {translate key="ScriptUrlNotConfigured"}
+        </div>
+    {elseif !empty($ScriptUrlMissingWebSuffix)}
+        <div id="script-url-web-suffix-warning" class="alert alert-danger text-center m-2" role="alert">
+            {translate key="ScriptUrlMissingWebSuffix"}
         </div>
     {/if}
 


### PR DESCRIPTION
DocumentRoot=Web deployments that omit /Web from script.url are not supported: navigation-link validation and login/SSO redirect construction both assume /Web is present in the request path, so omitting it breaks Schedule/Calendar navigation and can break external authentication redirects (see #1590).

Rather than relaxing that assumption, make the requirement explicit:

- Document the /Web requirement in INSTALLATION.rst (deployment section) and BASIC-CONFIGURATION.rst (script.url setting), and add a new FAQ.rst entry referencing #1590.
- Show a warning banner in globalheader.tpl when script.url is set but does not end in /Web (a trailing slash is tolerated, since ExternalAuthLoginPresenter already normalizes it that way), mirroring the existing banner shown when script.url is empty.
- Add the ScriptUrlMissingWebSuffix translation string and cover the new banner logic in SmartyPageTest.

Assisted-by: Claude:claude-sonnet-5
Related: #1590