### PR TITLE
feat(ics): fix ICS subscription key generation if empty

### DIFF
--- a/Presenters/Admin/ManageConfigurationPresenter.php
+++ b/Presenters/Admin/ManageConfigurationPresenter.php
@@ -224,6 +224,10 @@ class ManageConfigurationPresenter extends ActionPresenter
             }
         }
 
+        if (!$isPluginConfig) {
+            $mergedSettings = $this->EnableIcsSubscriptionIfNeeded($mergedSettings);
+        }
+
         Log::Debug('Saving %s settings', count($configSettings));
 
         // WriteSettings will handle the proper nesting based on file type
@@ -240,6 +244,42 @@ class ManageConfigurationPresenter extends ActionPresenter
         $command = new AdHocCommand('update users set homepageid = @homepageid');
         $command->AddParameter(new Parameter(ParameterNames::HOMEPAGE_ID, $homepageId));
         ServiceLocator::GetDatabase()->Execute($command);
+    }
+
+    /**
+     * Generates and stores an ICS subscription key when the admin enables ICS
+     * through this settings page without setting a key, so subscription links
+     * do not remain broken until an unrelated schedule/resource/user toggle
+     * triggers key generation.
+     *
+     * @param array $mergedSettings
+     * @return array
+     */
+    private function EnableIcsSubscriptionIfNeeded(array $mergedSettings): array
+    {
+        if (!isset($mergedSettings['ics']) || !is_array($mergedSettings['ics'])) {
+            return $mergedSettings;
+        }
+
+        if (ConfigKeys::hasEnv(ConfigKeys::ICS_SUBSCRIPTION_KEY)) {
+            return $mergedSettings;
+        }
+
+        $icsEnabled = filter_var(
+            $mergedSettings['ics']['enabled'] ?? ConfigKeys::ICS_ENABLED['default'],
+            FILTER_VALIDATE_BOOLEAN
+        );
+
+        $newKey = ConfigurationFile::GenerateSubscriptionKeyIfNeeded(
+            $icsEnabled,
+            $mergedSettings['ics']['subscription.key'] ?? ''
+        );
+
+        if ($newKey !== null) {
+            $mergedSettings['ics']['subscription.key'] = $newKey;
+        }
+
+        return $mergedSettings;
     }
 
     private function ShouldBeSkipped(string $key, ?ConfigKey $meta): bool

--- a/lib/Config/Configuration.php
+++ b/lib/Config/Configuration.php
@@ -63,10 +63,11 @@ interface IConfigurationFile
     public function GetAdminEmail();
 
     /**
-     * Enables ics subscriptionwith a random key if no key is set.
+     * Enables ics subscription with a random key if no key is set.
+     * @param string|null $configFilePath Path to rewrite; defaults to the live config file.
      * @return void
      */
-    public function EnableSubscription();
+    public function EnableSubscription(?string $configFilePath = null);
 }
 
 /**
@@ -262,11 +263,12 @@ class Configuration implements IConfiguration
 
     /**
      * Enables ICS subscription with a random key if no key is set.
+     * @param string|null $configFilePath Path to rewrite; defaults to the live config file.
      * @return void
      */
-    public function EnableSubscription()
+    public function EnableSubscription(?string $configFilePath = null)
     {
-        $this->File(self::DEFAULT_CONFIG_ID)->EnableSubscription();
+        $this->File(self::DEFAULT_CONFIG_ID)->EnableSubscription($configFilePath);
     }
 
     /**
@@ -679,23 +681,72 @@ class ConfigurationFile implements IConfigurationFile
      * This method updates the configuration file to include a new ICS subscription key.
      * If the key already exists, it does nothing.
      *
+     * @param string|null $configFilePath Path to rewrite; defaults to the live config file.
      * @return void
      */
