### PR TITLE
fix(schedule): don't require resource permissions for anonymous label formatting

### DIFF
--- a/lib/Application/Schedule/SlotLabelFactory.php
+++ b/lib/Application/Schedule/SlotLabelFactory.php
@@ -72,7 +72,13 @@ class SlotLabelFactory
             return '';
         }
 
-        if (!in_array($reservation->ResourceId, $this->UserResourcePermissions($this->user->UserId)) && !$reservation->IsUserOwner($this->user->UserId) && !$reservation->IsUserInvited($this->user->UserId) && !$reservation->IsUserParticipating($this->user->UserId)) {
+        if (
+            $this->user->IsLoggedIn() &&
+            !in_array($reservation->ResourceId, $this->UserResourcePermissions($this->user->UserId)) &&
+            !$reservation->IsUserOwner($this->user->UserId) &&
+            !$reservation->IsUserInvited($this->user->UserId) &&
+            !$reservation->IsUserParticipating($this->user->UserId)
+        ) {
             return '';
         }
 

--- a/tests/Application/Schedule/SlotLabelFactoryTest.php
+++ b/tests/Application/Schedule/SlotLabelFactoryTest.php
@@ -168,6 +168,19 @@ class SlotLabelFactoryTest extends TestBase
         $this->assertEquals('', $label);
     }
 
+    public function testAnonymousUserSeesLabelWhenPublicViewingIsAllowed()
+    {
+        $this->SetConfig('{name} - {title}');
+        $this->fakeConfig->SetKey(ConfigKeys::PRIVACY_VIEW_RESERVATIONS, 'true');
+
+        $anonymousUser = new NullUserSession();
+        $factory = new SlotLabelFactory($anonymousUser);
+
+        $label = $factory->Format($this->reservation);
+
+        $this->assertEquals('first last - some title', $label);
+    }
+
     private function SetConfig($value)
     {
         $this->fakeConfig->SetKey(ConfigKeys::SCHEDULE_RESERVATION_LABEL, $value);


### PR DESCRIPTION
SlotLabelFactory::Format() unconditionally required the requesting user to hold resource permissions or be owner/invitee/participant before rendering a reservation label. Anonymous sessions (UserId 0) can never satisfy that check, so every anonymous label render returned an empty string.

This broke unauthenticated ICS calendar subscriptions (SUMMARY was always blank, while DESCRIPTION/ORGANIZER/LOCATION rendered fine since they bypass this factory), even though privacy.view.reservations already permits anonymous viewing and iCalendarReservationView had already computed that via its own privacy filter. The same gate is also reached by the public schedule/calendar views and the Atom feed, which deliberately pass an anonymous session when guest viewing is enabled.

Skip the resource-permission check for non-logged-in users, since anonymous access is already gated earlier in the same method by privacy.view.reservations.

Closes: #1616