### PR TITLE
fix(dashboard): handle schedule availability windows for resource dis…

### DIFF
--- a/Controls/Dashboard/ResourceAvailabilityControl.php
+++ b/Controls/Dashboard/ResourceAvailabilityControl.php
@@ -123,8 +123,18 @@ class UnavailableDashboardItem
      */
     private $currentReservation;
 
-    public function __construct(ResourceDto $resource, ReservationItemView $currentReservation)
-    {
+    /**
+     * @param bool $isFutureScheduleAvailability true when this item stands in for a resource whose schedule's
+     *                                           availability window has not opened yet, rather than a resource
+     *                                           blocked by a real reservation. In that case $currentReservation
+     *                                           is a synthetic placeholder and ReservationEnds() returns the
+     *                                           date the schedule becomes available.
+     */
+    public function __construct(
+        ResourceDto $resource,
+        ReservationItemView $currentReservation,
+        private bool $isFutureScheduleAvailability
+    ) {
         $this->resource = $resource;
         $this->currentReservation = $currentReservation;
     }
@@ -161,6 +171,11 @@ class UnavailableDashboardItem
     public function GetTextColor()
     {
         return $this->currentReservation->GetTextColor();
+    }
+
+    public function IsFutureScheduleAvailability(): bool
+    {
+        return $this->isFutureScheduleAvailability;
     }
 }
 

--- a/Presenters/Dashboard/ResourceAvailabilityControlPresenter.php
+++ b/Presenters/Dashboard/ResourceAvailabilityControlPresenter.php
@@ -42,6 +42,13 @@ class ResourceAvailabilityControlPresenter
         $resources = $this->resourceService->GetAllResources(false, $user);
         $reservations = $this->GetReservations($this->reservationViewRepository->GetReservations($now, $now->AddDays(30)));
 
+        // Build schedule lookup table
+        $schedules = $this->scheduleRepository->GetAll();
+        $schedulesById = [];
+        foreach ($schedules as $schedule) {
+            $schedulesById[$schedule->GetId()] = $schedule;
+        }
+
         $available = [];
         $unavailable = [];
         $allday = [];
@@ -50,6 +57,38 @@ class ResourceAvailabilityControlPresenter
             if ($resource->StatusId == ResourceStatus::HIDDEN) {
                 continue;
             }