-    public function EnableSubscription()
+    public function EnableSubscription(?string $configFilePath = null)
     {
-        $icsKey = $this->GetKey(ConfigKeys::ICS_SUBSCRIPTION_KEY);
-        if (!empty($icsKey)) {
+        $newKey = self::GenerateSubscriptionKeyIfNeeded(
+            $this->GetKey(ConfigKeys::ICS_ENABLED, new BooleanConverter()),
+            $this->GetKey(ConfigKeys::ICS_SUBSCRIPTION_KEY)
+        );
+
+        if ($newKey === null) {
             return;
         }
 
-        $configFile = ROOT_DIR . 'config/config.php';
+        $configFilePath ??= ROOT_DIR . 'config/config.php';
 
-        if (file_exists($configFile)) {
-            $newKey = '$conf[\'settings\'][\'ics\'][\'subscription.key\'] = \'' . BookedStringHelper::Random(20) . '\';';
-            $str = file_get_contents($configFile);
-            $str = str_replace('$conf[\'settings\'][\'ics\'][\'subscription.key\'] = \'\';', $newKey, $str);
-            file_put_contents($configFile, $str);
-            Configuration::SetInstance(null);
+        if (!is_readable($configFilePath)) {
+            return;
         }
+
+        $contents = file_get_contents($configFilePath);
+
+        if ($contents === false) {
+            return;
+        }
+
+        // Matches the current `'subscription.key' => '',` nested-array entry.
+        $updated = preg_replace(
+            '/([\'"]subscription\.key[\'"]\s*=>\s*)([\'"])\2/',
+            '${1}${2}' . $newKey . '${2}',
+            $contents,
+            1,
+            $count
+        );
+
+        if ($updated === null || $count === 0) {
+            return;
+        }
+
+        // Checking is_writable() first keeps the common read-only-config case from
+        // emitting a warning, but the return value still has to be checked because
+        // the write can fail for reasons the check cannot see.
+        if (!is_writable($configFilePath) || file_put_contents($configFilePath, $updated) === false) {
+            Log::Error('Could not write the generated ICS subscription key to %s', $configFilePath);
+            return;
+        }
+
+        Configuration::SetInstance(null);
+    }
+
+    /**
+     * Shared gate for ICS subscription key generation: returns a freshly generated
+     * key when ICS is enabled and no key is set yet, or null when nothing should change.
+     * Used both here (patching the live config file) and by ManageConfigurationPresenter
+     * (patching the in-memory settings array before it writes the config file).
+     *
+     * @param bool $icsEnabled
+     * @param string|null $existingKey
+     * @return string|null
+     */
+    public static function GenerateSubscriptionKeyIfNeeded(bool $icsEnabled, ?string $existingKey): ?string
+    {
+        if (!$icsEnabled || !empty($existingKey)) {
+            return null;
+        }
+
+        return BookedStringHelper::Random(32);
     }
 }

--- a/tests/Infrastructure/Config/EnableSubscriptionTest.php
+++ b/tests/Infrastructure/Config/EnableSubscriptionTest.php
@@ -1,0 +1,256 @@
+<?php
+
+declare(strict_types=1);
+
+require_once(ROOT_DIR . 'lib/Config/namespace.php');
+
+class EnableSubscriptionTest extends TestBase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        Configuration::SetInstance(null);
+    }
+
+    public function testGeneratesKeyWhenIcsEnabledAndKeyEmptyInCurrentNestedFormat(): void
+    {
+        $path = $this->writeTempConfig(
+            <<<'PHP'
+<?php
+return [
+    'settings' => [
+        'ics' => [
+            'enabled' => true,
+            'subscription.key' => '',
+        ],
+    ],
+];
+PHP
+        );
+
+        try {
+            $config = $this->loadConfigurationFile($path);
+            $config->EnableSubscription($path);
+
+            $reloaded = $this->loadConfigurationFile($path);
+            $newKey = $reloaded->GetKey(ConfigKeys::ICS_SUBSCRIPTION_KEY);
+
+            $this->assertNotEmpty($newKey, 'Subscription key should have been generated');
+            $this->assertStringNotContainsString(
+                "'subscription.key' => '',",
+                file_get_contents($path),
+                'Placeholder empty key should have been replaced'
+            );
+        } finally {
+            unlink($path);
+        }
+    }
+
+    public function testGeneratesKeyAgainstRealConfigDistTemplate(): void
+    {
+        $path = $this->copyConfigDistTemplate();
+
+        try {
+            $config = $this->loadConfigurationFile($path);
+            $config->EnableSubscription($path);
+
+            $reloaded = $this->loadConfigurationFile($path);
+            $newKey = $reloaded->GetKey(ConfigKeys::ICS_SUBSCRIPTION_KEY);
+
+            $this->assertNotEmpty(
+                $newKey,
+                'Subscription key should have been generated against the real config.dist.php template'
+            );
+            $this->assertStringNotContainsString(
+                "'subscription.key' => '',",
+                file_get_contents($path),
+                'Placeholder empty key should have been replaced in config.dist.php'
+            );
+        } finally {
+            unlink($path);
+        }
+    }
+
+    public function testDoesNothingWhenIcsIsDisabled(): void
+    {
+        $path = $this->writeTempConfig(
+            <<<'PHP'
+<?php
+return [
+    'settings' => [
+        'ics' => [
+            'enabled' => false,
+            'subscription.key' => '',
+        ],
+    ],
+];
+PHP
+        );
+
+        try {
+            $before = file_get_contents($path);
+
+            $config = $this->loadConfigurationFile($path);
+            $config->EnableSubscription($path);
+
+            $this->assertSame($before, file_get_contents($path), 'Config file should not change when ICS is disabled');
+        } finally {
+            unlink($path);
+        }
+    }
+
+    public function testDoesNothingWhenConfigFileIsUnreadable(): void
+    {
+        if (!function_exists('posix_getuid') || posix_getuid() === 0) {
+            $this->markTestSkipped('File permissions are not enforced when running as root.');
+        }
+
+        $path = $this->writeTempConfig(
+            <<<'PHP'
+<?php
+return [
+    'settings' => [
+        'ics' => [
+            'enabled' => true,
+            'subscription.key' => '',
+        ],
+    ],
+];
+PHP
+        );
+
+        try {
+            $config = $this->loadConfigurationFile($path);
+
+            chmod($path, 0000);
+            $config->EnableSubscription($path);
+            chmod($path, 0644);
+
+            $this->assertStringContainsString(
+                "'subscription.key' => '',",
+                file_get_contents($path),
+                'Config file should be left untouched when it cannot be read'
+            );
+        } finally {
+            chmod($path, 0644);
+            unlink($path);
+        }
+    }
+
+    public function testKeepsTheLoadedConfigurationWhenTheConfigFileIsNotWritable(): void
+    {
+        if (!function_exists('posix_getuid') || posix_getuid() === 0) {
+            $this->markTestSkipped('File permissions are not enforced when running as root.');
+        }
+
+        $path = $this->writeTempConfig(
+            <<<'PHP'
+<?php
+return [
+    'settings' => [
+        'ics' => [
+            'enabled' => true,
+            'subscription.key' => '',
+        ],
+    ],
+];
+PHP
+        );
+
+        try {
+            $config = $this->loadConfigurationFile($path);
+            $instance = Configuration::Instance();
+
+            chmod($path, 0444);
+            $config->EnableSubscription($path);
+            chmod($path, 0644);
+
+            $this->assertStringContainsString(
+                "'subscription.key' => '',",
+                file_get_contents($path),
+                'Config file should be left untouched when it cannot be written'
+            );
+            $this->assertSame(
+                $instance,
+                Configuration::Instance(),
+                'Cached configuration should be kept when the generated key could not be persisted'
+            );
+        } finally {
+            chmod($path, 0644);
+            unlink($path);
+        }
+    }
+
+    public function testDoesNothingWhenKeyIsAlreadySet(): void
+    {
+        $path = $this->writeTempConfig(
+            <<<'PHP'
+<?php
+return [
+    'settings' => [
+        'ics' => [
+            'enabled' => true,
+            'subscription.key' => 'already-set-key',
+        ],
+    ],
+];
+PHP
+        );
+
+        try {
+            $before = file_get_contents($path);
+
+            $config = $this->loadConfigurationFile($path);
+            $config->EnableSubscription($path);
+
+            $this->assertSame($before, file_get_contents($path), 'Config file should not change when a key is already set');
+        } finally {
+            unlink($path);
+        }
+    }
+
+    private function copyConfigDistTemplate(): string
+    {
+        $path = tempnam(sys_get_temp_dir(), 'enable-subscription-test-');
+        if ($path === false) {
+            throw new RuntimeException('Failed to create temporary config file.');
+        }
+
+        if (!copy(ROOT_DIR . 'config/config.dist.php', $path)) {
+            throw new RuntimeException('Failed to copy config.dist.php to temporary path.');
+        }
+
+        return $path;
+    }
+
+    private function writeTempConfig(string $contents): string
+    {
+        $path = tempnam(sys_get_temp_dir(), 'enable-subscription-test-');
+        if ($path === false) {
+            throw new RuntimeException('Failed to create temporary config file.');
+        }
+
+        if (file_put_contents($path, $contents) === false) {
+            throw new RuntimeException('Failed to write temporary config file.');
+        }
+
+        return $path;
+    }
+
+    private function loadConfigurationFile(string $path): ConfigurationFile
+    {
+        $conf = [];
+        $loaded = require $path;
+
+        if (is_array($loaded) && isset($loaded['settings'])) {
+            return new ConfigurationFile($loaded);
+        }
+
+        if (isset($conf['settings'])) {
+            return new ConfigurationFile([Configuration::SETTINGS => $conf['settings']]);
+        }
+
+        throw new RuntimeException("Invalid config file: 'settings' section missing");
+    }
+}

