### PR TITLE
fix(schedule): correct schedule style icons on mobile and table. Fix …

### DIFF
--- a/tpl/Schedule/schedule.tpl
+++ b/tpl/Schedule/schedule.tpl
@@ -95,9 +95,9 @@
                                 <a href="#"
                                     class="schedule-style me-2 d-inline-flex align-items-center{if $ScheduleStyle == ScheduleStyle::Standard->value} active{/if}"
                                     id="schedule_standard" schedule-display="{ScheduleStyle::Standard->value}"
-                                    title="{translate key='StandardScheduleDisplay'}">
-                                    <img class="schedule_icon shadow-sm" src="img/table.png"
-                                        alt="{translate key='StandardScheduleDisplay'}" />
+                                    title="{if $IsMobile && !$IsTablet}{translate key='CondensedWeekScheduleDisplay'}{else}{translate key='StandardScheduleDisplay'}{/if}">
+                                    <img class="schedule_icon shadow-sm" src="{if $IsMobile && !$IsTablet}img/table-week.png{else}img/table.png{/if}"
+                                        alt="{if $IsMobile && !$IsTablet}{translate key='CondensedWeekScheduleDisplay'}{else}{translate key='StandardScheduleDisplay'}{/if}" />
                                 </a>
                                 <a href="#"
                                     class="schedule-style me-2 d-inline-flex align-items-center{if $ScheduleStyle == ScheduleStyle::Tall->value} active{/if}"
@@ -107,14 +107,14 @@
                                         alt="{translate key='TallScheduleDisplay'}" />
                                 </a>
                                 <a href="#"
-                                    class="schedule-style d-none d-md-inline-flex me-2 align-items-center{if $ScheduleStyle == ScheduleStyle::Wide->value} active{/if}"
+                                    class="schedule-style d-none d-sm-inline-flex me-2 align-items-center{if $ScheduleStyle == ScheduleStyle::Wide->value} active{/if}"
                                     id="schedule_wide" schedule-display="{ScheduleStyle::Wide->value}"
                                     title="{translate key='WideScheduleDisplay'}">
                                     <img class="schedule_icon shadow-sm" src="img/table-wide.png"
                                         alt="{translate key='WideScheduleDisplay'}" />
                                 </a>
                                 <a href="#"
-                                    class="schedule-style d-none d-md-inline-flex align-items-center{if $ScheduleStyle == ScheduleStyle::CondensedWeek->value} active{/if}"
+                                    class="schedule-style d-none d-sm-inline-flex align-items-center{if $ScheduleStyle == ScheduleStyle::CondensedWeek->value} active{/if}"
                                     id="schedule_week" schedule-display="{ScheduleStyle::CondensedWeek->value}"
                                     title="{translate key='CondensedWeekScheduleDisplay'}">
                                     <img class="schedule_icon shadow-sm" src="img/table-week.png"

--- a/tpl/Schedule/schedule.tpl
+++ b/tpl/Schedule/schedule.tpl
@@ -106,20 +106,22 @@
                                     <img class="schedule_icon shadow-sm" src="img/table-tall.png"
                                         alt="{translate key='TallScheduleDisplay'}" />
                                 </a>
+                                {if !$IsMobile || $IsTablet}
                                 <a href="#"
-                                    class="schedule-style d-none d-sm-inline-flex me-2 align-items-center{if $ScheduleStyle == ScheduleStyle::Wide->value} active{/if}"
+                                    class="schedule-style d-inline-flex me-2 align-items-center{if $ScheduleStyle == ScheduleStyle::Wide->value} active{/if}"
                                     id="schedule_wide" schedule-display="{ScheduleStyle::Wide->value}"
                                     title="{translate key='WideScheduleDisplay'}">
                                     <img class="schedule_icon shadow-sm" src="img/table-wide.png"
                                         alt="{translate key='WideScheduleDisplay'}" />
                                 </a>
                                 <a href="#"
-                                    class="schedule-style d-none d-sm-inline-flex align-items-center{if $ScheduleStyle == ScheduleStyle::CondensedWeek->value} active{/if}"
+                                    class="schedule-style d-inline-flex align-items-center{if $ScheduleStyle == ScheduleStyle::CondensedWeek->value} active{/if}"
                                     id="schedule_week" schedule-display="{ScheduleStyle::CondensedWeek->value}"
                                     title="{translate key='CondensedWeekScheduleDisplay'}">
                                     <img class="schedule_icon shadow-sm" src="img/table-week.png"
                                         alt="{translate key='CondensedWeekScheduleDisplay'}" />
                                 </a>
+                                {/if}
                             </div>
                             {if isset($SubscriptionUrl) && $SubscriptionUrl != null && $ShowSubscription && $LoggedIn}
                                 {assign var="atomUrl" value=$SubscriptionUrl->GetAtomUrl()}


### PR DESCRIPTION
What does this PR do? This PR fixes a bug where the schedule view icons in the toolbar behaved incorrectly or disappeared on mobile devices and tablets:

On Tablets: The Wide and Condensed Week schedule icons were completely missing because they were hidden by the CSS helper classes (d-none d-md-inline-flex) for viewports smaller than 768px (which includes portrait tablets). We changed these to d-none d-sm-inline-flex so that all 4 icons are visible and usable on tablets.
On Mobile Phones: Clicking the "Standard" layout icon (the table icon) correctly loads the mobile compact template layout, but the icon itself looked like the desktop standard grid. We made the icon and tooltip dynamically switch to display the Condensed/Compact icon on mobile phones to align the visual design with the actual view that gets rendered.
How was it tested?

Verified that on desktops and tablets, all 4 icons display and reload the schedule style correctly.
Verified that on mobile phones, the 2 icons display correctly with the first one using the compact layout icon.