### PR TITLE
docs: fix three dead links in the install and developer docs

### DIFF
--- a/docs/source/DEVELOPER-README.rst
+++ b/docs/source/DEVELOPER-README.rst
@@ -80,15 +80,15 @@ Run ``composer install`` to install Composer-managed tools into
 ``composer build`` Builds / Packages a distributable relase inside
 ``/build`` configured via ``/build.xml``.
 
-`PHPUnit <https://phpunit.readthedocs.io/en/latest/writing-tests-for-phpunit.html>`__
+`PHPUnit <https://docs.phpunit.de/en/13.3/writing-tests-for-phpunit.html>`__
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 All classes should have good unit test coverage. The level of coverage
 is up to the developer and should be done when the code is sufficiently
 complex. Tests must all succeed for a final release.
 
-`PHPDocumentor <https://docs.phpdoc.org/latest/guide/guides/running-phpdocumentor.html>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+`PHPDocumentor <https://docs.phpdoc.org/guide/getting-started/generating-documentation.html>`__
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Generates automatic documentation based on code comments. You can
 customize the output by copying ``/phpdoc.dist.xml`` to ``/phpdoc.xml``

--- a/docs/source/INSTALLATION.rst
+++ b/docs/source/INSTALLATION.rst
@@ -3,7 +3,7 @@ LibreBooking Installation
 
 .. note::
    For users without web hosting service or existing environment, packages like
-   `XAMMP <http://www.apachefriends.org/en/index.html>`__ or `WampServer
+   `XAMMP <https://www.apachefriends.org/>`__ or `WampServer
    <http://www.wampserver.com/en/>`__ can help you get set up quickly.
 
 Fresh Installation


### PR DESCRIPTION
Three links in the published docs return 404.

`docs/source/DEVELOPER-README.rst`

- PHPUnit: `phpunit.readthedocs.io/en/latest/writing-tests-for-phpunit.html` → `docs.phpunit.de/en/13.3/writing-tests-for-phpunit.html`. PHPUnit moved off Read the Docs.
- phpDocumentor: `docs.phpdoc.org/latest/guide/guides/running-phpdocumentor.html` → `docs.phpdoc.org/guide/getting-started/generating-documentation.html`. The page was renamed; the new one is the same "how to run it" content, and it is the entry their current nav links.

`docs/source/INSTALLATION.rst`

- XAMPP: `apachefriends.org/en/index.html` → `apachefriends.org/`. The `/en/index.html` path is gone; the root serves the downloads.

Each replacement returns 200; each old URL returns 404.

## What I deliberately left alone

- **WampServer**, on the line right after XAMPP. `wampserver.com/en/` 404s, but so does `wampserver.com/`, so their site is down or blocking rather than restructured, and I would rather not repoint a link based on an outage.
- `CHANGELOG.md` references `bookedscheduler.com/phpscheduleit`, also dead. That is the historical changelog, so rewriting old entries would falsify the record.
- The XAMPP link text reads `XAMMP` (transposed). I left it, since this PR is scoped to URLs — say the word and I will fix the spelling too.

Per the AI-assistance rule in `CONTRIBUTING.md`, both commits carry `Assisted-by: Claude Code:claude-opus-5`. Every URL claim above was verified with a request rather than inferred. Based against `develop`.