### PR TITLE
fix(apache): use Apache 2.4 authorization directives

### DIFF
--- a/Jobs/.htaccess
+++ b/Jobs/.htaccess
@@ -1,1 +1,1 @@
-deny from all
+Require all denied

--- a/README.md
+++ b/README.md
@@ -95,7 +95,9 @@ To run LibreBooking from a prebuilt release, your server needs:
 
 - PHP >= 8.2 with the extensions: ctype, curl, fileinfo, intl, json, mbstring, mysqli, openssl, pdo, pdo_mysql, tokenizer, xml
 - Optional PHP extensions: bcmath (needed for Active Directory authentication), gd (image processing), ldap (LDAP authentication)
-- A web server like Apache or Nginx
+- Apache >= 2.4. Other web servers, including Nginx, may work when configured
+  with equivalent routing and access-control rules, but are not currently
+  supported or tested by the LibreBooking project.
 - MySQL >= 8.0 (2018) or MariaDB >= 10.6 (2021)
 - Composer (for managing PHP dependencies)
 - Git (optional, useful for cloning the repository or managing updates)

--- a/Web/Services/.htaccess
+++ b/Web/Services/.htaccess
@@ -1,5 +1,5 @@
 <Limit GET POST PUT DELETE OPTIONS>
-  Allow from all
+  Require all granted
 </Limit>
 
 

--- a/config/.htaccess
+++ b/config/.htaccess
@@ -1,1 +1,1 @@
-deny from all
+Require all denied

--- a/uploads/.htaccess
+++ b/uploads/.htaccess
@@ -1,5 +1,1 @@
-deny from all
-
-<Files ~ "^.*">
-Deny from all
-</Files>
+Require all denied


### PR DESCRIPTION
Replace legacy Allow and Deny access controls with Require directives since Apache 2.4 is the minimum supported version.

Simplify upload protection to a directory-wide denial while preserving the existing access policy for API methods.

Update README to state Nginx is not a supported/tested web server. And that Apache >= 2.4 is required.

Assisted-by: Codex:GPT-5