### PR TITLE
feat(calendar): show a descriptive name in ICS subscription feeds

### DIFF
--- a/Pages/Export/CalendarSubscriptionPage.php
+++ b/Pages/Export/CalendarSubscriptionPage.php
@@ -21,6 +21,6 @@ class CalendarSubscriptionPage extends SubscriptionPage
         header('Content-Disposition: inline; filename=calendar.ics');
 
         $display = new CalendarExportDisplay();
-        echo $display->Render($this->reservations);
+        echo $display->Render($this->reservations, $this->calendarName);
     }
 }

--- a/Pages/Export/ICalendarSubscriptionPage.php
+++ b/Pages/Export/ICalendarSubscriptionPage.php
@@ -17,6 +17,8 @@ interface ICalendarSubscriptionPage
      */
     public function SetReservations($reservations);
 
+    public function SetCalendarName(string $calendarName): void;
+
     /**
      * @return string
      */

--- a/Pages/Export/SubscriptionPage.php
+++ b/Pages/Export/SubscriptionPage.php
@@ -24,6 +24,8 @@ abstract class SubscriptionPage extends Page implements ICalendarSubscriptionPag
     /** @var iCalendarReservationView[] */
     protected array $reservations = [];
 
+    protected ?string $calendarName = null;
+
     protected function __construct()
     {
         $authorization = new ReservationAuthorization(PluginManager::Instance()->LoadAuthorization());
@@ -42,6 +44,11 @@ abstract class SubscriptionPage extends Page implements ICalendarSubscriptionPag
     public function SetReservations($reservations): void
     {
         $this->reservations = $reservations;
+    }
+
+    public function SetCalendarName(string $calendarName): void
+    {
+        $this->calendarName = $calendarName;
     }
 
     public function GetSubscriptionKey()

--- a/Presenters/CalendarSubscriptionPresenter.php
+++ b/Presenters/CalendarSubscriptionPresenter.php
@@ -84,27 +84,34 @@ class CalendarSubscriptionPresenter
         $summaryFormat = Configuration::Instance()->GetKey(ConfigKeys::RESERVATION_LABELS_ICS_SUMMARY);
 
         $reservationUserLevel = ReservationUserLevel::OWNER;
+
         if (!empty($scheduleId)) {
-            $schedule = $this->subscriptionService->GetSchedule($scheduleId);
-            $sid = $schedule->GetId();
+            $sid = $this->subscriptionService->GetSchedule($scheduleId)->GetId();
         }
         if (!empty($resourceId)) {
-            $resource = $this->subscriptionService->GetResource($resourceId);
-            $rid = $resource->GetId();
+            $rid = $this->subscriptionService->GetResource($resourceId)->GetId();
         }
         if (!empty($accessoryIds)) {
             ## No transformation is implemented. It is assumed the accessoryIds is provided as AccessoryName
             ## filter is defined by LIKE "PATTERN%"
             $aid = $accessoryIds;
         }
+
+        $calendarName = $this->subscriptionService->ResolveCalendarName($scheduleId, $resourceId, $resourceGroupId, $userId);
+
         if (!empty($userId)) {
             $user = $this->subscriptionService->GetUser($userId);
             $uid = $user->Id();
             $reservationUserLevel = ReservationUserLevel::ALL;
             $summaryFormat = Configuration::Instance()->GetKey(ConfigKeys::RESERVATION_LABELS_ICS_MY_SUMMARY);
         }
+
         if (!empty($resourceGroupId)) {
             $resourceIds = $this->subscriptionService->GetResourcesInGroup($resourceGroupId);
+        }
+
+        if ($calendarName !== null && $calendarName !== '') {
+            $this->page->SetCalendarName($calendarName);
         }
 
         if (!empty($uid) || !empty($sid) || !empty($rid) || !empty($resourceIds)) {

--- a/lib/Application/Schedule/CalendarSubscriptionService.php
+++ b/lib/Application/Schedule/CalendarSubscriptionService.php
@@ -47,6 +47,15 @@ interface ICalendarSubscriptionService
      * @return int[]
      */
     public function GetResourcesInGroup($publicResourceGroupId);
+
+    public function GetResourceGroup(string $publicResourceGroupId): ?ResourceGroup;
+
+    public function ResolveCalendarName(
+        ?string $publicScheduleId,
+        ?string $publicResourceId,
+        ?string $publicResourceGroupId,
+        ?string $publicUserId = null
+    ): ?string;
 }
 
 class CalendarSubscriptionDetails
@@ -106,6 +115,7 @@ class CalendarSubscriptionDetails
 class CalendarSubscriptionService implements ICalendarSubscriptionService
 {
     private $cache = [];
+    private $groupCache = [];
 
     /**
      * @var IUserRepository
@@ -177,7 +187,7 @@ class CalendarSubscriptionService implements ICalendarSubscriptionService
     public function GetResourcesInGroup($publicResourceGroupId)
     {
         if (!array_key_exists($publicResourceGroupId, $this->cache)) {
-            $group = $this->resourceRepository->LoadResourceGroupByPublicId($publicResourceGroupId);
+            $group = $this->LoadResourceGroup($publicResourceGroupId);
 
             if ($group == null) {
                 return [];
@@ -188,6 +198,51 @@ class CalendarSubscriptionService implements ICalendarSubscriptionService
         }
 
         return $this->cache[$publicResourceGroupId];
+    }
+
+    public function GetResourceGroup(string $publicResourceGroupId): ?ResourceGroup
+    {
+        return $this->LoadResourceGroup($publicResourceGroupId);
+    }
+
+    public function ResolveCalendarName(
+        ?string $publicScheduleId,
+        ?string $publicResourceId,
+        ?string $publicResourceGroupId,
+        ?string $publicUserId = null
+    ): ?string {
+        $calendarName = null;
+
+        if (!empty($publicScheduleId)) {
+            $calendarName = $this->GetSchedule($publicScheduleId)->GetName();
+        }
+
+        if (!empty($publicResourceId)) {
+            $calendarName = $this->GetResource($publicResourceId)->GetName();
+        }
+
+        if (!empty($publicResourceGroupId)) {
+            $resourceGroup = $this->GetResourceGroup($publicResourceGroupId);
+            if ($resourceGroup !== null && $resourceGroup->name !== null && $resourceGroup->name !== '') {
+                $calendarName = $resourceGroup->name;
+            }
+        }
+
+        if (!empty($publicUserId)) {
+            $myCalendarName = Resources::GetInstance()->GetString('MyCalendar');
+            $calendarName = empty($calendarName) ? $myCalendarName : sprintf('%s - %s', $myCalendarName, $calendarName);
+        }
+
+        return $calendarName;
+    }
+
+    private function LoadResourceGroup(string $publicResourceGroupId): ?ResourceGroup
+    {
+        if (!array_key_exists($publicResourceGroupId, $this->groupCache)) {
+            $this->groupCache[$publicResourceGroupId] = $this->resourceRepository->LoadResourceGroupByPublicId($publicResourceGroupId);
+        }
+
+        return $this->groupCache[$publicResourceGroupId];
     }
 
     public function ForUser($userId, $resourceId = null, $scheduleId = null)

--- a/tests/Application/Schedule/CalendarSubscriptionServiceTest.php
+++ b/tests/Application/Schedule/CalendarSubscriptionServiceTest.php
@@ -82,6 +82,207 @@ class CalendarSubscriptionServiceTest extends TestBase
         $this->assertEquals($expected, $actual);
     }
 
+    public function testGetsResourceGroupByPublicId()
+    {
+        $publicId = uniqid();
+        $group = new ResourceGroup(5, 'Engineering Rooms');
+
+        $this->resourceRepo->expects($this->once())
+                ->method('LoadResourceGroupByPublicId')
+                ->with($this->equalTo($publicId))
+                ->willReturn($group);
+
+        $actual = $this->service->GetResourceGroup($publicId);
+
+        $this->assertEquals($group, $actual);
+    }
+
+    public function testGetsNullResourceGroupWhenGroupNotFound()
+    {
+        $publicId = uniqid();
+
+        $this->resourceRepo->expects($this->once())
+                ->method('LoadResourceGroupByPublicId')
+                ->with($this->equalTo($publicId))
+                ->willReturn(null);
+
+        $actual = $this->service->GetResourceGroup($publicId);
+
+        $this->assertNull($actual);
+    }
+
+    public function testGetResourceGroupReusesGroupLoadedByGetResourcesInGroup()
+    {
+        $publicId = uniqid();
+        $group = new ResourceGroup(5, 'Engineering Rooms');
+        $groups = $this->createMock('ResourceGroupTree');
+
+        $this->resourceRepo->expects($this->once())
+                ->method('LoadResourceGroupByPublicId')
+                ->with($this->equalTo($publicId))
+                ->willReturn($group);
+
+        $this->resourceRepo->expects($this->once())
+                ->method('GetResourceGroups')
+                ->willReturn($groups);
+
+        $groups->expects($this->once())
+                ->method('GetResourceIds')
+                ->with($this->equalTo($group->id))
+                ->willReturn([1, 2]);
+
+        $this->service->GetResourcesInGroup($publicId);
+        $actual = $this->service->GetResourceGroup($publicId);
+
+        $this->assertEquals($group, $actual);
+    }
+
+    public function testResolveCalendarNameReturnsScheduleNameWhenOnlyScheduleIdIsSet()
+    {
+        $publicScheduleId = uniqid();
+        $schedule = new FakeSchedule(1, 'Engineering Schedule');
+
+        $this->scheduleRepo->expects($this->once())
+                ->method('LoadByPublicId')
+                ->with($this->equalTo($publicScheduleId))
+                ->willReturn($schedule);
+
+        $actual = $this->service->ResolveCalendarName($publicScheduleId, null, null);
+
+        $this->assertEquals('Engineering Schedule', $actual);
+    }
+
+    public function testResolveCalendarNameReturnsResourceNameWhenOnlyResourceIdIsSet()
+    {
+        $publicResourceId = uniqid();
+        $resource = new FakeBookableResource(1, 'Meeting Room 3');
+
+        $this->resourceRepo->expects($this->once())
+                ->method('LoadByPublicId')
+                ->with($this->equalTo($publicResourceId))
+                ->willReturn($resource);
+
+        $actual = $this->service->ResolveCalendarName(null, $publicResourceId, null);
+
+        $this->assertEquals('Meeting Room 3', $actual);
+    }
+
+    public function testResolveCalendarNameResourceOverridesSchedule()
+    {
+        $publicScheduleId = uniqid();
+        $publicResourceId = uniqid();
+        $schedule = new FakeSchedule(1, 'Engineering Schedule');
+        $resource = new FakeBookableResource(2, 'Meeting Room 3');
+
+        $this->scheduleRepo->method('LoadByPublicId')->willReturn($schedule);
+        $this->resourceRepo->method('LoadByPublicId')->willReturn($resource);
+
+        $actual = $this->service->ResolveCalendarName($publicScheduleId, $publicResourceId, null);
+
+        $this->assertEquals('Meeting Room 3', $actual);
+    }
+
+    public function testResolveCalendarNameResourceGroupOverridesScheduleWhenGroupNameIsNotEmpty()
+    {
+        $publicScheduleId = uniqid();
+        $publicGroupId = uniqid();
+        $schedule = new FakeSchedule(1, 'Engineering Schedule');
+        $group = new ResourceGroup(5, 'Engineering Rooms');
+
+        $this->scheduleRepo->expects($this->once())
+                ->method('LoadByPublicId')
+                ->with($this->equalTo($publicScheduleId))
+                ->willReturn($schedule);
+
+        $this->resourceRepo->expects($this->once())
+                ->method('LoadResourceGroupByPublicId')
+                ->with($this->equalTo($publicGroupId))
+                ->willReturn($group);
+
+        $actual = $this->service->ResolveCalendarName($publicScheduleId, null, $publicGroupId);
+
+        $this->assertEquals('Engineering Rooms', $actual);
+    }
+
+    public function testResolveCalendarNameFallsBackToScheduleWhenResourceGroupNameIsNull()
+    {
+        $publicScheduleId = uniqid();
+        $publicGroupId = uniqid();
+        $schedule = new FakeSchedule(1, 'Engineering Schedule');
+
+        $this->scheduleRepo->expects($this->once())
+                ->method('LoadByPublicId')
+                ->with($this->equalTo($publicScheduleId))
+                ->willReturn($schedule);
+
+        $this->resourceRepo->expects($this->once())
+                ->method('LoadResourceGroupByPublicId')
+                ->with($this->equalTo($publicGroupId))
+                ->willReturn(null);
+
+        $actual = $this->service->ResolveCalendarName($publicScheduleId, null, $publicGroupId);
+
+        $this->assertEquals('Engineering Schedule', $actual);
+    }
+
+    public function testResolveCalendarNameReturnsNullWhenNoIdsAreSet()
+    {
+        $actual = $this->service->ResolveCalendarName(null, null, null);
+
+        $this->assertNull($actual);
+    }
+
+    public function testResolveCalendarNameReturnsMyCalendarWhenOnlyUserIdIsSet()
+    {
+        $publicUserId = uniqid();
+
+        $actual = $this->service->ResolveCalendarName(null, null, null, $publicUserId);
+
+        $this->assertEquals(Resources::GetInstance()->GetString('MyCalendar'), $actual);
+    }
+
+    public function testResolveCalendarNameCombinesUserNameWithScheduleName()
+    {
+        $publicScheduleId = uniqid();
+        $publicUserId = uniqid();
+        $schedule = new FakeSchedule(1, 'Engineering Schedule');
+
+        $this->scheduleRepo->method('LoadByPublicId')->willReturn($schedule);
+
+        $actual = $this->service->ResolveCalendarName($publicScheduleId, null, null, $publicUserId);
+
+        $expected = sprintf('%s - %s', Resources::GetInstance()->GetString('MyCalendar'), 'Engineering Schedule');
+        $this->assertEquals($expected, $actual);
+    }
+
+    public function testResolveCalendarNameCombinesUserNameWithResourceName()
+    {
+        $publicResourceId = uniqid();
+        $publicUserId = uniqid();
+        $resource = new FakeBookableResource(1, 'Meeting Room 3');
+
+        $this->resourceRepo->method('LoadByPublicId')->willReturn($resource);
+
+        $actual = $this->service->ResolveCalendarName(null, $publicResourceId, null, $publicUserId);
+
+        $expected = sprintf('%s - %s', Resources::GetInstance()->GetString('MyCalendar'), 'Meeting Room 3');
+        $this->assertEquals($expected, $actual);
+    }
+
+    public function testResolveCalendarNameCombinesUserNameWithResourceGroupName()
+    {
+        $publicGroupId = uniqid();
+        $publicUserId = uniqid();
+        $group = new ResourceGroup(5, 'Engineering Rooms');
+
+        $this->resourceRepo->method('LoadResourceGroupByPublicId')->willReturn($group);
+
+        $actual = $this->service->ResolveCalendarName(null, null, $publicGroupId, $publicUserId);
+
+        $expected = sprintf('%s - %s', Resources::GetInstance()->GetString('MyCalendar'), 'Engineering Rooms');
+        $this->assertEquals($expected, $actual);
+    }
+
     public function testSubscriptionDetailsAreNotEnabledWhenIcsFeatureIsDisabled()
     {
         $this->fakeConfig->SetKey(ConfigKeys::ICS_ENABLED, false);

--- a/tests/Presenters/CalendarExportPresenterTest.php
+++ b/tests/Presenters/CalendarExportPresenterTest.php
@@ -291,6 +291,29 @@ class CalendarExportPresenterTest extends TestBase
         $this->assertStringNotContainsString('9.9.9-user-config', $calendar);
     }
 
+    public function testCalendarNameIsRenderedAsNameAndXWrCalname()
+    {
+        $this->fakeConfig->_ScriptUrl = 'https://example.com/Web';
+
+        $display = new CalendarExportDisplay();
+        $calendar = $display->Render([], 'Engineering Schedule');
+
+        // NAME: is checked with line boundaries since X-WR-CALNAME: also contains "NAME:" as a substring.
+        $this->assertStringContainsString("\r\nNAME:Engineering Schedule\r\n", $calendar);
+        $this->assertStringContainsString('X-WR-CALNAME:Engineering Schedule', $calendar);
+    }
+
+    public function testCalendarNameIsOmittedWhenNotProvided()
+    {
+        $this->fakeConfig->_ScriptUrl = 'https://example.com/Web';
+
+        $display = new CalendarExportDisplay();
+        $calendar = $display->Render([]);
+
+        $this->assertStringNotContainsString('NAME:', $calendar);
+        $this->assertStringNotContainsString('X-WR-CALNAME:', $calendar);
+    }
+
     public function testExtraIcalLinesPreservesPropertyParametersAndNestedComponents()
     {
         $user = new FakeUserSession();

--- a/tests/Presenters/CalendarSubscriptionPresenterTest.php
+++ b/tests/Presenters/CalendarSubscriptionPresenterTest.php
@@ -66,7 +66,7 @@ class CalendarSubscriptionPresenterTest extends TestBase
         $reservationResult = [new TestReservationItemView(1, Date::Now(), Date::Now())];
 
         $scheduleId = 999;
-        $schedule = new FakeSchedule($scheduleId);
+        $schedule = new FakeSchedule($scheduleId, 'Engineering Schedule');
 
         $weekAgo = Date::Now()->AddDays(0);
         $nextYear = Date::Now()->AddDays(30);
@@ -78,6 +78,11 @@ class CalendarSubscriptionPresenterTest extends TestBase
                 ->with($this->equalTo($publicId))
                 ->willReturn($schedule);
 
+        $this->service->expects($this->once())
+                ->method('ResolveCalendarName')
+                ->with($this->equalTo($publicId), $this->isNull(), $this->isNull(), $this->isNull())
+                ->willReturn('Engineering Schedule');
+
         $this->repo->expects($this->once())
                 ->method('GetReservations')
                 ->with($this->equalTo($weekAgo), $this->equalTo($nextYear), $this->isNull(), ReservationUserLevel::OWNER, $scheduleId, $this->isNull())
@@ -86,6 +91,7 @@ class CalendarSubscriptionPresenterTest extends TestBase
         $this->presenter->PageLoad();
 
         $this->assertCount(1, $this->page->Reservations);
+        $this->assertEquals('Engineering Schedule', $this->page->CalendarName);
     }
 
     public function testGetsScheduleReservationsForTheNextYearByResourceId()
@@ -94,7 +100,7 @@ class CalendarSubscriptionPresenterTest extends TestBase
         $reservationResult = [new TestReservationItemView(1, Date::Now(), Date::Now())];
 
         $resourceId = 999;
-        $resource = new FakeBookableResource($resourceId);
+        $resource = new FakeBookableResource($resourceId, 'Meeting Room 3');
 
         $weekAgo = Date::Now()->AddDays(0);
         $nextYear = Date::Now()->AddDays(30);
@@ -106,6 +112,11 @@ class CalendarSubscriptionPresenterTest extends TestBase
                 ->with($this->equalTo($publicId))
                 ->willReturn($resource);
 
+        $this->service->expects($this->once())
+                ->method('ResolveCalendarName')
+                ->with($this->isNull(), $this->equalTo($publicId), $this->isNull(), $this->isNull())
+                ->willReturn('Meeting Room 3');
+
         $this->repo->expects($this->once())
                 ->method('GetReservations')
                 ->with($this->equalTo($weekAgo), $this->equalTo($nextYear), $this->isNull(), ReservationUserLevel::OWNER, $this->isNull(), $resourceId)
@@ -114,6 +125,7 @@ class CalendarSubscriptionPresenterTest extends TestBase
         $this->presenter->PageLoad();
 
         $this->assertCount(1, $this->page->Reservations);
+        $this->assertEquals('Meeting Room 3', $this->page->CalendarName);
     }
 
     public function testGetsUserReservationsForTheNextYearByResourceId()
@@ -134,6 +146,11 @@ class CalendarSubscriptionPresenterTest extends TestBase
                 ->with($this->equalTo($publicId))
                 ->willReturn($user);
 
+        $this->service->expects($this->once())
+                ->method('ResolveCalendarName')
+                ->with($this->isNull(), $this->isNull(), $this->isNull(), $this->equalTo($publicId))
+                ->willReturn(Resources::GetInstance()->GetString('MyCalendar'));
+
         $this->repo->expects($this->once())
                 ->method('GetReservations')
                 ->with($this->equalTo($weekAgo), $this->equalTo($nextYear), $this->equalTo($userId), ReservationUserLevel::ALL, $this->isNull(), $this->isNull())
@@ -142,6 +159,48 @@ class CalendarSubscriptionPresenterTest extends TestBase
         $this->presenter->PageLoad();
 
         $this->assertCount(1, $this->page->Reservations);
+        $this->assertEquals(Resources::GetInstance()->GetString('MyCalendar'), $this->page->CalendarName);
+    }
+
+    public function testGetsUserReservationsFilteredByResourceCombinesCalendarNameWithResourceName()
+    {
+        $userPublicId = '1';
+        $resourcePublicId = '2';
+        $reservationResult = [new TestReservationItemView(1, Date::Now(), Date::Now())];
+
+        $userId = 999;
+        $user = new FakeUser($userId);
+
+        $resourceId = 888;
+        $resource = new FakeBookableResource($resourceId, 'Meeting Room 3');
+
+        $this->page->UserId = $userPublicId;
+        $this->page->ResourceId = $resourcePublicId;
+
+        $this->service->expects($this->once())
+                ->method('GetUser')
+                ->with($this->equalTo($userPublicId))
+                ->willReturn($user);
+
+        $this->service->expects($this->once())
+                ->method('GetResource')
+                ->with($this->equalTo($resourcePublicId))
+                ->willReturn($resource);
+
+        $combinedName = sprintf('%s - %s', Resources::GetInstance()->GetString('MyCalendar'), 'Meeting Room 3');
+
+        $this->service->expects($this->once())
+                ->method('ResolveCalendarName')
+                ->with($this->isNull(), $this->equalTo($resourcePublicId), $this->isNull(), $this->equalTo($userPublicId))
+                ->willReturn($combinedName);
+
+        $this->repo->expects($this->once())
+                ->method('GetReservations')
+                ->willReturn($reservationResult);
+
+        $this->presenter->PageLoad();
+
+        $this->assertEquals($combinedName, $this->page->CalendarName);
     }
 
     public function testGetsResourceGroupReservationsForTheNextYearByGroupId()
@@ -172,6 +231,70 @@ class CalendarSubscriptionPresenterTest extends TestBase
         $this->presenter->PageLoad();
 
         $this->assertCount(1, $this->page->Reservations);
+    }
+
+    public function testGetsResourceGroupReservationsSetsCalendarNameFromGroup()
+    {
+        $publicId = '1';
+        $reservationResult = [new TestReservationItemView(1, Date::Now(), Date::Now(), 1)];
+
+        $resourceIds = [1];
+
+        $this->page->ResourceGroupId = $publicId;
+
+        $this->service->expects($this->once())
+                ->method('GetResourcesInGroup')
+                ->with($this->equalTo($publicId))
+                ->willReturn($resourceIds);
+
+        $this->service->expects($this->once())
+                ->method('ResolveCalendarName')
+                ->with($this->isNull(), $this->isNull(), $this->equalTo($publicId), $this->isNull())
+                ->willReturn('Engineering Rooms');
+
+        $this->repo->expects($this->once())
+                ->method('GetReservations')
+                ->willReturn($reservationResult);
+
+        $this->presenter->PageLoad();
+
+        $this->assertEquals('Engineering Rooms', $this->page->CalendarName);
+    }
+
+    public function testGetsResourceGroupReservationsKeepsScheduleCalendarNameWhenGroupNameIsNull()
+    {
+        $publicScheduleId = '1';
+        $publicGroupId = '2';
+        $reservationResult = [new TestReservationItemView(1, Date::Now(), Date::Now(), 1)];
+
+        $scheduleId = 999;
+        $schedule = new FakeSchedule($scheduleId, 'Engineering Schedule');
+
+        $this->page->ScheduleId = $publicScheduleId;
+        $this->page->ResourceGroupId = $publicGroupId;
+
+        $this->service->expects($this->once())
+                ->method('GetSchedule')
+                ->with($this->equalTo($publicScheduleId))
+                ->willReturn($schedule);
+
+        $this->service->expects($this->once())
+                ->method('GetResourcesInGroup')
+                ->with($this->equalTo($publicGroupId))
+                ->willReturn([1]);
+
+        $this->service->expects($this->once())
+                ->method('ResolveCalendarName')
+                ->with($this->equalTo($publicScheduleId), $this->isNull(), $this->equalTo($publicGroupId), $this->isNull())
+                ->willReturn('Engineering Schedule');
+
+        $this->repo->expects($this->once())
+                ->method('GetReservations')
+                ->willReturn($reservationResult);
+
+        $this->presenter->PageLoad();
+
+        $this->assertEquals('Engineering Schedule', $this->page->CalendarName);
     }
 
     public function testPageLoadReturnsFalseAndDoesNotLoadReservationsWhenValidationFails()
@@ -215,6 +338,7 @@ class FakeCalendarSubscriptionPage implements ICalendarSubscriptionPage
     public $SubscriptionKey = '123';
     public $PastDays;
     public $FutureDays;
+    public $CalendarName;
 
     public function GetSubscriptionKey()
     {
@@ -229,6 +353,11 @@ class FakeCalendarSubscriptionPage implements ICalendarSubscriptionPage
     public function SetReservations($reservations)
     {
         $this->Reservations = $reservations;
+    }
+
+    public function SetCalendarName(string $calendarName): void
+    {
+        $this->CalendarName = $calendarName;
     }
 
     public function GetScheduleId()


### PR DESCRIPTION
Add per-subscription calendar name (schedule name, resource name, resource group name, or the current user's own calendar) and pass it to CalendarExportDisplay::Render() so subscribed calendars ics files get a readable NAME/X-WR-CALNAME instead of a generic one in calendar clients.

Assisted-by: Claude:claude-sonnet-5