### PR TITLE
fix(iCalendar): log error if private organizer email is not configured

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -176,10 +176,10 @@ LB_EMAIL_ENABLED=true
 LB_EMAIL_ENFORCE_CUSTOM_TEMPLATE=false
 
 # Default email address to use for outgoing emails
-LB_EMAIL_DEFAULT_FROM_ADDRESS=
+LB_EMAIL_DEFAULT_FROM_ADDRESS='no-reply@example.com'
 
 # Default name to use for outgoing emails
-LB_EMAIL_DEFAULT_FROM_NAME=
+LB_EMAIL_DEFAULT_FROM_NAME='LB'
 
 #########
 # Logging

--- a/config/config.dist.php
+++ b/config/config.dist.php
@@ -196,10 +196,10 @@ return [
             'enforce.custom.template' => false,
 
             # Default email address to use for outgoing emails
-            'default.from.address' => '',
+            'default.from.address' => 'no-reply@example.com',
 
             # Default name to use for outgoing emails
-            'default.from.name' => '',
+            'default.from.name' => 'LB',
         ],
 
         #########

--- a/lib/Application/Schedule/iCalendarReservationView.php
+++ b/lib/Application/Schedule/iCalendarReservationView.php
@@ -61,6 +61,11 @@ class iCalendarReservationView
 
         $privateNotice = 'Private';
         $privateEmail = Configuration::Instance()->GetKey(ConfigKeys::EMAIL_DEFAULT_FROM_ADDRESS);
+        static $missingPrivateOrganizerEmailLogged = false;
+        if (!$canViewUser && $privateEmail === '' && !$missingPrivateOrganizerEmailLogged) {
+            Log::Error('ICS private organizer email is not configured. Set the email.default.from.address setting.');
+            $missingPrivateOrganizerEmailLogged = true;
+        }
 
         $this->Classification = method_exists($this->ExportFactory, 'GetIcalendarClassification') ? $this->ExportFactory->GetIcalendarClassification($res) : 'PUBLIC';
         if ($res->DateCreated) {

--- a/lib/Config/ConfigKeys.php
+++ b/lib/Config/ConfigKeys.php
@@ -416,7 +416,7 @@ class ConfigKeys extends AbstractConfigKeys
     public const EMAIL_DEFAULT_FROM_ADDRESS = [
         'key' => 'email.default.from.address',
         'type' => 'string',
-        'default' => '',
+        'default' => 'no-reply@example.com',
         'label' => 'Default From Address',
         'description' => 'Default email address for outgoing emails',
         'config_file_comment' => 'Default email address to use for outgoing emails',
@@ -427,7 +427,7 @@ class ConfigKeys extends AbstractConfigKeys
     public const EMAIL_DEFAULT_FROM_NAME = [
         'key' => 'email.default.from.name',
         'type' => 'string',
-        'default' => '',
+        'default' => 'LB',
         'label' => 'Default From Name',
         'description' => 'Default display name for outgoing emails',
         'config_file_comment' => 'Default name to use for outgoing emails',


### PR DESCRIPTION
This pull request improves the default configuration for outgoing emails and adds error logging to help with missing email settings in the iCalendar reservation view. The main changes are as follows:

**Configuration updates:**

* Set the default outgoing email address (`default.from.address`) to `'no-reply@example.com'` and the default sender name (`default.from.name`) to `'LB'` in `config/config.dist.php` to provide sensible defaults for email notifications.

**Error handling improvements:**

* Added a check in `iCalendarReservationView.php` to log an error if the default outgoing email address is not configured, helping administrators identify misconfigurations more easily.