### PR TITLE
fix: group CSV import ignoring read-only permissions on update

### DIFF
--- a/Presenters/Admin/ManageGroupsPresenter.php
+++ b/Presenters/Admin/ManageGroupsPresenter.php
@@ -605,7 +605,7 @@ class ManageGroupsPresenter extends ActionPresenter
                         $group->ChangeAllowedPermissions($resourceIds);
                     }
 
-                    if (!empty($row->permissionsView)) {
+                    if (!empty($row->permissionsRead)) {
                         $resourceIds = $this->GetImportResources($row->permissionsRead, $resourcesIndexed);
 
                         $group->ChangeViewPermissions($resourceIds);


### PR DESCRIPTION
GroupImportCsvRow only defines permissionsRead, but the update
branch of ManageGroupsPresenter::Import() checked the nonexistent
property $row->permissionsView. That check always evaluated as
empty, so read-only permissions from the CSV were silently
skipped whenever an existing group was updated. Full-access
permissions were unaffected, since that branch checked the
correct property.

Fixed the condition to check $row->permissionsRead instead.

Fixes #1665