--- a/tests/Presenters/Admin/ManageConfigurationPresenterTest.php
+++ b/tests/Presenters/Admin/ManageConfigurationPresenterTest.php
@@ -131,6 +131,82 @@ class ManageConfigurationPresenterTest extends TestBase
 
         $this->presenter->Update();
     }
+
+    public function testGeneratesIcsSubscriptionKeyWhenEnablingIcsWithoutExistingKey()
+    {
+        $this->page->_SubmittedSettings = [ConfigSetting::ParseForm('enabled|ics', 'true')];
+
+        $this->configSettings->method('GetSettings')->willReturn([]);
+        $this->configSettings->method('BuildConfig')->willReturn([
+            'ics' => ['enabled' => 'true', 'subscription.key' => ''],
+        ]);
+
+        $writtenSettings = null;
+        $this->configSettings->expects($this->once())
+                ->method('WriteSettings')
+                ->with(
+                    $this->equalTo($this->configFilePath),
+                    $this->callback(function ($settings) use (&$writtenSettings) {
+                        $writtenSettings = $settings;
+                        return true;
+                    })
+                );
+
+        $this->presenter->Update();
+
+        $this->assertNotEmpty($writtenSettings['ics']['subscription.key']);
+    }
+
+    public function testDoesNotOverwriteExistingIcsSubscriptionKeyWhenEnablingIcs()
+    {
+        $this->page->_SubmittedSettings = [ConfigSetting::ParseForm('enabled|ics', 'true')];
+
+        $this->configSettings->method('GetSettings')->willReturn([]);
+        $this->configSettings->method('BuildConfig')->willReturn([
+            'ics' => ['enabled' => 'true', 'subscription.key' => 'already-set-key'],
+        ]);
+
+        $writtenSettings = null;
+        $this->configSettings->expects($this->once())
+                ->method('WriteSettings')
+                ->with(
+                    $this->equalTo($this->configFilePath),
+                    $this->callback(function ($settings) use (&$writtenSettings) {
+                        $writtenSettings = $settings;
+                        return true;
+                    })
+                );
+
+        $this->presenter->Update();
+
+        $this->assertSame('already-set-key', $writtenSettings['ics']['subscription.key']);
+    }
+
+    public function testDoesNotGenerateIcsSubscriptionKeyWhenIcsRemainsDisabled()
+    {
+        $this->page->_SubmittedSettings = [ConfigSetting::ParseForm('enabled|ics', 'false')];
+
+        $this->configSettings->method('GetSettings')->willReturn([]);
+        $this->configSettings->method('BuildConfig')->willReturn([
+            'ics' => ['enabled' => 'false', 'subscription.key' => ''],
+        ]);
+
+        $writtenSettings = null;
+        $this->configSettings->expects($this->once())
+                ->method('WriteSettings')
+                ->with(
+                    $this->equalTo($this->configFilePath),
+                    $this->callback(function ($settings) use (&$writtenSettings) {
+                        $writtenSettings = $settings;
+                        return true;
+                    })
+                );
+
+        $this->presenter->Update();
+
+        $this->assertSame('', $writtenSettings['ics']['subscription.key']);
+    }
+
     private function getDefaultConfigValues()
     {
         $configFile = realpath(ROOT_DIR . 'config/config.dist.php');

--- a/tests/fakes/FakeConfig.php
+++ b/tests/fakes/FakeConfig.php
@@ -39,7 +39,7 @@ class FakeConfig extends Configuration implements IConfiguration
         return $this->_ScriptUrl;
     }
 
