### PR TITLE
fix(email): clear attachments before each send to stop them leaking

### DIFF
--- a/lib/Email/EmailService.php
+++ b/lib/Email/EmailService.php
@@ -45,6 +45,7 @@ class EmailService implements IEmailService
     {
         $this->phpMailer->clearAllRecipients();
         $this->phpMailer->clearReplyTos();
+        $this->phpMailer->clearAttachments();
         $this->phpMailer->CharSet = $emailMessage->Charset();
         $this->phpMailer->Subject = $emailMessage->Subject();
         $this->phpMailer->Body = $emailMessage->Body();

--- a/tests/fakes/FakeEmailMessage.php
+++ b/tests/fakes/FakeEmailMessage.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+class FakeEmailMessage implements IEmailMessage
+{
+    public $_Charset = 'UTF-8';
+    public $_To = [];
+    public $_From;
+    public $_CC = [];
+    public $_BCC = [];
+    public $_Subject = '';
+    public $_Body = '';
+    public $_ReplyTo;
+    public $_AttachmentContents;
+    public $_AttachmentFileName;
+
+    public function __construct()
+    {
+        $this->_From = new EmailAddress('from@example.com', 'From');
+        $this->_ReplyTo = new EmailAddress('replyto@example.com', 'ReplyTo');
+    }
+
+    public function Charset()
+    {
+        return $this->_Charset;
+    }
+
+    public function To()
+    {
+        return $this->_To;
+    }
+
+    public function From()
+    {
+        return $this->_From;
+    }
+
+    public function CC()
+    {
+        return $this->_CC;
+    }
+
+    public function BCC()
+    {
+        return $this->_BCC;
+    }
+
+    public function Subject()
+    {
+        return $this->_Subject;
+    }
+
+    public function Body()
+    {
+        return $this->_Body;
+    }
+
+    public function ReplyTo()
+    {
+        return $this->_ReplyTo;
+    }
+
+    public function AddStringAttachment($contents, $fileName)
+    {
+        $this->_AttachmentContents = $contents;
+        $this->_AttachmentFileName = $fileName;
+    }
+
+    public function HasStringAttachment()
+    {
+        return !empty($this->_AttachmentContents);
+    }
+
+    public function AttachmentContents()
+    {
+        return $this->_AttachmentContents;
+    }
+
+    public function AttachmentFileName()
+    {
+        return $this->_AttachmentFileName;
+    }
+}

--- a/tests/fakes/namespace.php
+++ b/tests/fakes/namespace.php
@@ -28,6 +28,7 @@ require_once(ROOT_DIR . 'tests/fakes/TestCustomAttribute.php');
 require_once(ROOT_DIR . 'tests/fakes/TestDateRange.php');
 require_once(ROOT_DIR . 'tests/fakes/TestReservation.php');
 require_once(ROOT_DIR . 'tests/fakes/TestReservationSeries.php');
+require_once(ROOT_DIR . 'tests/fakes/FakeEmailMessage.php');
 require_once(ROOT_DIR . 'tests/fakes/FakePluginManager.php');
 require_once(ROOT_DIR . 'tests/fakes/FakeRegistrationPage.php');
 require_once(ROOT_DIR . 'tests/fakes/FakeActivation.php');

--- a/tests/lib/Email/EmailServiceTest.php
+++ b/tests/lib/Email/EmailServiceTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+require_once(ROOT_DIR . 'lib/Email/EmailService.php');
+
+class EmailServiceTest extends TestBase
+{
+    public function setUp(): void
+    {
+        parent::setup();
+    }
+
+    public function teardown(): void
+    {
+        parent::teardown();
+    }
+
+    public function testAttachmentsAreClearedBeforeEachSendToPreventLeakingIntoSubsequentEmails()
+    {
+        $phpMailer = $this->createMock('PHPMailer\PHPMailer\PHPMailer');
+
+        $attachments = [];
+        $attachmentsAtSend = [];
+
+        $phpMailer->expects($this->exactly(2))
+            ->method('clearAttachments')
+            ->willReturnCallback(function () use (&$attachments) {
+                $attachments = [];
+            });
+
+        $phpMailer->expects($this->exactly(2))
+            ->method('addStringAttachment')
+            ->willReturnCallback(function ($contents, $fileName) use (&$attachments) {
+                $attachments[] = $fileName;
+            });
+
+        $phpMailer->expects($this->exactly(2))
+            ->method('send')
+            ->willReturnCallback(function () use (&$attachments, &$attachmentsAtSend) {
+                $attachmentsAtSend[] = $attachments;
+                return true;
+            });
+
+        $message1 = new FakeEmailMessage();
+        $message1->AddStringAttachment('first attachment', 'first.ics');
+
+        $message2 = new FakeEmailMessage();
+        $message2->AddStringAttachment('second attachment', 'second.ics');
+
+        $service = new EmailService($phpMailer);
+        $service->Send($message1);
+        $service->Send($message2);
+
+        $this->assertEquals(
+            [['first.ics'], ['second.ics']],
+            $attachmentsAtSend,
+            'Each send() should see only the attachment for its own message, proving clearAttachments() ran before addStringAttachment() each time.'
+        );
+    }
+}


### PR DESCRIPTION
ServiceLocator::GetEmailService(): PHPMailer  Send() already clears recipients and reply-tos before each message but never called clearAttachments(), so PHPMailer's internal attachment list persisted across sends. A reservation-creation notification burst (owner, admins, participants, invitees, guests) sends several emails through that same instance, so each subsequent email inherited every prior message's attachment on top of its own.

Add a generic FakeEmailMessage and EmailServiceTest proving EmailService::Send() clears PHPMailer's attachment list before each message, so a second Send() on the same instance doesn't inherit the first message's attachment.

Assisted-by: Claude:claude-sonnet-4-6