### PR TITLE
fix(calendar): disable subscription link during loading

### DIFF
--- a/Web/css/librebooking.css
+++ b/Web/css/librebooking.css
@@ -149,6 +149,11 @@ fieldset:disabled .btn {
   border-color: var(--primary-disabled);
 }
 
+a.disabled {
+  pointer-events: none;
+  opacity: 0.5;
+}
+
 .link-primary {
   color: var(--primary) !important;
   text-decoration: none;

--- a/Web/scripts/calendar.js
+++ b/Web/scripts/calendar.js
@@ -455,8 +455,20 @@ function Calendar(opts) {
     var url = _options.getSubscriptionUrl + '&rid=' + rid + '&sid=' + sid + '&gid=' + gid;
     ajaxGet(
       url,
-      function () {},
+      function () {
+        // Disable the link while it may still reflect the previous filter selection.
+        // The href and inline onclick are dropped as well: pointer-events: none only
+        // blocks the mouse, so a focused link could otherwise still be activated with
+        // the keyboard and copy the stale subscription URL to the clipboard.
+        $('#subscribeToCalendar')
+          .addClass('disabled')
+          .attr('aria-disabled', 'true')
+          .removeAttr('onclick')
+          .removeAttr('href');
+      },
       function (response) {
+        // Re-enabling happens by replacement: the link lives inside #calendarSubscription
+        // and is rendered fresh, enabled, and carrying the current filter's URL.
         $('#calendarSubscription').html(response);
       }
     );


### PR DESCRIPTION
This pull request improves the user experience when subscribing to the calendar by disabling the "Subscribe to Calendar" link while a new subscription request is being processed. This prevents users from making duplicate requests or interacting with the link during loading.