-    public function EnableSubscription()
+    public function EnableSubscription(?string $configFilePath = null)
     {
     }
 
@@ -148,7 +148,7 @@ class FakeConfigFile extends ConfigurationFile implements IConfigurationFile
         return $this->_values;
     }
 
-    public function EnableSubscription()
+    public function EnableSubscription(?string $configFilePath = null)
     {
     }
 }


### PR DESCRIPTION
This pull request improves the reliability and robustness of ICS (iCalendar) subscription key management in the application's configuration system. It ensures that when ICS subscriptions are enabled via the admin interface, a subscription key is automatically generated if one does not already exist, preventing broken subscription links. The changes also refactor and centralize the logic for generating the subscription key, and add comprehensive tests to verify correct behavior in various scenarios.

Key changes include:

### ICS Subscription Key Generation and Management

* Added a new private method `EnableIcsSubscriptionIfNeeded` in `ManageConfigurationPresenter.php` to automatically generate and inject an ICS subscription key into the settings array when ICS is enabled and no key is set, ensuring the key is always present when needed. [[1]](diffhunk://#diff-da3b7736ce68acb8149905fa05bb1bdd951a62bb433abdb47aaf77a0f0339debR227-R230) [[2]](diffhunk://#diff-da3b7736ce68acb8149905fa05bb1bdd951a62bb433abdb47aaf77a0f0339debR249-R280)
* Refactored `Configuration::EnableSubscription` and `ConfigurationFile::EnableSubscription` to accept an optional config file path, and to use a new static method `GenerateSubscriptionKeyIfNeeded` for consistent key generation logic. The key is now generated only if ICS is enabled and no key is set, and the config file is updated in-place using a regex replacement. [[1]](diffhunk://#diff-596cae96f35bfd2bdcdf597f59ce8761b2c204cd9e39bb02c74da5df52f30a55R265-R270) [[2]](diffhunk://#diff-596cae96f35bfd2bdcdf597f59ce8761b2c204cd9e39bb02c74da5df52f30a55R683-R736)
* Added the static method `GenerateSubscriptionKeyIfNeeded` to centralize the key generation logic and ensure consistent behavior across the codebase.

### Testing Improvements

* Added a new test class `EnableSubscriptionTest` to verify that the ICS subscription key is generated only when ICS is enabled and the key is empty, and that the config file is not modified in other cases (ICS disabled or key already set).
* Enhanced `ManageConfigurationPresenterTest` with tests to verify that the presenter generates a subscription key only when appropriate, and does not overwrite an existing key or generate a key when ICS is disabled.
* Updated `FakeConfig` to match the new method signature for `EnableSubscription`. [[1]](diffhunk://#diff-222b761c1c97f2e74e1e0898468e7b43e1aad1a931869d1fcdf69a79f0364253L42-R42) [[2]](diffhunk://#diff-222b761c1c97f2e74e1e0898468e7b43e1aad1a931869d1fcdf69a79f0364253L151-R151)