### PR TITLE
fix(accessory): fix exceeded max_input_vars (default 1000) error on '…

### DIFF
--- a/Web/scripts/admin/accessory.js
+++ b/Web/scripts/admin/accessory.js
@@ -99,7 +99,11 @@ function AccessoryManagement(opts) {
 
   function handleAccessoryResourceClick(checkbox) {
     var quantities = checkbox.closest('div[resource-id]').find('.quantities');
+    var accMin = checkbox.closest('div[resource-id]').find('#acc_min');
+    var accMax = checkbox.closest('div[resource-id]').find('#acc_max');
 
+    accMin.attr('disabled', false);
+    accMax.attr('disabled', false);
     if (checkbox.is(':checked')) {
       quantities.removeClass('show');
     } else {
@@ -128,8 +132,12 @@ function AccessoryManagement(opts) {
 
         handleAccessoryResourceClick(checkbox);
 
-        div.find('[data-type="min-quantity"]').val(resource.MinQuantity);
-        div.find('[data-type="max-quantity"]').val(resource.MaxQuantity);
+        var minQ = div.find('[data-type="min-quantity"]');
+        minQ.val(resource.MinQuantity);
+        minQ.removeAttr('disabled');
+        var maxQ = div.find('[data-type="max-quantity"]');
+        maxQ.val(resource.MaxQuantity);
+        maxQ.removeAttr('disabled');
       });
 
       elements.accessoryResourcesDialog

--- a/tpl/Admin/manage_accessories.tpl
+++ b/tpl/Admin/manage_accessories.tpl
@@ -191,12 +191,14 @@
 													<label class="fw-bold">{translate key=MinimumQuantity}
 														<input type="number" min="0" data-type="min-quantity"
 															class="form-control form-control-sm" size="4" maxlength="4"
-															name="{FormKeys::ACCESSORY_MIN_QUANTITY}[{$resource->GetId()}]">
+															name="{FormKeys::ACCESSORY_MIN_QUANTITY}[{$resource->GetId()}]"
+															id="acc_min" disabled>
 													</label>
 													<label class="fw-bold">{translate key=MaximumQuantity}
 														<input type="number" min="0" data-type="max-quantity"
 															class="form-control form-control-sm" size="4" maxlength="4"
-															name="{FormKeys::ACCESSORY_MAX_QUANTITY}[{$resource->GetId()}]">
+															name="{FormKeys::ACCESSORY_MAX_QUANTITY}[{$resource->GetId()}]"
+															id="acc_max" disabled>
 													</label>
 												</div>
 											</div>


### PR DESCRIPTION
Fix "hit PHP default max_input_vars limit" issue when number of resource over 500. (still will hit the limit issue if checked over 500 resources on 1 accessory on the accessory - resource mapping dialog)

`PHP Warning: PHP Request Startup: Input variables exceeded 1000. To increase the limit change max_input_vars in php.ini. in Unknown on line 0`