### PR TITLE
fix(schedule): remove empty query strings

### DIFF
--- a/lib/Application/Schedule/CalendarSubscriptionUrl.php
+++ b/lib/Application/Schedule/CalendarSubscriptionUrl.php
@@ -23,9 +23,15 @@ class CalendarSubscriptionUrl
         $scriptUrl .= '/export/' . self::PAGE_TOKEN;
         $url = new Url($scriptUrl);
 
-        $url->AddQueryString(QueryStringKeys::USER_ID, $userPublicId);
-        $url->AddQueryString(QueryStringKeys::SCHEDULE_ID, $schedulePublicId);
-        $url->AddQueryString(QueryStringKeys::RESOURCE_ID, $resourcePublicId);
+        if (!empty($userPublicId)) {
+            $url->AddQueryString(QueryStringKeys::USER_ID, $userPublicId);
+        }
+        if (!empty($schedulePublicId)) {
+            $url->AddQueryString(QueryStringKeys::SCHEDULE_ID, $schedulePublicId);
+        }
+        if (!empty($resourcePublicId)) {
+            $url->AddQueryString(QueryStringKeys::RESOURCE_ID, $resourcePublicId);
+        }
         $url->AddQueryString(QueryStringKeys::SUBSCRIPTION_KEY, $subscriptionKey);
         $this->url = $url;
     }

--- a/tests/Application/Schedule/CalendarSubscriptionUrlTest.php
+++ b/tests/Application/Schedule/CalendarSubscriptionUrlTest.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+require_once(ROOT_DIR . 'lib/Application/Schedule/namespace.php');
+
+class CalendarSubscriptionUrlTest extends TestBase
+{
+    public function setUp(): void
+    {
+        parent::setup();
+
+        $this->fakeConfig->SetKey(ConfigKeys::ICS_SUBSCRIPTION_KEY, 'thekey');
+    }
+
+    public function testOnlyIncludesQueryStringForIdsThatWereProvided()
+    {
+        $url = new CalendarSubscriptionUrl(null, 'scheduleId', null);
+
+        $webcalUrl = $url->GetWebcalUrl();
+
+        $this->assertStringContainsString('sid=scheduleId', $webcalUrl);
+        $this->assertStringNotContainsString('uid=', $webcalUrl);
+        $this->assertStringNotContainsString('rid=', $webcalUrl);
+    }
+
+    public function testIncludesAllProvidedIds()
+    {
+        $url = new CalendarSubscriptionUrl('userId', 'scheduleId', 'resourceId');
+
+        $webcalUrl = $url->GetWebcalUrl();
+
+        $this->assertStringContainsString('uid=userId', $webcalUrl);
+        $this->assertStringContainsString('sid=scheduleId', $webcalUrl);
+        $this->assertStringContainsString('rid=resourceId', $webcalUrl);
+    }
+
+    public function testOnlyIncludesResourceIdWhenScheduleAndUserAreOmitted()
+    {
+        $url = new CalendarSubscriptionUrl(null, null, 'resourceId');
+
+        $webcalUrl = $url->GetWebcalUrl();
+
+        $this->assertStringContainsString('rid=resourceId', $webcalUrl);
+        $this->assertStringNotContainsString('uid=', $webcalUrl);
+        $this->assertStringNotContainsString('sid=', $webcalUrl);
+    }
+
+    public function testOnlyIncludesUserIdWhenScheduleAndResourceAreOmitted()
+    {
+        $url = new CalendarSubscriptionUrl('userId', null, null);
+
+        $webcalUrl = $url->GetWebcalUrl();
+
+        $this->assertStringContainsString('uid=userId', $webcalUrl);
+        $this->assertStringNotContainsString('sid=', $webcalUrl);
+        $this->assertStringNotContainsString('rid=', $webcalUrl);
+    }
+
+    public function testTreatsEmptyStringIdsTheSameAsNull()
+    {
+        $url = new CalendarSubscriptionUrl('', '', '');
+
+        $webcalUrl = $url->GetWebcalUrl();
+
+        $this->assertStringNotContainsString('uid=', $webcalUrl);
+        $this->assertStringNotContainsString('sid=', $webcalUrl);
+        $this->assertStringNotContainsString('rid=', $webcalUrl);
+    }
+}


### PR DESCRIPTION
This pull request updates the `CalendarSubscriptionUrl` class to only include query string parameters for IDs that are actually provided, and adds tests to verify this behavior.

**Conditional query string parameter inclusion:**

* Updated the `__construct` method in `CalendarSubscriptionUrl` to only add `userPublicId`, `schedulePublicId`, and `resourcePublicId` to the query string if they are not empty.

**Test coverage improvements:**

* Added `CalendarSubscriptionUrlTest` to verify that only provided IDs are included in the generated URL, and that all provided IDs appear as expected.