### PR TITLE
fix(schedule): normalize phone schedule styles

### DIFF
--- a/Pages/SchedulePage.php
+++ b/Pages/SchedulePage.php
@@ -469,6 +469,16 @@ class SchedulePage extends ActionPage implements ISchedulePage
 
     public function SetScheduleStyle(ScheduleStyle $style): void
     {
+        // Phones render schedule-mobile.tpl for every style except Tall, and that
+        // template is the Standard layout. Keep the effective style aligned with
+        // the template that is actually rendered so that the active style control
+        // and the scheduleStyle passed to schedule.js both describe it. The stored
+        // cookie is deliberately left alone so a style chosen on a desktop is
+        // still there when the user returns in desktop mode.
+        if ($this->IsMobile && !$this->IsTablet && $style !== ScheduleStyle::Tall) {
+            $style = ScheduleStyle::Standard;
+        }
+
         $this->ScheduleStyle = $style;
         $this->Set('CookieName', 'schedule-style-' . $this->GetVar('ScheduleId'));
         $this->Set('ScheduleStyle', $style->value);

--- a/tests/Pages/SchedulePageTest.php
+++ b/tests/Pages/SchedulePageTest.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+require_once(ROOT_DIR . 'Pages/SchedulePage.php');
+
+use PHPUnit\Framework\Attributes\DataProvider;
+
+/**
+ * A phone renders schedule-mobile.tpl for every style except Tall, so the
+ * effective style has to be normalized to Standard. Otherwise the toolbar marks
+ * no control active and schedule.js takes rendering paths that do not match the
+ * template that was emitted.
+ */
+class SchedulePageTest extends TestBase
+{
+    public const SCHEDULE_ID = 1;
+
+    #[DataProvider('phoneStyles')]
+    public function testNormalizesNonTallStylesToStandardOnAPhone(
+        ScheduleStyle $selected,
+        ScheduleStyle $expected
+    ): void {
+        $page = new TestableSchedulePage(isMobile: true, isTablet: false);
+
+        $page->SetScheduleStyle($selected);
+
+        $this->assertSame($expected, $page->EffectiveScheduleStyle());
+        $this->assertSame($expected->value, $page->AssignedValue('ScheduleStyle'));
+    }
+
+    #[DataProvider('allStyles')]
+    public function testPreservesTheSelectedStyleOnATablet(ScheduleStyle $selected): void
+    {
+        $page = new TestableSchedulePage(isMobile: true, isTablet: true);
+
+        $page->SetScheduleStyle($selected);
+
+        $this->assertSame($selected, $page->EffectiveScheduleStyle());
+        $this->assertSame($selected->value, $page->AssignedValue('ScheduleStyle'));
+    }
+
+    #[DataProvider('allStyles')]
+    public function testPreservesTheSelectedStyleOnADesktop(ScheduleStyle $selected): void
+    {
+        $page = new TestableSchedulePage(isMobile: false, isTablet: false);
+
+        $page->SetScheduleStyle($selected);
+
+        $this->assertSame($selected, $page->EffectiveScheduleStyle());
+        $this->assertSame($selected->value, $page->AssignedValue('ScheduleStyle'));
+    }
+
+    public function testKeepsTheCookieNameTiedToTheSchedule(): void
+    {
+        $page = new TestableSchedulePage(isMobile: true, isTablet: false);
+
+        $page->SetScheduleStyle(ScheduleStyle::Wide);
+
+        $this->assertSame(
+            'schedule-style-' . self::SCHEDULE_ID,
+            $page->AssignedValue('CookieName')
+        );
+    }
+
+    /**
+     * @return array<string, array{0:ScheduleStyle, 1:ScheduleStyle}>
+     */
+    public static function phoneStyles(): array
+    {
+        return [
+            'standard is left alone' => [ScheduleStyle::Standard, ScheduleStyle::Standard],
+            'wide becomes standard' => [ScheduleStyle::Wide, ScheduleStyle::Standard],
+            'condensed week becomes standard' => [ScheduleStyle::CondensedWeek, ScheduleStyle::Standard],
+            'tall is preserved' => [ScheduleStyle::Tall, ScheduleStyle::Tall],
+        ];
+    }
+
+    /**
+     * @return array<string, array{0:ScheduleStyle}>
+     */
+    public static function allStyles(): array
+    {
+        return [
+            'standard' => [ScheduleStyle::Standard],
+            'wide' => [ScheduleStyle::Wide],
+            'tall' => [ScheduleStyle::Tall],
+            'condensed week' => [ScheduleStyle::CondensedWeek],
+        ];
+    }
+}
+
+/**
+ * SchedulePage's constructor builds a large graph of repositories and services,
+ * so it is deliberately not called here. Set() and GetVar() are overridden to
+ * keep Smarty out of the test.
+ */
+class TestableSchedulePage extends SchedulePage
+{
+    /** @var array<string, mixed> */
+    private array $assigned = [];
+
+    public function __construct(bool $isMobile, bool $isTablet)
+    {
+        $this->IsMobile = $isMobile;
+        $this->IsTablet = $isTablet;
+    }
+
+    public function Set($var, $value)
+    {
+        $this->assigned[$var] = $value;
+    }
+
+    public function AssignedValue(string $var): mixed
+    {
+        return $this->assigned[$var] ?? null;
+    }
+
+    public function EffectiveScheduleStyle(): ScheduleStyle
+    {
+        return $this->ScheduleStyle;
+    }
+
+    protected function GetVar($var)
+    {
+        return $var === 'ScheduleId' ? (string) SchedulePageTest::SCHEDULE_ID : '';
+    }
+}


### PR DESCRIPTION
Phones render schedule-mobile.tpl for every style except Tall, but the selected style was still passed to Smarty and schedule.js unchanged, so the reported style could describe a template that was never rendered.

With Wide, schedule.js positions reservations using the desktop grid inside a template that has no grid. With Condensed Week it skips Standard-only layout adjustments. In both cases no style control shows as active, since neither control is in the DOM on phones. A schedule whose default style is Wide hits this on every phone visit, so no stale cookie is needed to reproduce it.

Normalize any non-Tall style to Standard on phones in SetScheduleStyle(). Tall is preserved because it genuinely renders a different template, and ViewSchedulePage inherits the method, so both entry points are covered. The style cookie is left untouched so a desktop choice survives a phone visit.

Add tests/Pages/SchedulePageTest.php covering all four styles across phone, tablet and desktop.

Refs: #1600
Assisted-by: Claude:claude-opus-5