### PR TITLE
refactor(autoload): add initial PSR-4 support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,6 +35,7 @@ This file contains essential information for AI coding agents working on the Lib
 /Pages                   Page binding and workflow logic
 /Presenters              Application logic and page population
 /plugins                 Plugin architecture (various types)
+/src                     PSR-4 autoloaded code, namespace LibreBooking\ (migration in progress)
 /tests                   PHPUnit test suite
 /tpl                     Smarty templates
 /tpl_c                   Template cache (auto-generated, not tracked)
@@ -177,6 +178,7 @@ Test suites available:
 - `domain` - Domain layer tests
 - `plugins` - Plugin tests
 - `presenters` - Presenter tests
+- `src` - Tests for PSR-4 code under `src/`
 - `webservice` / `webservices` - API tests
 - `integration` - Integration tests (requires database setup)
 
@@ -264,6 +266,64 @@ Configuration: `build.xml`
 - Each page should have a class in `/Pages`
 - Each page class should have a presenter in `/Presenters`
 - Related code grouped in directories with `namespace.php` for easy inclusion
+  (legacy pattern; new self-contained code uses PSR-4 in `/src` — see
+  "PSR-4 Migration" below)
+
+### PSR-4 Migration (`src/` directory)
+
+The project is gradually migrating from `require_once` include chains to
+Composer PSR-4 autoloading. `composer.json` maps the `LibreBooking\` namespace
+to `src/`, and CI runs `composer dump-autoload --optimize --strict-psr`, so
+everything under `src/` must be strictly PSR-4 compliant.
+
+**Where new code goes**:
+
+- **New self-contained classes** (value objects, helpers, services that do not
+  extend or implement anything from the legacy include system) go in `src/`
+  under the `LibreBooking\` namespace.
+- **Code extending an existing legacy subsystem** (a new Presenter, Page, or a
+  class implementing a legacy global interface) stays in the existing
+  directory layout for now. The legacy `namespace.php` include chains
+  reference global class names and cannot see namespaced classes.
+
+**Rules for code in `src/`**:
+
+- Exactly one class, enum, interface, or trait per file; the filename must
+  match the type name.
+- The namespace mirrors the path: `src/Application/Authentication/Foo.php`
+  declares `LibreBooking\Application\Authentication\Foo`.
+- Start every file with `declare(strict_types=1);`.
+- Never add the legacy trees (`lib/`, `Domain/`, `Pages/`, etc.) to the PSR-4
+  autoload mapping in `composer.json` — they are not PSR-4 compliant and the
+  strict CI check will fail.
+- Run `composer dump-autoload` after adding or moving files (never commit
+  anything under `vendor/`).
+- Tests live in `tests/src/`, mirroring the source path, and are namespaced
+  `LibreBooking\Tests\...` (mapped via `autoload-dev`). The strict CI autoload
+  check enforces that test namespaces and class names match their paths. Run
+  them alone with `composer phpunit -- --testsuite src`.
+
+**Migrating a legacy file to `src/`**:
+
+1. Split multi-type files so each class/enum gets its own file.
+2. Add the namespace and update every call site with `use` imports.
+3. Delete the old file from the legacy tree.
+4. Move the class's tests to `tests/src/` and namespace them
+   `LibreBooking\Tests\...` (see Testing Strategy).
+5. Web entry points (`Web/*.php`) must keep
+   `require_once ROOT_DIR . 'lib/Common/namespace.php';` in addition to
+   `require_once ROOT_DIR . 'vendor/autoload.php';`. The Composer autoloader
+   cannot load legacy global classes such as `Configuration` and `Log`, and
+   the legacy bootstrap also registers the global exception handler. Dropping
+   it causes fatals that only appear at runtime (see the OAuth regression in
+   PR #1552).
+6. When changing an entry point's bootstrap, add an entry-point-level
+   regression test that executes the script in a subprocess (see
+   `tests/Web/MicrosoftAuthEntryPointTest.php` for the pattern).
+
+`src/` is already covered by php-cs-fixer, PHPStan (`phpstan.neon` and
+`phpstan_next.neon` list it in `paths`), release packaging, and phplint, so no
+per-PR tooling changes are needed when adding files there.
 
 ### Naming Conventions
 
@@ -447,7 +507,8 @@ composer preflight
    - Create page class in `/Pages/`
    - Create presenter in `/Presenters/`
    - Create template in `/tpl/`
-   - Add domain logic in `/Domain/` or `/lib/Application/`
+   - Add domain logic in `/Domain/` or `/lib/Application/`; prefer `/src/`
+     for new self-contained classes (see "PSR-4 Migration" above)
 
 3. Add tests in `/tests/` matching the directory structure
 
@@ -630,6 +691,7 @@ chmod 755 tpl_c tpl uploads
 - Keep tests fast and isolated
 - Test file location should mirror source file structure
 - Name test files and test classes after the class under test with a `Test` suffix (for example, `Pages/Admin/ManageUsersPage.php` -> `tests/Pages/Admin/ManageUsersPageTest.php`)
+- Tests for PSR-4 code under `src/` go in `tests/src/` mirroring the source path, and are namespaced `LibreBooking\Tests\...` via the `autoload-dev` mapping (for example, `src/Application/Authentication/MicrosoftOAuthCallback.php` -> `tests/src/Application/Authentication/MicrosoftOAuthCallbackTest.php` declaring `LibreBooking\Tests\Application\Authentication\MicrosoftOAuthCallbackTest`)
 - Prefer one primary test file per source class; add extra files only when a clear separation is needed
 
 ### Integration Tests

--- a/Web/microsoft-auth.php
+++ b/Web/microsoft-auth.php
@@ -1,9 +1,11 @@
 <?php
 
+use LibreBooking\Application\Authentication\MicrosoftOAuthCallback;
+
 define('ROOT_DIR', '../');
 
+require_once(ROOT_DIR . 'vendor/autoload.php');
 require_once(ROOT_DIR . 'lib/Common/namespace.php');
-require_once(ROOT_DIR . 'lib/Application/Authentication/MicrosoftOAuthCallback.php');
 
 $result = (new MicrosoftOAuthCallback())->handle(
     params: $_GET,

--- a/commitlint.config.cjs
+++ b/commitlint.config.cjs
@@ -3,7 +3,7 @@ module.exports = {
   rules: {
     'body-leading-blank': [2, 'always'],
     'body-max-line-length': [2, 'always', 72],
-    'footer-leading-blank': [2, 'always'],
+    'footer-leading-blank': [1, 'always'],
     'footer-max-line-length': [2, 'always', 72],
     'header-max-length': [2, 'always', 72],
     'scope-case': [0],

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,16 @@
     "name": "librebooking/librebooking",
     "description": "LibreBooking",
     "license": "GPL-3.0-only",
-    "autoload": {},
+    "autoload": {
+        "psr-4": {
+            "LibreBooking\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "LibreBooking\\Tests\\": "tests/src/"
+        }
+    },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.95",
         "squizlabs/php_codesniffer": "^3.7.1",

--- a/phpdoc.dist.xml
+++ b/phpdoc.dist.xml
@@ -25,6 +25,7 @@
                 <path>Pages/*</path>
                 <path>plugins/*</path>
                 <path>Presenters/*</path>
+                <path>src/*</path>
                 <path>Web/*</path>
                 <path>WebServices/*</path>
             </source>

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -20,6 +20,7 @@ parameters:
         - phing-tasks
         # Keep `plugins` in paths so PHPStan can scan symbols used via dynamic plugin loading.
         - plugins
+        - src
         - tests
     excludePaths:
         analyse:

--- a/phpstan_next.neon
+++ b/phpstan_next.neon
@@ -20,6 +20,7 @@ parameters:
         - phing-tasks
         # Keep `plugins` in paths so PHPStan can scan symbols used via dynamic plugin loading.
         - plugins
+        - src
         - tests
     excludePaths:
         analyse:

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -23,6 +23,9 @@
     <testsuite name="presenters">
       <directory>./tests/Presenters</directory>
     </testsuite>
+    <testsuite name="src">
+      <directory>./tests/src</directory>
+    </testsuite>
     <testsuite name="webservice">
       <directory>./tests/WebService</directory>
     </testsuite>
@@ -46,6 +49,7 @@
       <directory suffix=".php">Pages</directory>
       <directory suffix=".php">plugins</directory>
       <directory suffix=".php">Presenters</directory>
+      <directory suffix=".php">src</directory>
       <directory suffix=".php">Web</directory>
       <directory suffix=".php">WebServices</directory>
     </include>

--- a/src/Application/Authentication/MicrosoftOAuthCallback.php
+++ b/src/Application/Authentication/MicrosoftOAuthCallback.php
@@ -2,69 +2,8 @@
 
 declare(strict_types=1);
 
-/**
- * Classification of a Microsoft OAuth callback request.
- */
-enum MicrosoftOAuthCallbackOutcome
-{
-    case SUCCESS;
-    case OAUTH_ERROR;
-    case MALFORMED_REQUEST;
-}
+namespace LibreBooking\Application\Authentication;
 