+
+            // Check schedule availability
+            if (isset($schedulesById[$resource->ScheduleId])) {
+                $schedule = $schedulesById[$resource->ScheduleId];
+                if ($schedule->HasAvailability()) {
+                    $begin = $schedule->GetAvailabilityBegin();
+                    $end = $schedule->GetAvailabilityEnd();
+
+                    // If schedule is past, don't show this resource
+                    if ($now->GreaterThanOrEqual($end)) {
+                        continue;
+                    }
+
+                    // If schedule is future, add to unavailable with availability begin date
+                    if ($now->LessThan($begin)) {
+                        $futureReservation = new ReservationItemView(
+                            startDate: $begin,
+                            endDate: $begin,
+                            resourceName: $resource->GetName(),
+                            resourceId: $resource->GetId()
+                        );
+                        $futureReservation->ResourceColor = $resource->GetColor();
+                        $unavailable[$resource->ScheduleId][] = new UnavailableDashboardItem(
+                            resource: $resource,
+                            currentReservation: $futureReservation,
+                            isFutureScheduleAvailability: true
+                        );
+                        continue;
+                    }
+                }
+            }
+
             $reservation = $this->GetOngoingReservation($resource, $reservations);
 
             if ($reservation != null) {
@@ -60,9 +99,17 @@ class ResourceAvailabilityControlPresenter
                 }
 
                 if (!$reservation->EndDate->DateEquals($now)) {
-                    $allday[$resource->ScheduleId][] = new UnavailableDashboardItem($resource, $lastReservationBeforeOpening);
+                    $allday[$resource->ScheduleId][] = new UnavailableDashboardItem(
+                        resource: $resource,
+                        currentReservation: $lastReservationBeforeOpening,
+                        isFutureScheduleAvailability: false
+                    );
                 } else {
-                    $unavailable[$resource->ScheduleId][] = new UnavailableDashboardItem($resource, $lastReservationBeforeOpening);
+                    $unavailable[$resource->ScheduleId][] = new UnavailableDashboardItem(
+                        resource: $resource,
+                        currentReservation: $lastReservationBeforeOpening,
+                        isFutureScheduleAvailability: false
+                    );
                 }
             } else {
                 $resourceId = $resource->GetId();
@@ -77,7 +124,7 @@ class ResourceAvailabilityControlPresenter
         $this->control->SetAvailable($available);
         $this->control->SetUnavailable($unavailable);
         $this->control->SetUnavailableAllDay($allday);
-        $this->control->SetSchedules($this->scheduleRepository->GetAll());
+        $this->control->SetSchedules($schedules);
     }
 
     /**

--- a/tests/Presenters/Dashboard/ResourceAvailabilityControlPresenterTest.php
+++ b/tests/Presenters/Dashboard/ResourceAvailabilityControlPresenterTest.php
@@ -75,13 +75,67 @@ class ResourceAvailabilityControlPresenterTest extends TestBase
             $this->control->_AvailableNow[1][0]
         );
         $this->assertEquals(
-            new UnavailableDashboardItem($this->unavailableResource, $this->reservationRepo->_Reservations[1]),
+            new UnavailableDashboardItem(
+                resource: $this->unavailableResource,
+                currentReservation: $this->reservationRepo->_Reservations[1],
+                isFutureScheduleAvailability: false
+            ),
             $this->control->_UnavailableNow[1][0]
         );
         $this->assertEquals(
-            new UnavailableDashboardItem($this->unavailableAllDayResource, $this->reservationRepo->_Reservations[2]),
+            new UnavailableDashboardItem(
+                resource: $this->unavailableAllDayResource,
+                currentReservation: $this->reservationRepo->_Reservations[2],
+                isFutureScheduleAvailability: false
+            ),
             $this->control->_UnavailableAllDay[1][0]
         );
+
+        $this->assertFalse($this->control->_UnavailableNow[1][0]->IsFutureScheduleAvailability());
+        $this->assertFalse($this->control->_UnavailableAllDay[1][0]->IsFutureScheduleAvailability());
+    }
+
+    public function testFutureScheduleResourceAppearsAsUnavailable()
+    {
+        Date::_SetNow(Date::Parse('2026-07-29 10:00', 'UTC'));
+
+        $futureSchedule = new FakeSchedule(1);
+        $futureSchedule->SetAvailability(Date::Now()->AddDays(5), Date::Now()->AddDays(35));
+        $this->scheduleRepo->_Schedules = [$futureSchedule];
+
+        $futureResource = new TestResourceDto(1, '1');
+        $this->resourceService->_AllResources = [$futureResource];
+        $this->reservationRepo->_Reservations = [];
+
+        $this->presenter->PageLoad($this->fakeUser);
+
+        $this->assertNotEmpty($this->control->_UnavailableNow);
+        $this->assertNotEmpty($this->control->_UnavailableNow[1]);
+        $unavailableItem = $this->control->_UnavailableNow[1][0];
+        $this->assertInstanceOf('UnavailableDashboardItem', $unavailableItem);
+        $this->assertEquals($futureResource->GetId(), $unavailableItem->ResourceId());
+        $this->assertTrue($unavailableItem->IsFutureScheduleAvailability());
+        // Verify that the availability begin date is set as the end date of the synthetic reservation
+        $this->assertTrue($unavailableItem->ReservationEnds()->Equals(Date::Now()->AddDays(5)));
+    }
+
+    public function testPastScheduleResourceIsHidden()
+    {
+        Date::_SetNow(Date::Parse('2026-07-29 10:00', 'UTC'));
+
+        $pastSchedule = new FakeSchedule(1);
+        $pastSchedule->SetAvailability(Date::Now()->AddDays(-30), Date::Now()->AddDays(-1));
+        $this->scheduleRepo->_Schedules = [$pastSchedule];
+
+        $pastResource = new TestResourceDto(1, '1');
+        $this->resourceService->_AllResources = [$pastResource];
+        $this->reservationRepo->_Reservations = [];
+
+        $this->presenter->PageLoad($this->fakeUser);
+
+        $this->assertEmpty($this->control->_AvailableNow);
+        $this->assertEmpty($this->control->_UnavailableNow);
+        $this->assertEmpty($this->control->_UnavailableAllDay);
     }
 
     private function PopulateResources()
@@ -105,7 +159,11 @@ class ResourceAvailabilityControlPresenterTest extends TestBase
 
     private function PopulateSchedules()
     {
-        $this->scheduleRepo->_Schedules = [new FakeSchedule(1), new FakeSchedule(2)];
+        $schedule1 = new FakeSchedule(1);
+        $schedule1->SetAvailability(Date::Now()->AddDays(-30), Date::Now()->AddDays(30));
+        $schedule2 = new FakeSchedule(2);
+        $schedule2->SetAvailability(Date::Now()->AddDays(-30), Date::Now()->AddDays(30));
+        $this->scheduleRepo->_Schedules = [$schedule1, $schedule2];
     }
 }
 

--- a/tpl/Dashboard/resource_availability.tpl
+++ b/tpl/Dashboard/resource_availability.tpl
@@ -17,21 +17,18 @@
                     'data' => $Available,
                     'dateField' => 'NextTime',
                     'label' => 'AvailableUntil',
-                    'urlDate' => false
                 ],
                 [
                     'title' => 'Unavailable',
                     'data' => $Unavailable,
                     'dateField' => 'ReservationEnds',
                     'label' => 'AvailableBeginningAt',
-                    'urlDate' => true
                 ],
                 [
                     'title' => 'UnavailableAllDay',
                     'data' => $UnavailableAllDay,
                     'dateField' => 'ReservationEnds',
                     'label' => 'AvailableAt',
-                    'urlDate' => true
                 ]
             ]}
 
@@ -61,6 +58,12 @@
                                 {assign var=date value=$i->ReservationEnds()}
                             {/if}
 
+                            {* Determine date format for future schedule availability *}
+                            {assign var=dateFormat value='dashboard'}
+                            {if $section.dateField == 'ReservationEnds' && $i->IsFutureScheduleAvailability()}
+                                {assign var=dateFormat value='schedule_daily'}
+                            {/if}
+
                             <div class="availabilityItem row gy-2 p-2 border-bottom align-items-center">
 
                                 {* Resource name *}
@@ -71,7 +74,7 @@
                                         <i resource-id="{$i->ResourceId()}" class="resourceNameSelector bi bi-info-circle-fill"></i>
                                         <a resource-id="{$i->ResourceId()}" class="resourceNameSelector"
                                             {if $i->GetColor()}style="color:{$i->GetTextColor()};" {/if}
-                                            href="{$Path}{Pages::RESERVATION}?{QueryStringKeys::RESOURCE_ID}={$i->ResourceId()}">
+                                            href="{$Path}{Pages::SCHEDULE}?{QueryStringKeys::SCHEDULE_ID}={$s->GetId()}&{QueryStringKeys::RESOURCE_ID}={$i->ResourceId()}{if ($section.dateField == 'ReservationEnds') && $date}&{QueryStringKeys::START_DATE}={format_date date=$date timezone=$Timezone key=url}{/if}">
                                             {$i->ResourceName()}
                                         </a>
                                     </span>
@@ -81,7 +84,7 @@
                                 <div class="availability col-12 col-sm-4">
                                     {if $date != null}
                                         {translate key=$section.label}
-                                        {format_date date=$date timezone=$Timezone key=dashboard}
+                                        {format_date date=$date timezone=$Timezone key=$dateFormat}
                                     {else}
                                         <span class="no-data fst-italic">
                                             {translate key=AllNoUpcomingReservations args=30}
@@ -92,7 +95,7 @@
                                 {* Button *}
                                 <div class="reserveButton col-12 col-sm-3 d-grid">
                                     <button class="btn btn-sm btn-primary"
-                                        onclick="window.location.href='{$Path}{Pages::RESERVATION}?{QueryStringKeys::RESOURCE_ID}={$i->ResourceId()}{if $section.urlDate && $date}&{QueryStringKeys::START_DATE}={format_date date=$date timezone=$Timezone key=url_full}{/if}'">
+                                        onclick="window.location.href='{$Path}{Pages::RESERVATION}?{QueryStringKeys::RESOURCE_ID}={$i->ResourceId()}{if ($section.dateField == 'ReservationEnds') && $date}&{QueryStringKeys::START_DATE}={format_date date=$date timezone=$Timezone key=url_full}{/if}'">
                                         {translate key=Reserve}
                                     </button>
                                 </div>


### PR DESCRIPTION
…play

Add schedule availability window evaluation to the resource availability dashboard widget. Resources are now filtered based on their schedule's availability date range (start_date/end_date).

Behavior changes:

- PAST schedules (now >= end_date): Resources are hidden from dashboard
- ACTIVE schedules (start_date <= now < end_date): Resources display normally with current reservations/availability
- FUTURE schedules (now < start_date): Resources appear in "Unavailable" section showing the availability start date (without time component) and with pre-filled START_DATE in reservation links
- Update resource links in the Resource Availability  dashboard to open the corresponding schedule  filtered by the selected resource instead of the  Reserve page. This allows users to see when  resources become available and start making
  reservations from their scheduled availability date.

This allows users to see when resources will become available and to start making reservations from their scheduled availability date.

Relates: #1512
Assisted-by: Claude:claude-haiku-4.5