-/**
- * Microsoft's OAuth callback outcome — either a redirect to external-auth or a redirect to home on error.
- *
- * The error fields exist only for logging and are bounded/normalized at
- * construction; a feature that displays them to users should add a separate
- * raw accessor rather than widen the caps.
- */
-class MicrosoftOAuthCallbackResult
-{
-    private function __construct(
-        public readonly string $redirectURL,
-        private readonly MicrosoftOAuthCallbackOutcome $outcome,
-        public readonly ?string $error = null,
-        private readonly ?string $errorDescription = null,
-    ) {
-    }
-
-    public static function success(string $redirectURL): self
-    {
-        return new self($redirectURL, MicrosoftOAuthCallbackOutcome::SUCCESS);
-    }
-
-    public static function oauthError(string $failureRedirectURL, string $error, ?string $errorDescription = null): self
-    {
-        return new self($failureRedirectURL, MicrosoftOAuthCallbackOutcome::OAUTH_ERROR, $error, $errorDescription);
-    }
-
-    public static function malformedRequest(string $failureRedirectURL): self
-    {
-        return new self($failureRedirectURL, MicrosoftOAuthCallbackOutcome::MALFORMED_REQUEST);
-    }
-
-    /**
-     * True when the provider reported an error (?error=...). This is the only
-     * outcome worth logging: malformed requests to this unauthenticated
-     * endpoint are dominated by scanner noise, so they are deliberately not
-     * logged; the web server access log is the diagnostic fallback.
-     */
-    public function hasOAuthErrorResponse(): bool
-    {
-        return $this->outcome === MicrosoftOAuthCallbackOutcome::OAUTH_ERROR;
-    }
-
-    public function isMalformedRequest(): bool
-    {
-        return $this->outcome === MicrosoftOAuthCallbackOutcome::MALFORMED_REQUEST;
-    }
-
-    public function getErrorDescription(): string
-    {
-        return $this->errorDescription ?? 'No error description was provided.';
-    }
-}
 /**
  * Handler for Microsoft OAuth workflows.
  */

--- a/src/Application/Authentication/MicrosoftOAuthCallbackOutcome.php
+++ b/src/Application/Authentication/MicrosoftOAuthCallbackOutcome.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LibreBooking\Application\Authentication;
+
+/**
+ * Classification of a Microsoft OAuth callback request.
+ */
+enum MicrosoftOAuthCallbackOutcome
+{
+    case SUCCESS;
+    case OAUTH_ERROR;
+    case MALFORMED_REQUEST;
+}

--- a/src/Application/Authentication/MicrosoftOAuthCallbackResult.php
+++ b/src/Application/Authentication/MicrosoftOAuthCallbackResult.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LibreBooking\Application\Authentication;
+
+/**
+ * Microsoft's OAuth callback outcome — either a redirect to external-auth or a redirect to home on error.
+ *
+ * The error fields exist only for logging and are bounded/normalized at
+ * construction; a feature that displays them to users should add a separate
+ * raw accessor rather than widen the caps.
+ */
+class MicrosoftOAuthCallbackResult
+{
+    private function __construct(
+        public readonly string $redirectURL,
+        private readonly MicrosoftOAuthCallbackOutcome $outcome,
+        public readonly ?string $error = null,
+        private readonly ?string $errorDescription = null,
+    ) {
+    }
+
+    public static function success(string $redirectURL): self
+    {
+        return new self($redirectURL, MicrosoftOAuthCallbackOutcome::SUCCESS);
+    }
+
+    public static function oauthError(string $failureRedirectURL, string $error, ?string $errorDescription = null): self
+    {
+        return new self($failureRedirectURL, MicrosoftOAuthCallbackOutcome::OAUTH_ERROR, $error, $errorDescription);
+    }
+
+    public static function malformedRequest(string $failureRedirectURL): self
+    {
+        return new self($failureRedirectURL, MicrosoftOAuthCallbackOutcome::MALFORMED_REQUEST);
+    }
+
+    /**
+     * True when the provider reported an error (?error=...). This is the only
+     * outcome worth logging: malformed requests to this unauthenticated
+     * endpoint are dominated by scanner noise, so they are deliberately not
+     * logged; the web server access log is the diagnostic fallback.
+     */
+    public function hasOAuthErrorResponse(): bool
+    {
+        return $this->outcome === MicrosoftOAuthCallbackOutcome::OAUTH_ERROR;
+    }
+
+    public function isMalformedRequest(): bool
+    {
+        return $this->outcome === MicrosoftOAuthCallbackOutcome::MALFORMED_REQUEST;
+    }
+
+    public function getErrorDescription(): string
+    {
+        return $this->errorDescription ?? 'No error description was provided.';
+    }
+}

--- a/tests/Web/MicrosoftAuthEntryPointTest.php
+++ b/tests/Web/MicrosoftAuthEntryPointTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Runs Web/microsoft-auth.php in a separate PHP process to verify the
+ * entry-point bootstrap: the Composer autoloader must resolve the callback
+ * handler while the legacy include bootstrap supplies the global classes that
+ * Log depends on. The handler unit test cannot catch a missing-class fatal in
+ * this file because it never executes the entry point.
+ */
+class MicrosoftAuthEntryPointTest extends TestCase
+{
+    public function testOAuthErrorCallbackRunsWithoutFatalError(): void
+    {
+        [$exitCode, $output] = $this->runEntryPoint(
+            get: ['error' => 'access_denied', 'error_description' => 'the user canceled the authentication'],
+        );
+
+        $this->assertSame(0, $exitCode, "Entry point exited non-zero. Output:\n" . $output);
+        $this->assertStringNotContainsString('Fatal error', $output);
+        $this->assertStringNotContainsString('not found', $output);
+    }
+
+    public function testSuccessCallbackRunsWithoutFatalError(): void
+    {
+        [$exitCode, $output] = $this->runEntryPoint(get: ['code' => 'abc123', 'state' => '/Web/']);
+
+        $this->assertSame(0, $exitCode, "Entry point exited non-zero. Output:\n" . $output);
+        $this->assertStringNotContainsString('Fatal error', $output);
+        $this->assertStringNotContainsString('not found', $output);
+    }
+
+    /**
+     * @param array<string, string> $get
+     * @return array{0: int, 1: string} exit code and combined stdout/stderr
+     */
+    private function runEntryPoint(array $get): array
+    {
+        $code = '$_GET = ' . var_export($get, true) . '; include "microsoft-auth.php";';
+
+        $process = proc_open(
+            command: [PHP_BINARY, '-d', 'display_errors=1', '-d', 'error_reporting=E_ALL', '-r', $code],
+            descriptor_spec: [1 => ['pipe', 'w'], 2 => ['pipe', 'w']],
+            pipes: $pipes,
+            cwd: __DIR__ . '/../../Web',
+        );
+        $this->assertIsResource($process, 'Failed to start PHP subprocess');
+
+        $stdout = stream_get_contents($pipes[1]);
+        $stderr = stream_get_contents($pipes[2]);
+        fclose($pipes[1]);
+        fclose($pipes[2]);
+        $exitCode = proc_close($process);
+
+        return [$exitCode, $stdout . $stderr];
+    }
+}

--- a/tests/src/Application/Authentication/MicrosoftOAuthCallbackTest.php
+++ b/tests/src/Application/Authentication/MicrosoftOAuthCallbackTest.php
@@ -2,7 +2,10 @@
 
 declare(strict_types=1);
 
-require_once(ROOT_DIR . 'lib/Application/Authentication/MicrosoftOAuthCallback.php');
+namespace LibreBooking\Tests\Application\Authentication;
+
+use LibreBooking\Application\Authentication\MicrosoftOAuthCallback;
+use TestBase;
 
 class MicrosoftOAuthCallbackTest extends TestBase
 {


### PR DESCRIPTION
Establish a Composer PSR-4 autoload mapping for the LibreBooking namespace rooted at the new src/ directory and migrate the first component: the Microsoft OAuth callback handler.

- Map LibreBooking\ to src/ in composer.json, leaving the legacy lib/ tree on the existing include system so the gradual migration passes `composer dump-autoload --optimize --strict-psr`.
- Split MicrosoftOAuthCallback, MicrosoftOAuthCallbackResult, and MicrosoftOAuthCallbackOutcome into one file per type under src/Application/Authentication/ and delete the legacy file.
- Keep the lib/Common/namespace.php bootstrap in Web/microsoft-auth.php alongside vendor/autoload.php so Log's dependencies and the global exception handler keep working; dropping it caused OAuth error callbacks to fatal with "Class 'Configuration' not found" in an earlier attempt (PR #1552).
- Add an entry-point regression test that runs Web/microsoft-auth.php in a subprocess to catch missing-class fatals in the bootstrap.
- Map LibreBooking\Tests\ to tests/src/ via autoload-dev and move the handler test there as a namespaced class; the strict CI autoload check now enforces that test names match their paths. Add a "src" PHPUnit testsuite for running these tests in isolation.
- Add src to both PHPStan configurations.
- Document the migration policy in AGENTS.md: what belongs in src/, the one-type-per-file and namespace rules, the test location and naming convention, and the entry-point bootstrap requirements.

Related: #1501

Assisted-by: Claude:claude-fable-5